### PR TITLE
fix(factory): sanitize planner-lane model subprocess env

### DIFF
--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -637,8 +637,9 @@ class RunPlannerTests(unittest.TestCase):
         self.assertNotIn("PROMPT INJECTION", cmd[cmd.index("--system-prompt") + 1])
 
     def test_run_planner_claude_cli_package_is_version_pinned(self) -> None:
-        # The planner fetches the CLI with GH_TOKEN in the environment, so it
-        # must never resolve `@latest`. Same guard as the contributor lane.
+        # A compromised `@latest` must never run in the planner job; the model
+        # subprocess env is sanitized but the npx fetch itself is supply chain.
+        # Same guard as the contributor lane.
         fixture = load_fixture("planner-prompt-injection.json")
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr="")
         with (
@@ -676,21 +677,32 @@ class RunPlannerTests(unittest.TestCase):
         self.assertNotIn("EVIDENCE_UPLOAD_TOKEN", env)
 
     def test_run_claude_sanitizes_model_subprocess_env(self) -> None:
-        # GH_TOKEN reaches gh/git calls but must never reach the model subprocess.
+        # GH_TOKEN must reach the gh lookup inside run_claude but never the
+        # model subprocess — sanitizing at the top of run_claude instead of at
+        # the model call must fail this test. GITHUB_REPOSITORY stays unset so
+        # repo_owner_name takes its gh-subprocess fallback.
         fixture = load_fixture("planner-prompt-injection.json")
-        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr="")
+        gh_completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"owner": {"login": "fairchild"}, "name": "workspaces"}',
+            stderr="",
+        )
+        model_completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr="")
         planner_env = {
             "PATH": os.environ.get("PATH", ""),
             "CLAUDE_CODE_OAUTH_TOKEN": "claude-token",
             "GH_TOKEN": "gh-token",
             "GITHUB_TOKEN": "github-token",
         }
-        with (
-            mock.patch.object(run_planner, "repo_owner_name", return_value=("fairchild", "workspaces")),
-            mock.patch.object(run_planner, "run_checked", return_value=completed) as run_checked,
-        ):
+        with mock.patch.object(
+            run_planner, "run_checked", side_effect=[gh_completed, model_completed]
+        ) as run_checked:
             run_planner.run_claude(fixture["discussion"], CATALOG, planner_env, mode="cli")
-        model_env = run_checked.call_args.kwargs["env"]
+        self.assertEqual(run_checked.call_count, 2)
+        gh_env = run_checked.call_args_list[0].kwargs["env"]
+        self.assertEqual(gh_env["GH_TOKEN"], "gh-token")
+        model_env = run_checked.call_args_list[1].kwargs["env"]
         self.assertEqual(model_env["CLAUDE_CODE_OAUTH_TOKEN"], "claude-token")
         self.assertNotIn("GH_TOKEN", model_env)
         self.assertNotIn("GITHUB_TOKEN", model_env)

--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -654,6 +654,47 @@ class RunPlannerTests(unittest.TestCase):
         self.assertRegex(package.rsplit("@", 1)[1], r"^\d+\.\d+\.\d+")
         self.assertEqual(package, run_contributor.CLAUDE_CODE_PACKAGE)
 
+    def test_sanitized_claude_env_excludes_github_tokens_and_keeps_auth(self) -> None:
+        env = run_planner.sanitized_claude_env(
+            {
+                "PATH": os.environ.get("PATH", ""),
+                "HOME": os.environ.get("HOME", ""),
+                "CLAUDE_CODE_OAUTH_TOKEN": "claude-token",
+                "OPENAI_API_KEY": "openai-key",
+                "GH_TOKEN": "gh-token",
+                "GITHUB_TOKEN": "github-token",
+                "GITHUB_REPOSITORY": "fairchild/workspaces",
+                "EVIDENCE_UPLOAD_TOKEN": "evidence-token",
+            }
+        )
+        self.assertEqual(env["CLAUDE_CODE_OAUTH_TOKEN"], "claude-token")
+        self.assertEqual(env["OPENAI_API_KEY"], "openai-key")
+        self.assertIn("PATH", env)
+        self.assertNotIn("GH_TOKEN", env)
+        self.assertNotIn("GITHUB_TOKEN", env)
+        self.assertNotIn("GITHUB_REPOSITORY", env)
+        self.assertNotIn("EVIDENCE_UPLOAD_TOKEN", env)
+
+    def test_run_claude_sanitizes_model_subprocess_env(self) -> None:
+        # GH_TOKEN reaches gh/git calls but must never reach the model subprocess.
+        fixture = load_fixture("planner-prompt-injection.json")
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr="")
+        planner_env = {
+            "PATH": os.environ.get("PATH", ""),
+            "CLAUDE_CODE_OAUTH_TOKEN": "claude-token",
+            "GH_TOKEN": "gh-token",
+            "GITHUB_TOKEN": "github-token",
+        }
+        with (
+            mock.patch.object(run_planner, "repo_owner_name", return_value=("fairchild", "workspaces")),
+            mock.patch.object(run_planner, "run_checked", return_value=completed) as run_checked,
+        ):
+            run_planner.run_claude(fixture["discussion"], CATALOG, planner_env, mode="cli")
+        model_env = run_checked.call_args.kwargs["env"]
+        self.assertEqual(model_env["CLAUDE_CODE_OAUTH_TOKEN"], "claude-token")
+        self.assertNotIn("GH_TOKEN", model_env)
+        self.assertNotIn("GITHUB_TOKEN", model_env)
+
 
 class RunContributorTests(unittest.TestCase):
     def test_sanitized_claude_env_strips_runtime_credentials(self) -> None:

--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -668,7 +668,7 @@ class RunPlannerTests(unittest.TestCase):
             }
         )
         self.assertEqual(env["CLAUDE_CODE_OAUTH_TOKEN"], "claude-token")
-        self.assertEqual(env["OPENAI_API_KEY"], "openai-key")
+        self.assertNotIn("OPENAI_API_KEY", env)
         self.assertIn("PATH", env)
         self.assertNotIn("GH_TOKEN", env)
         self.assertNotIn("GITHUB_TOKEN", env)

--- a/.agents/skills/peter-planner/scripts/run-planner.py
+++ b/.agents/skills/peter-planner/scripts/run-planner.py
@@ -192,6 +192,43 @@ def normalize_provider_env(env: dict[str, str]) -> dict[str, str]:
     return normalized
 
 
+def sanitized_claude_env(env: dict[str, str]) -> dict[str, str]:
+    """Env for the model subprocess only: benign vars plus its provider auth,
+    never GH_TOKEN/GITHUB_TOKEN or other CI/GitHub context. Runs after
+    normalize_provider_env so the OPENAI_API_KEY it resolves is carried through.
+    """
+    allowed = {
+        "PATH",
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "LANG",
+        "LC_ALL",
+        "TERM",
+        "CI",
+        "TZ",
+        "XDG_CACHE_HOME",
+        "NPM_CONFIG_CACHE",
+        "npm_config_cache",
+        "NO_COLOR",
+        "COLORTERM",
+    }
+    sanitized = {
+        key: value
+        for key, value in env.items()
+        if key in allowed and value
+    }
+    for auth_var in ("CLAUDE_CODE_OAUTH_TOKEN", "OPENAI_API_KEY"):
+        value = env.get(auth_var, "").strip()
+        if value:
+            sanitized[auth_var] = value
+    return sanitized
+
+
 def run_checked(
     cmd: list[str],
     *,
@@ -890,7 +927,11 @@ def run_claude(
         cmd.extend(["--max-budget-usd", "0.50"])
         timeout = 600
     cmd.append(f"{task}\n\n{prompt_context}")
-    return run_checked(cmd, timeout=timeout, cwd=REPO_ROOT, env=env).stdout
+    # GH_TOKEN lives in the planner's env for gh/git calls; the model subprocess
+    # gets a sanitized env that keeps only its provider auth.
+    return run_checked(
+        cmd, timeout=timeout, cwd=REPO_ROOT, env=sanitized_claude_env(env)
+    ).stdout
 
 
 def load_plan_output(

--- a/.agents/skills/peter-planner/scripts/run-planner.py
+++ b/.agents/skills/peter-planner/scripts/run-planner.py
@@ -193,9 +193,9 @@ def normalize_provider_env(env: dict[str, str]) -> dict[str, str]:
 
 
 def sanitized_claude_env(env: dict[str, str]) -> dict[str, str]:
-    """Env for the model subprocess only: benign vars plus its provider auth,
-    never GH_TOKEN/GITHUB_TOKEN or other CI/GitHub context. Runs after
-    normalize_provider_env so the OPENAI_API_KEY it resolves is carried through.
+    """Env for the model subprocess only: benign vars plus its Anthropic auth,
+    never GH_TOKEN/GITHUB_TOKEN or other CI/GitHub context. Same allowlist as
+    the contributor lane's sanitized_claude_env.
     """
     allowed = {
         "PATH",
@@ -222,10 +222,9 @@ def sanitized_claude_env(env: dict[str, str]) -> dict[str, str]:
         for key, value in env.items()
         if key in allowed and value
     }
-    for auth_var in ("CLAUDE_CODE_OAUTH_TOKEN", "OPENAI_API_KEY"):
-        value = env.get(auth_var, "").strip()
-        if value:
-            sanitized[auth_var] = value
+    claude_token = env.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+    if claude_token:
+        sanitized["CLAUDE_CODE_OAUTH_TOKEN"] = claude_token
     return sanitized
 
 

--- a/.agents/skills/peter-planner/scripts/run-planner.py
+++ b/.agents/skills/peter-planner/scripts/run-planner.py
@@ -41,8 +41,9 @@ PLANNER_TASK_CLI = (
 REPO_ROOT = Path(__file__).resolve().parents[4]
 
 # Pin the Claude Code CLI to an exact version so a compromised `@latest` release
-# can't run in the planner job (GH_TOKEN is in the environment). Shares the
-# contributor lane's bump var so one env/repo-var moves both lanes together.
+# can't run in the planner job (the model subprocess env is sanitized, but the
+# npx fetch itself is supply chain). Shares the contributor lane's bump var so
+# one env/repo-var moves both lanes together.
 CLAUDE_CODE_VERSION = os.environ.get(
     "CONTRIBUTOR_CLAUDE_CODE_VERSION", "2.1.200"
 ).strip() or "2.1.200"


### PR DESCRIPTION
Closes #1135.

The planner lane's model subprocess (`npx @anthropic-ai/claude-code`, tools `Read,Grep,Glob`) inherited the planner's full process env — GH_TOKEN and GITHUB_TOKEN included. This adds `sanitized_claude_env` to `run-planner.py`, the same benign-vars allowlist the contributor lane has carried since PR #212, applied only at the model call in `run_claude()`. Every gh/GraphQL/git subprocess keeps the full env; the model keeps only its Anthropic auth (`CLAUDE_CODE_OAUTH_TOKEN` when set, plus HOME so `~/.claude` config auth still works). Read-tool path scoping from the issue is deliberately deferred.

## Review loop

Orchestrator QC (1 finding):
- `OPENAI_API_KEY` was initially kept in the model allowlist ("provider vars normalize_provider_env manages"). Dropped for strict contributor parity — the model subprocess is always the Claude CLI and has no use for it (`68366c3`).

Codex (gpt-5.6-sol, xhigh) directed review — no high/medium findings; 2 addressed (`61f58db`):
- **Low:** the wiring test mocked `repo_owner_name`, so it could not catch a future refactor that sanitizes at the top of `run_claude` (stripping GH_TOKEN before the gh lookup). The test now drives the real gh fallback and asserts both `run_checked` calls: gh keeps GH_TOKEN, the model call lacks it.
- **Informational:** two #1133 CLI-pin comments still justified the pin with "GH_TOKEN is in the environment"; reworded to the supply-chain rationale that survives sanitization.
- Confirmed by review, no change needed: `run_claude` is the only model-subprocess site; no documented invocation relies on `ANTHROPIC_API_KEY` or other dropped vars; nothing from #1133 asserts full-env passthrough.

## Mergeability

- **Surface:** Factory planner lane only — `.agents/skills/peter-planner/scripts/run-planner.py` plus its tests. No app, web, or CI-workflow code.
- **Behavior changed:** The model subprocess env shrinks to the allowlist + Anthropic auth. All planner GitHub API behavior is unchanged; gh/git subprocess env untouched.
- **Non-happy paths:** Missing `CLAUDE_CODE_OAUTH_TOKEN` falls back to HOME-based `~/.claude` config auth, unchanged. An undocumented local invocation relying on ambient `ANTHROPIC_API_KEY` or proxy vars (HTTP(S)_PROXY, NODE_EXTRA_CA_CERTS) would lose them — same trade the contributor lane made; no such invocation exists in-repo.
- **Residual risk:** Low. The allowlist is a copy, not shared code — the two lanes can drift; consolidation is worth a follow-up if a third lane appears.

## Evidence

- [Planner + contributor test runs, 113 + 67 OK](https://evidence.cloudcompute.com/workspaces/pr-1144/20260718-063551-planner-env-tests.png) at `61f58db`

![planner-env-tests](https://evidence.cloudcompute.com/workspaces/pr-1144/20260718-063551-planner-env-tests.png)
