### PR TITLE
feat(factory): per-run cost telemetry rows and stream-json transcript artifacts

### DIFF
--- a/.agents/skills/cofounder-contributor/scripts/_helpers.py
+++ b/.agents/skills/cofounder-contributor/scripts/_helpers.py
@@ -7,6 +7,7 @@ import os
 import re
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 
@@ -47,6 +48,7 @@ def run_checked(
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
     input: str | None = None,
+    on_failure_output: Callable[[str], None] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     try:
         result = subprocess.run(
@@ -61,6 +63,12 @@ def run_checked(
     except subprocess.TimeoutExpired as exc:
         command = " ".join(cmd)
         print(f"error: command timed out after {exc.timeout}s: {command}", file=sys.stderr)
+        if on_failure_output is not None:
+            # TimeoutExpired can carry bytes even in text mode.
+            partial = exc.stdout
+            if isinstance(partial, bytes):
+                partial = partial.decode("utf-8", errors="replace")
+            on_failure_output(partial or "")
         sys.exit(1)
     if result.returncode != 0:
         command = " ".join(cmd)
@@ -72,6 +80,8 @@ def run_checked(
             # Print-mode CLIs (claude --print) report errors on stdout.
             print("--- stdout ---", file=sys.stderr)
             print(result.stdout.strip()[:8000], file=sys.stderr)
+        if on_failure_output is not None:
+            on_failure_output(result.stdout or "")
         sys.exit(result.returncode or 1)
     return result
 

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -315,8 +315,8 @@ PRIVILEGED_PATCH_ENV = "AGENT_ALLOW_PRIVILEGED_PATCHES"
 # can't run in the contributor job (where GH_TOKEN is still in the environment).
 # Bump via the CONTRIBUTOR_CLAUDE_CODE_VERSION env/repo-var — no code change needed.
 CLAUDE_CODE_VERSION = os.environ.get(
-    "CONTRIBUTOR_CLAUDE_CODE_VERSION", "2.1.200"
-).strip() or "2.1.200"
+    "CONTRIBUTOR_CLAUDE_CODE_VERSION", "2.1.212"
+).strip() or "2.1.212"
 CLAUDE_CODE_PACKAGE = f"@anthropic-ai/claude-code@{CLAUDE_CODE_VERSION}"
 
 ALLOWED_SELECTION_KINDS = {

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -241,6 +241,16 @@ from execution import (  # noqa: E402, F401
     working_tree_dirty,
 )
 
+from telemetry import (  # noqa: E402, F401
+    COST_DISAGREEMENT_FACTOR,
+    MODEL_PRICING,
+    build_cost_row,
+    derive_cost,
+    parse_result_event,
+    record_run_telemetry,
+    redact_secrets,
+)
+
 # ---------------------------------------------------------------------------
 # Constants and helpers used only by main()
 # ---------------------------------------------------------------------------
@@ -794,6 +804,7 @@ def run_claude(
     budget: str = "2.50",
     cwd: Path | None = None,
     write_scope: Path | None = None,
+    phase: str = "action",
 ) -> str:
     prompt_text = (
         system_prompt.read_text(encoding="utf-8")
@@ -837,6 +848,7 @@ def run_claude(
     raw_output = run_checked(cmd, timeout=effective_timeout, cwd=cwd or REPO_ROOT, env=env).stdout
     summary = summarize_stream_json(raw_output)
     emit_stream_telemetry(summary)
+    record_run_telemetry(raw_output, phase=phase)
     if summary.result_text is None:
         log("stream-json result event missing; returning raw model output")
         return raw_output
@@ -1068,6 +1080,7 @@ def choose_next_task(
         tools=SELECTOR_TOOLS,
         timeout=300,
         budget="0.25",
+        phase="selector",
     )
     return parse_selection_output(raw_output)
 
@@ -1513,6 +1526,7 @@ def main() -> int:
             write_scope=(
                 scratch_workspace.scratch_dir if scratch_workspace is not None else None
             ),
+            phase="action",
         )
         exit_code, validated_json, error_text = validate_output(raw_output, env)
 

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -845,7 +845,14 @@ def run_claude(
         cmd.extend(["--max-budget-usd", budget])
         effective_timeout = timeout or 1200
     cmd.append(task)
-    raw_output = run_checked(cmd, timeout=effective_timeout, cwd=cwd or REPO_ROOT, env=env).stdout
+    raw_output = run_checked(
+        cmd,
+        timeout=effective_timeout,
+        cwd=cwd or REPO_ROOT,
+        env=env,
+        # Timeouts and nonzero exits still leave a (partial) durable record.
+        on_failure_output=lambda partial: record_run_telemetry(partial, phase=phase),
+    ).stdout
     summary = summarize_stream_json(raw_output)
     emit_stream_telemetry(summary)
     record_run_telemetry(raw_output, phase=phase)

--- a/.agents/skills/cofounder-contributor/scripts/telemetry.py
+++ b/.agents/skills/cofounder-contributor/scripts/telemetry.py
@@ -211,6 +211,11 @@ def derive_cost(
 def _select_cost(reported: float, derived: float, all_priced: bool) -> tuple[float, str]:
     if not all_priced:
         return reported, "reported_unpriced"
+    if derived <= 0 < reported:
+        # A zero derivation against a positive reported cost means missing
+        # usage data (e.g. an empty modelUsage entry), not the inflation bug —
+        # inflation shows as reported far above a nonzero derived value.
+        return reported, "reported_unpriced"
     if _disagrees(reported, derived):
         return derived, "derived"
     return reported, "reported"

--- a/.agents/skills/cofounder-contributor/scripts/telemetry.py
+++ b/.agents/skills/cofounder-contributor/scripts/telemetry.py
@@ -1,0 +1,320 @@
+"""Per-run cost telemetry for the contributor runner.
+
+Extracts token usage and cost from a Claude CLI `--output-format stream-json`
+transcript. When FACTORY_TELEMETRY_DIR is set in the runner's process env, it
+writes a redacted copy of the transcript and appends one cost row per model
+invocation for CI to persist to the factory/ops-data branch; when unset (local
+runs) it writes nothing. Cost is derived independently from per-model API
+pricing because the CLI's reported total_cost_usd can read ~10x high on some
+models (anthropics/claude-code#53371); the row keeps both values.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections import namedtuple
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from _helpers import log
+
+# Per-MTok USD rates verified 2026-07-17 from the Anthropic pricing page
+# (https://platform.claude.com/docs/en/docs/about-claude/pricing). cache_write
+# is the 5-minute-TTL rate (1.25x base input); the stream-json
+# cache_creation_input_tokens aggregate does not separate 5m/1h writes and the
+# CLI defaults to 5-minute caching. cache_read is the cache-hit rate (0.1x base
+# input). Keyed by model-id family substring. Sonnet uses the standard $3/$15
+# tier (Sonnet 5's intro $2/$10 through 2026-08-31 derives a lower cost, which
+# only widens the reported-vs-derived gap in the safe direction).
+Rate = namedtuple("Rate", "input output cache_write cache_read")
+MODEL_PRICING: tuple[tuple[str, Rate], ...] = (
+    ("opus", Rate(5.0, 25.0, 6.25, 0.50)),
+    ("sonnet", Rate(3.0, 15.0, 3.75, 0.30)),
+    ("haiku", Rate(1.0, 5.0, 1.25, 0.10)),
+    ("fable", Rate(10.0, 50.0, 12.50, 1.00)),
+    ("mythos", Rate(10.0, 50.0, 12.50, 1.00)),
+)
+
+# Reported and derived cost may legitimately differ (rounding, cache-write TTL
+# ambiguity); only a gap beyond this factor in either direction is treated as
+# the known upstream inflation bug and resolved in favor of the derived value.
+COST_DISAGREEMENT_FACTOR = 2.0
+
+USAGE_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
+
+# Literal values of these vars are scrubbed from transcripts before upload
+# (the repo is public and artifacts are world-downloadable).
+SECRET_ENV_VARS = (
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "EVIDENCE_UPLOAD_TOKEN",
+)
+
+CREDENTIAL_PATTERNS = (
+    re.compile(r"ghp_[A-Za-z0-9]{36}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{22,}"),
+    re.compile(r"gh[sour]_[A-Za-z0-9]{36}"),
+    re.compile(r"sk-ant-[A-Za-z0-9_-]{10,}"),
+    re.compile(r"bearer [A-Za-z0-9._-]{20,}", re.IGNORECASE),
+)
+
+REDACTED = "[REDACTED]"
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int0(value: Any) -> int:
+    return _as_int(value) or 0
+
+
+def _as_float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _usage_field(usage: Mapping[str, Any], *names: str) -> int:
+    for name in names:
+        if name in usage:
+            return _int0(usage.get(name))
+    return 0
+
+
+def _normalize_usage(usage: Mapping[str, Any] | None) -> dict[str, int]:
+    usage = usage or {}
+    return {
+        "input_tokens": _usage_field(usage, "input_tokens", "inputTokens"),
+        "output_tokens": _usage_field(usage, "output_tokens", "outputTokens"),
+        "cache_creation_input_tokens": _usage_field(
+            usage, "cache_creation_input_tokens", "cacheCreationInputTokens"
+        ),
+        "cache_read_input_tokens": _usage_field(
+            usage, "cache_read_input_tokens", "cacheReadInputTokens"
+        ),
+    }
+
+
+def _normalize_model_usage(model_usage: Mapping[str, Any] | None) -> dict[str, dict[str, int]]:
+    result: dict[str, dict[str, int]] = {}
+    for model_id, usage in (model_usage or {}).items():
+        if isinstance(usage, Mapping):
+            result[str(model_id)] = _normalize_usage(usage)
+    return result
+
+
+def _sum_model_usage(model_usage: Mapping[str, dict[str, int]]) -> dict[str, int]:
+    totals = {key: 0 for key in USAGE_KEYS}
+    for usage in model_usage.values():
+        for key in USAGE_KEYS:
+            totals[key] += _int0(usage.get(key))
+    return totals
+
+
+def _match_pricing(model_id: str | None) -> Rate | None:
+    if not model_id:
+        return None
+    lowered = model_id.lower()
+    for family, rate in MODEL_PRICING:
+        if family in lowered:
+            return rate
+    return None
+
+
+def _price_usage(usage: Mapping[str, int], rate: Rate) -> float:
+    return (
+        _int0(usage.get("input_tokens")) * rate.input
+        + _int0(usage.get("output_tokens")) * rate.output
+        + _int0(usage.get("cache_creation_input_tokens")) * rate.cache_write
+        + _int0(usage.get("cache_read_input_tokens")) * rate.cache_read
+    ) / 1_000_000
+
+
+def parse_result_event(raw_output: str) -> dict[str, Any] | None:
+    """Return the stream-json `result` event, or None if the transcript has none."""
+    result: dict[str, Any] | None = None
+    for line in raw_output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict) and event.get("type") == "result":
+            result = event
+    return result
+
+
+def _primary_model(model_usage: Mapping[str, dict[str, int]], raw_output: str) -> str | None:
+    if model_usage:
+        return max(model_usage.items(), key=lambda item: sum(item[1].values()))[0]
+    for line in raw_output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict) and event.get("type") == "assistant":
+            model = (event.get("message") or {}).get("model")
+            if model:
+                return str(model)
+    return None
+
+
+def derive_cost(
+    model_usage: Mapping[str, dict[str, int]],
+    top_usage: Mapping[str, int],
+    primary_model: str | None,
+) -> tuple[float, bool]:
+    """Price token usage against the API rate table.
+
+    Returns (derived_cost_usd, all_priced). all_priced is False when a model
+    with non-zero usage has no known pricing family, so the caller can fall
+    back to the reported value rather than trust a partial derivation.
+    """
+    if model_usage:
+        total = 0.0
+        all_priced = True
+        for model_id, usage in model_usage.items():
+            rate = _match_pricing(model_id)
+            if rate is None:
+                all_priced = False
+                continue
+            total += _price_usage(usage, rate)
+        return total, all_priced
+    rate = _match_pricing(primary_model)
+    if rate is None:
+        has_usage = any(_int0(top_usage.get(key)) for key in USAGE_KEYS)
+        return 0.0, not has_usage
+    return _price_usage(top_usage, rate), True
+
+
+def _select_cost(reported: float, derived: float, all_priced: bool) -> tuple[float, str]:
+    if not all_priced:
+        return reported, "reported_unpriced"
+    if _disagrees(reported, derived):
+        return derived, "derived"
+    return reported, "reported"
+
+
+def _disagrees(reported: float, derived: float) -> bool:
+    if reported <= 0 and derived <= 0:
+        return False
+    if reported <= 0 or derived <= 0:
+        return True
+    ratio = reported / derived
+    return ratio > COST_DISAGREEMENT_FACTOR or ratio < 1 / COST_DISAGREEMENT_FACTOR
+
+
+def redact_secrets(text: str, env: Mapping[str, str]) -> str:
+    """Scrub known secret env values and credential-shaped patterns from text."""
+    for name in SECRET_ENV_VARS:
+        value = (env.get(name) or "").strip()
+        if len(value) >= 8:
+            text = text.replace(value, REDACTED)
+    for pattern in CREDENTIAL_PATTERNS:
+        text = pattern.sub(REDACTED, text)
+    return text
+
+
+def _run_row_id(env: Mapping[str, str], phase: str) -> str:
+    run_id = env.get("GITHUB_RUN_ID") or "local"
+    run_attempt = env.get("GITHUB_RUN_ATTEMPT") or "0"
+    return f"{run_id}-{run_attempt}-{phase}"
+
+
+def build_cost_row(raw_output: str, phase: str, env: Mapping[str, str]) -> dict[str, Any]:
+    """Fold a stream-json transcript into one cost row (schema 1)."""
+    event = parse_result_event(raw_output) or {}
+    model_usage = _normalize_model_usage(event.get("modelUsage") or event.get("model_usage"))
+    top_usage = _normalize_usage(event.get("usage"))
+    primary_model = _primary_model(model_usage, raw_output)
+    reported = _as_float(event.get("total_cost_usd"))
+    derived, all_priced = derive_cost(model_usage, top_usage, primary_model)
+    cost, source = _select_cost(reported, derived, all_priced)
+    totals = top_usage if any(top_usage.values()) else _sum_model_usage(model_usage)
+    return {
+        "schema": 1,
+        "id": _run_row_id(env, phase),
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "lane": env.get("FACTORY_TELEMETRY_LANE") or None,
+        "workflow": env.get("GITHUB_WORKFLOW") or None,
+        "run_id": _as_int(env.get("GITHUB_RUN_ID")),
+        "run_attempt": _as_int(env.get("GITHUB_RUN_ATTEMPT")),
+        "phase": phase,
+        "issue": _as_int(env.get("ISSUE_NUMBER")),
+        "pr": _as_int(env.get("PR_NUMBER")),
+        "reviewer": env.get("FACTORY_TELEMETRY_REVIEWER") or None,
+        "model": primary_model,
+        "model_usage": model_usage,
+        "input_tokens": totals.get("input_tokens", 0),
+        "output_tokens": totals.get("output_tokens", 0),
+        "cache_creation_input_tokens": totals.get("cache_creation_input_tokens", 0),
+        "cache_read_input_tokens": totals.get("cache_read_input_tokens", 0),
+        "cost_usd": round(cost, 6),
+        "cost_usd_reported": round(reported, 6),
+        "cost_usd_derived": round(derived, 6),
+        "cost_source": source,
+        "duration_ms": _int0(event.get("duration_ms")),
+        "num_turns": _int0(event.get("num_turns")),
+        "result_subtype": str(event.get("subtype") or ""),
+    }
+
+
+def _write_transcript(raw_output: str, phase: str, telemetry_dir: Path, env: Mapping[str, str]) -> None:
+    transcripts = telemetry_dir / "transcripts"
+    transcripts.mkdir(parents=True, exist_ok=True)
+    seq = sum(1 for _ in transcripts.glob("*.jsonl")) + 1
+    redacted = redact_secrets(raw_output, env)
+    (transcripts / f"{seq:04d}-{phase}.jsonl").write_text(redacted, encoding="utf-8")
+
+
+def _append_cost_row(raw_output: str, phase: str, telemetry_dir: Path, env: Mapping[str, str]) -> None:
+    row = build_cost_row(raw_output, phase, env)
+    telemetry_dir.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(row, ensure_ascii=False)
+    with (telemetry_dir / "cost-rows.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+
+
+def record_run_telemetry(
+    raw_output: str,
+    *,
+    phase: str,
+    env: Mapping[str, str] | None = None,
+) -> None:
+    """Persist a redacted transcript and a cost row when telemetry is enabled.
+
+    Reads FACTORY_TELEMETRY_DIR and context from the runner's own process env
+    (not the sanitized model-subprocess env). Never raises: a telemetry failure
+    must not fail the contributor run.
+    """
+    env = os.environ if env is None else env
+    telemetry_dir = (env.get("FACTORY_TELEMETRY_DIR") or "").strip()
+    if not telemetry_dir:
+        return
+    try:
+        path = Path(telemetry_dir)
+        _write_transcript(raw_output, phase, path, env)
+        _append_cost_row(raw_output, phase, path, env)
+    except Exception as exc:  # telemetry is best-effort
+        log(f"telemetry: skipped for phase={phase} ({exc})")

--- a/.agents/skills/cofounder-contributor/scripts/telemetry.py
+++ b/.agents/skills/cofounder-contributor/scripts/telemetry.py
@@ -11,6 +11,7 @@ models (anthropics/claude-code#53371); the row keeps both values.
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import re
@@ -19,6 +20,7 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from _helpers import log
 
@@ -230,12 +232,35 @@ def _disagrees(reported: float, derived: float) -> bool:
     return ratio > COST_DISAGREEMENT_FACTOR or ratio < 1 / COST_DISAGREEMENT_FACTOR
 
 
+def _secret_variants(value: str) -> list[str]:
+    """The literal secret plus its common reversible encodings. A model driven
+    by untrusted content can re-encode a secret it can read before emitting
+    it; redacting these variants raises the bar (arbitrary transforms and
+    fragmentation remain out of reach for any redaction pass)."""
+    raw = value.encode("utf-8")
+    b64 = base64.b64encode(raw).decode("ascii")
+    b64url = base64.urlsafe_b64encode(raw).decode("ascii")
+    variants = [
+        value,
+        b64,
+        b64.rstrip("="),
+        b64url,
+        b64url.rstrip("="),
+        raw.hex(),
+        quote(value, safe=""),
+    ]
+    return [v for v in dict.fromkeys(variants) if len(v) >= 8]
+
+
 def redact_secrets(text: str, env: Mapping[str, str]) -> str:
-    """Scrub known secret env values and credential-shaped patterns from text."""
+    """Scrub known secret env values (and their common encodings) plus
+    credential-shaped patterns from text."""
     for name in SECRET_ENV_VARS:
         value = (env.get(name) or "").strip()
-        if len(value) >= 8:
-            text = text.replace(value, REDACTED)
+        if len(value) < 8:
+            continue
+        for variant in _secret_variants(value):
+            text = text.replace(variant, REDACTED)
     for pattern in CREDENTIAL_PATTERNS:
         text = pattern.sub(REDACTED, text)
     return text

--- a/.agents/skills/peter-planner/scripts/run-planner.py
+++ b/.agents/skills/peter-planner/scripts/run-planner.py
@@ -45,8 +45,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 # npx fetch itself is supply chain). Shares the contributor lane's bump var so
 # one env/repo-var moves both lanes together.
 CLAUDE_CODE_VERSION = os.environ.get(
-    "CONTRIBUTOR_CLAUDE_CODE_VERSION", "2.1.200"
-).strip() or "2.1.200"
+    "CONTRIBUTOR_CLAUDE_CODE_VERSION", "2.1.212"
+).strip() or "2.1.212"
 CLAUDE_CODE_PACKAGE = f"@anthropic-ai/claude-code@{CLAUDE_CODE_VERSION}"
 
 # The planner drafts issue specs and is asked to reference relevant source

--- a/.github/workflows/factory-comment-responder.yml
+++ b/.github/workflows/factory-comment-responder.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           node-version: 22
       - name: Install pinned Claude Code CLI
-        run: npm install --global @anthropic-ai/claude-code@2.1.200
+        run: npm install --global @anthropic-ai/claude-code@2.1.212
       - name: Generate app token
         id: app-token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3

--- a/.github/workflows/factory-implement.yml
+++ b/.github/workflows/factory-implement.yml
@@ -122,6 +122,8 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           FACTORY_EXPECTED_ISSUE_SCOPE_DIGEST: ${{ needs.claim.outputs.issue_scope_digest }}
           FACTORY_REQUIRE_EXPLICIT_EVIDENCE: "true"
+          FACTORY_TELEMETRY_DIR: ${{ runner.temp }}/factory-telemetry
+          FACTORY_TELEMETRY_LANE: implement
           FACTORY_VISUAL_EVIDENCE_AVAILABLE: "false"
           GH_APP_SLUG: april-clearwater
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -134,6 +136,14 @@ jobs:
             --prompt-file .agents/skills/cofounder-contributor/references/april-clearwater.md \
             --mode cli \
             --message "$MESSAGE"
+      - name: Upload contributor telemetry
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: factory-implement-telemetry
+          path: ${{ runner.temp }}/factory-telemetry
+          if-no-files-found: ignore
+          retention-days: 14
 
   rollback:
     needs: [claim, implement]
@@ -188,3 +198,38 @@ jobs:
       APP_ID: ${{ secrets.APRIL_APP_ID }}
       PRIVATE_KEY: ${{ secrets.APRIL_PRIVATE_KEY }}
       EVIDENCE_UPLOAD_TOKEN: ${{ secrets.EVIDENCE_UPLOAD_TOKEN }}
+
+  telemetry:
+    needs: [implement]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # The model job stays read-only; only this job may write factory/ops-data.
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+      - name: Download contributor telemetry
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        continue-on-error: true
+        with:
+          pattern: factory-implement-telemetry
+          path: telemetry
+          merge-multiple: true
+          github-token: ${{ github.token }}
+      - name: Append cost telemetry
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ROWS="$GITHUB_WORKSPACE/telemetry/cost-rows.jsonl"
+          if [ ! -f "$ROWS" ]; then
+            echo "No telemetry cost rows found; nothing to append."
+            exit 0
+          fi
+          uv run --script scripts/factory-cost-append.py --rows "$ROWS"

--- a/.github/workflows/factory-implement.yml
+++ b/.github/workflows/factory-implement.yml
@@ -201,7 +201,10 @@ jobs:
 
   telemetry:
     needs: [implement]
-    if: always()
+    # Runs after success or failure (rows can exist either way), but not when
+    # the model job never started — no artifact can exist, so don't spin up a
+    # write-capable runner for nothing.
+    if: always() && needs.implement.result != 'skipped' && needs.implement.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # The model job stays read-only; only this job may write factory/ops-data.

--- a/.github/workflows/factory-review-execute.yml
+++ b/.github/workflows/factory-review-execute.yml
@@ -148,6 +148,9 @@ jobs:
           CONTRIBUTOR_MODEL_CWD: ${{ github.workspace }}/model-workspace
           FACTORY_EXPECTED_LINKED_ISSUE: ${{ needs.admit.outputs.linked_issue }}
           FACTORY_EXPECTED_PR_HEAD_SHA: ${{ needs.admit.outputs.head_sha }}
+          FACTORY_TELEMETRY_DIR: ${{ runner.temp }}/factory-telemetry
+          FACTORY_TELEMETRY_LANE: review
+          FACTORY_TELEMETRY_REVIEWER: april
           GH_APP_SLUG: april-clearwater
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ needs.admit.outputs.pr_number }}
@@ -158,6 +161,14 @@ jobs:
             --prompt-file .agents/skills/cofounder-contributor/references/april-clearwater.md \
             --mode cli \
             --message "$MESSAGE"
+      - name: Upload April review telemetry
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: factory-review-telemetry-april
+          path: ${{ runner.temp }}/factory-telemetry
+          if-no-files-found: ignore
+          retention-days: 14
 
   plat:
     needs: admit
@@ -221,6 +232,9 @@ jobs:
           CONTRIBUTOR_MODEL_CWD: ${{ github.workspace }}/model-workspace
           FACTORY_EXPECTED_LINKED_ISSUE: ${{ needs.admit.outputs.linked_issue }}
           FACTORY_EXPECTED_PR_HEAD_SHA: ${{ needs.admit.outputs.head_sha }}
+          FACTORY_TELEMETRY_DIR: ${{ runner.temp }}/factory-telemetry
+          FACTORY_TELEMETRY_LANE: review
+          FACTORY_TELEMETRY_REVIEWER: plat
           GH_APP_SLUG: workspace-agents
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ needs.admit.outputs.pr_number }}
@@ -231,3 +245,46 @@ jobs:
             --prompt-file .agents/skills/cofounder-contributor/references/plat-ironwood.md \
             --mode cli \
             --message "$MESSAGE"
+      - name: Upload Plat review telemetry
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: factory-review-telemetry-plat
+          path: ${{ runner.temp }}/factory-telemetry
+          if-no-files-found: ignore
+          retention-days: 14
+
+  telemetry:
+    needs: [admit, april, plat]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # The reviewer jobs stay read-only; only this job may write factory/ops-data.
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+      - name: Download review telemetry
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        continue-on-error: true
+        with:
+          pattern: factory-review-telemetry-*
+          path: telemetry
+          merge-multiple: true
+          github-token: ${{ github.token }}
+      - name: Append cost telemetry
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ROWS="$GITHUB_WORKSPACE/telemetry/cost-rows.jsonl"
+          if [ ! -f "$ROWS" ]; then
+            echo "No telemetry cost rows found; nothing to append."
+            exit 0
+          fi
+          uv run --script scripts/factory-cost-append.py --rows "$ROWS"

--- a/.github/workflows/factory-review-execute.yml
+++ b/.github/workflows/factory-review-execute.yml
@@ -256,7 +256,9 @@ jobs:
 
   telemetry:
     needs: [admit, april, plat]
-    if: always()
+    # Runs when either reviewer ran (success or failure); skipped-both means no
+    # artifact can exist, so don't spin up a write-capable runner for nothing.
+    if: always() && !(needs.april.result == 'skipped' && needs.plat.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # The reviewer jobs stay read-only; only this job may write factory/ops-data.

--- a/scripts/factory-cost-append.py
+++ b/scripts/factory-cost-append.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Append Factory per-run cost rows to the factory/ops-data branch.
+
+CI hands this the `cost-rows.jsonl` produced by the contributor runner. It
+clones factory/ops-data, appends rows to docs/ops/cost/runs.jsonl deduplicated
+by row `id` (idempotent across job re-runs and lane races), and pushes as
+github-actions[bot], retrying on push contention. It never creates the branch:
+the monitor lane owns that, and a missing branch is a hard error here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+BRANCH = "factory/ops-data"
+RUNS_PATH = "docs/ops/cost/runs.jsonl"
+COMMIT_MESSAGE = "chore(factory): append cost telemetry rows"
+BOT_NAME = "github-actions[bot]"
+BOT_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
+MAX_ATTEMPTS = 3
+
+
+def log(message: str) -> None:
+    print(f"[factory-cost-append] {message}", file=sys.stderr)
+
+
+def die(message: str) -> None:
+    log(f"error: {message}")
+    raise SystemExit(1)
+
+
+def run_git(args: list[str], *, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        # Never surface the remote URL (it carries the token) in error text.
+        raise RuntimeError(result.stderr.strip() or f"git {args[0]} failed")
+    return result
+
+
+def remote_url() -> str:
+    """Clone/push URL for factory/ops-data.
+
+    FACTORY_OPS_DATA_REMOTE overrides the derived GitHub URL (used by tests to
+    point at a local bare repo); production leaves it unset.
+    """
+    override = os.environ.get("FACTORY_OPS_DATA_REMOTE", "").strip()
+    if override:
+        return override
+    token = os.environ.get("GH_TOKEN", "").strip()
+    repo = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    if not token or not repo:
+        die("GH_TOKEN and GITHUB_REPOSITORY are required (or set FACTORY_OPS_DATA_REMOTE)")
+    return f"https://x-access-token:{token}@github.com/{repo}.git"
+
+
+def read_candidate_rows(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        die(f"rows file not found: {path}")
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            log(f"skipping unparseable row: {line[:80]}")
+            continue
+        if isinstance(row, dict) and row.get("id"):
+            rows.append(row)
+        else:
+            log("skipping row without an id")
+    return rows
+
+
+def existing_ids(runs_file: Path) -> set[str]:
+    ids: set[str] = set()
+    if not runs_file.is_file():
+        return ids
+    for line in runs_file.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        row_id = row.get("id") if isinstance(row, dict) else None
+        if row_id:
+            ids.add(str(row_id))
+    return ids
+
+
+def branch_exists(url: str) -> bool:
+    result = run_git(["ls-remote", "--heads", url, BRANCH], check=False)
+    if result.returncode not in (0, 2):
+        raise RuntimeError(result.stderr.strip() or "git ls-remote failed")
+    return bool(result.stdout.strip())
+
+
+def is_push_rejection(stderr: str) -> bool:
+    lowered = stderr.lower()
+    return "rejected" in lowered or "non-fast-forward" in lowered or "fetch first" in lowered
+
+
+def append_and_push(url: str, candidate_rows: list[dict[str, Any]], workdir: Path) -> bool:
+    """Clone, append not-yet-present rows, commit and push once.
+
+    Returns True on success or no-op; raises on a push rejection so the caller
+    can retry against fresh remote state.
+    """
+    clone_dir = workdir / "ops-data"
+    run_git(["clone", "--depth", "1", "--branch", BRANCH, "--single-branch", url, str(clone_dir)])
+    run_git(["config", "user.name", BOT_NAME], cwd=clone_dir)
+    run_git(["config", "user.email", BOT_EMAIL], cwd=clone_dir)
+
+    runs_file = clone_dir / RUNS_PATH
+    seen = existing_ids(runs_file)
+    new_rows: list[dict[str, Any]] = []
+    for row in candidate_rows:
+        row_id = str(row["id"])
+        if row_id in seen:
+            continue
+        seen.add(row_id)
+        new_rows.append(row)
+
+    if not new_rows:
+        log("no new cost rows to append (all present or empty); nothing to commit")
+        return True
+
+    runs_file.parent.mkdir(parents=True, exist_ok=True)
+    with runs_file.open("a", encoding="utf-8") as handle:
+        for row in new_rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    run_git(["add", RUNS_PATH], cwd=clone_dir)
+    run_git(["commit", "-m", COMMIT_MESSAGE], cwd=clone_dir)
+    push = run_git(["push", "origin", f"HEAD:{BRANCH}"], cwd=clone_dir, check=False)
+    if push.returncode != 0:
+        if is_push_rejection(push.stderr):
+            raise RuntimeError("push rejected")
+        raise RuntimeError(push.stderr.strip() or "git push failed")
+    log(f"appended {len(new_rows)} cost row(s) to {RUNS_PATH}")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Append Factory cost rows to factory/ops-data")
+    parser.add_argument("--rows", required=True, help="Path to cost-rows.jsonl")
+    args = parser.parse_args()
+
+    candidate_rows = read_candidate_rows(Path(args.rows))
+    if not candidate_rows:
+        log("no cost rows provided; nothing to do")
+        return 0
+
+    url = remote_url()
+    if not branch_exists(url):
+        die(f"{BRANCH} does not exist; the monitor lane must create it first")
+
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                append_and_push(url, candidate_rows, Path(tmp))
+                return 0
+            except RuntimeError as exc:
+                if "push rejected" in str(exc) and attempt < MAX_ATTEMPTS:
+                    log(f"push contention on attempt {attempt}; retrying")
+                    continue
+                die(str(exc))
+    die(f"exhausted {MAX_ATTEMPTS} attempts appending cost rows")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/factory-cost-append.py
+++ b/scripts/factory-cost-append.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -40,6 +41,12 @@ def die(message: str) -> None:
     raise SystemExit(1)
 
 
+def scrub_credentials(text: str) -> str:
+    """Redact userinfo from embedded remote URLs — git echoes the clone/push
+    URL (token included) into stderr on failure, and job logs are public."""
+    return re.sub(r"//[^/@\s]+@", "//[REDACTED]@", text)
+
+
 def run_git(args: list[str], *, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
         ["git", *args],
@@ -48,8 +55,7 @@ def run_git(args: list[str], *, cwd: Path | None = None, check: bool = True) -> 
         text=True,
     )
     if check and result.returncode != 0:
-        # Never surface the remote URL (it carries the token) in error text.
-        raise RuntimeError(result.stderr.strip() or f"git {args[0]} failed")
+        raise RuntimeError(scrub_credentials(result.stderr.strip()) or f"git {args[0]} failed")
     return result
 
 
@@ -110,7 +116,7 @@ def existing_ids(runs_file: Path) -> set[str]:
 def branch_exists(url: str) -> bool:
     result = run_git(["ls-remote", "--heads", url, BRANCH], check=False)
     if result.returncode not in (0, 2):
-        raise RuntimeError(result.stderr.strip() or "git ls-remote failed")
+        raise RuntimeError(scrub_credentials(result.stderr.strip()) or "git ls-remote failed")
     return bool(result.stdout.strip())
 
 
@@ -155,7 +161,7 @@ def append_and_push(url: str, candidate_rows: list[dict[str, Any]], workdir: Pat
     if push.returncode != 0:
         if is_push_rejection(push.stderr):
             raise RuntimeError("push rejected")
-        raise RuntimeError(push.stderr.strip() or "git push failed")
+        raise RuntimeError(scrub_credentials(push.stderr.strip()) or "git push failed")
     log(f"appended {len(new_rows)} cost row(s) to {RUNS_PATH}")
     return True
 

--- a/scripts/tests/test_factory_cost_append.py
+++ b/scripts/tests/test_factory_cost_append.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Behavior tests for the Factory cost-row append script.
+
+Exercises the script against a local bare repo seeded with a factory/ops-data
+branch (via FACTORY_OPS_DATA_REMOTE): first append, idempotent re-run, empty
+input, and the missing-branch guard.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "factory-cost-append.py"
+RUNS_PATH = "docs/ops/cost/runs.jsonl"
+
+
+def git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env={
+            "GIT_AUTHOR_NAME": "seed",
+            "GIT_AUTHOR_EMAIL": "seed@example.com",
+            "GIT_COMMITTER_NAME": "seed",
+            "GIT_COMMITTER_EMAIL": "seed@example.com",
+            "PATH": _path(),
+            "HOME": str(cwd or REPO_ROOT),
+        },
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"git {args}: {result.stderr}")
+    return result
+
+
+def _path() -> str:
+    import os
+
+    return os.environ.get("PATH", "")
+
+
+def run_script(rows_file: Path, remote: str) -> subprocess.CompletedProcess[str]:
+    import os
+
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--rows", str(rows_file)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "FACTORY_OPS_DATA_REMOTE": remote,
+            "GH_TOKEN": "unused",
+            "GITHUB_REPOSITORY": "owner/repo",
+        },
+    )
+
+
+def seed_bare_repo(root: Path, *, branch: str = "factory/ops-data") -> Path:
+    work = root / "work"
+    git(["init", "-b", branch, str(work)])
+    ops_dir = work / "docs" / "ops"
+    ops_dir.mkdir(parents=True)
+    (ops_dir / "README.md").write_text("ops-data\n", encoding="utf-8")
+    git(["add", "."], cwd=work)
+    git(["commit", "-m", "seed"], cwd=work)
+    origin = root / "origin.git"
+    git(["clone", "--bare", str(work), str(origin)])
+    return origin
+
+
+def read_runs(origin: Path, root: Path) -> list[dict]:
+    verify = root / "verify"
+    git(["clone", "--branch", "factory/ops-data", str(origin), str(verify)])
+    runs = verify / RUNS_PATH
+    if not runs.is_file():
+        return []
+    return [json.loads(line) for line in runs.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def head_sha(origin: Path) -> str:
+    return git(["rev-parse", "factory/ops-data"], cwd=origin).stdout.strip()
+
+
+def write_rows(path: Path, rows: list[dict]) -> None:
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+
+class FactoryCostAppendTests(unittest.TestCase):
+    def test_append_then_idempotent_rerun(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            origin = seed_bare_repo(root)
+            rows_file = root / "cost-rows.jsonl"
+            write_rows(rows_file, [{"id": "a", "cost_usd": 1.0}, {"id": "b", "cost_usd": 2.0}])
+
+            first = run_script(rows_file, str(origin))
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual({r["id"] for r in read_runs(origin, root / "v1")}, {"a", "b"})
+
+            sha_after_first = head_sha(origin)
+
+            second = run_script(rows_file, str(origin))
+            self.assertEqual(second.returncode, 0, second.stderr)
+            rows = read_runs(origin, root / "v2")
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(head_sha(origin), sha_after_first, "duplicate rows must not commit")
+
+    def test_new_rows_merge_with_existing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            origin = seed_bare_repo(root)
+            rows_file = root / "cost-rows.jsonl"
+
+            write_rows(rows_file, [{"id": "a"}])
+            self.assertEqual(run_script(rows_file, str(origin)).returncode, 0)
+
+            write_rows(rows_file, [{"id": "a"}, {"id": "c"}])
+            self.assertEqual(run_script(rows_file, str(origin)).returncode, 0)
+
+            self.assertEqual({r["id"] for r in read_runs(origin, root / "v")}, {"a", "c"})
+
+    def test_empty_rows_exits_zero_without_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            origin = seed_bare_repo(root)
+            sha_before = head_sha(origin)
+            rows_file = root / "empty.jsonl"
+            rows_file.write_text("\n  \n", encoding="utf-8")
+
+            result = run_script(rows_file, str(origin))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(head_sha(origin), sha_before)
+
+    def test_missing_branch_is_hard_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            origin = seed_bare_repo(root, branch="main")
+            rows_file = root / "cost-rows.jsonl"
+            write_rows(rows_file, [{"id": "a"}])
+
+            result = run_script(rows_file, str(origin))
+            self.assertNotEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_factory_cost_append.py
+++ b/scripts/tests/test_factory_cost_append.py
@@ -153,6 +153,32 @@ class FactoryCostAppendTests(unittest.TestCase):
             result = run_script(rows_file, str(origin))
             self.assertNotEqual(result.returncode, 0)
 
+    def test_git_errors_never_leak_remote_credentials(self) -> None:
+        # Job logs are public: no git failure may echo the token. Modern git
+        # strips URL userinfo itself; the script's scrub is the backstop for
+        # git versions and messages that don't.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            rows_file = root / "cost-rows.jsonl"
+            write_rows(rows_file, [{"id": "a"}])
+
+            remote = "https://x-access-token:sekret-token-value@localhost:1/none.git"
+            result = run_script(rows_file, remote)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertNotIn("sekret-token-value", result.stdout + result.stderr)
+
+    def test_scrub_credentials_redacts_url_userinfo(self) -> None:
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("factory_cost_append", SCRIPT)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        scrubbed = module.scrub_credentials(
+            "fatal: unable to access 'https://x-access-token:tok123@github.com/o/r.git/'"
+        )
+        self.assertNotIn("tok123", scrubbed)
+        self.assertIn("//[REDACTED]@github.com", scrubbed)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_factory_workflows.py
+++ b/scripts/tests/test_factory_workflows.py
@@ -80,8 +80,11 @@ def grants_contents_write(block: str) -> bool:
 
     Line-anchored so it does not match `permission-contents: write` — the input
     to actions/create-github-app-token, which mints a separately-scoped App
-    installation token rather than widening the job's GITHUB_TOKEN.
+    installation token rather than widening the job's GITHUB_TOKEN. The scalar
+    `permissions: write-all` form grants contents write too.
     """
+    if re.search(r"(?m)^\s*permissions:\s*write-all\s*$", block) is not None:
+        return True
     return re.search(r"(?m)^\s*contents:\s*write\s*$", block) is not None
 
 

--- a/scripts/tests/test_factory_workflows.py
+++ b/scripts/tests/test_factory_workflows.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -17,6 +18,7 @@ from unittest import mock
 REPO_ROOT = Path(__file__).resolve().parents[2]
 IMPLEMENT_SCRIPT = REPO_ROOT / "scripts" / "factory-implement.py"
 IMPLEMENT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "factory-implement.yml"
+REVIEW_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "factory-review-execute.yml"
 
 
 def load_module(name: str, path: Path):
@@ -26,6 +28,61 @@ def load_module(name: str, path: Path):
     sys.modules[name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def parse_jobs(text: str) -> dict[str, str]:
+    """Split a workflow into per-job text blocks keyed by job name.
+
+    Jobs are the 2-space-indented keys under the top-level ``jobs:`` mapping.
+    Stdlib-only (no YAML dependency) — indentation is enough to isolate the
+    text of each job for permission and env assertions.
+    """
+    jobs: dict[str, str] = {}
+    in_jobs = False
+    current: str | None = None
+    buffer: list[str] = []
+    for line in text.splitlines():
+        if re.match(r"^jobs:\s*$", line):
+            in_jobs = True
+            continue
+        if not in_jobs:
+            continue
+        if re.match(r"^\S", line):  # a new top-level key ends the jobs section
+            break
+        header = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", line)
+        if header:
+            if current is not None:
+                jobs[current] = "\n".join(buffer)
+            current = header.group(1)
+            buffer = [line]
+        elif current is not None:
+            buffer.append(line)
+    if current is not None:
+        jobs[current] = "\n".join(buffer)
+    return jobs
+
+
+def workflow_permissions_block(text: str) -> str:
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if re.match(r"^permissions:\s*$", line):
+            block = [line]
+            for follow in lines[i + 1 :]:
+                if re.match(r"^\S", follow):
+                    break
+                block.append(follow)
+            return "\n".join(block)
+    return ""
+
+
+def grants_contents_write(block: str) -> bool:
+    """True when a `permissions:` entry grants GITHUB_TOKEN `contents: write`.
+
+    Line-anchored so it does not match `permission-contents: write` — the input
+    to actions/create-github-app-token, which mints a separately-scoped App
+    installation token rather than widening the job's GITHUB_TOKEN.
+    """
+    return re.search(r"(?m)^\s*contents:\s*write\s*$", block) is not None
 
 
 factory_implement = load_module("factory_implement", IMPLEMENT_SCRIPT)
@@ -596,6 +653,43 @@ class FactoryImplementTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn("actions: read", monitor)
         self.assertNotIn("Re-fire ready implementation work", monitor)
+
+
+class FactoryTelemetryContractTests(unittest.TestCase):
+    def test_implement_lane_keeps_model_job_readonly_and_grants_telemetry_write(self) -> None:
+        text = IMPLEMENT_WORKFLOW.read_text(encoding="utf-8")
+        self.assertFalse(grants_contents_write(workflow_permissions_block(text)))
+        jobs = parse_jobs(text)
+
+        self.assertIn("implement", jobs)
+        self.assertFalse(grants_contents_write(jobs["implement"]))
+        self.assertIn("FACTORY_TELEMETRY_DIR:", jobs["implement"])
+        self.assertIn("FACTORY_TELEMETRY_LANE: implement", jobs["implement"])
+        self.assertIn("factory-implement-telemetry", jobs["implement"])
+
+        self.assertIn("telemetry", jobs)
+        self.assertTrue(grants_contents_write(jobs["telemetry"]))
+        self.assertIn("actions: read", jobs["telemetry"])
+        self.assertIn("scripts/factory-cost-append.py", jobs["telemetry"])
+
+    def test_review_lane_keeps_reviewer_jobs_readonly_and_grants_telemetry_write(self) -> None:
+        text = REVIEW_WORKFLOW.read_text(encoding="utf-8")
+        self.assertFalse(grants_contents_write(workflow_permissions_block(text)))
+        jobs = parse_jobs(text)
+
+        for reviewer, label in (("april", "april"), ("plat", "plat")):
+            self.assertIn(reviewer, jobs)
+            self.assertFalse(grants_contents_write(jobs[reviewer]))
+            self.assertIn("FACTORY_TELEMETRY_DIR:", jobs[reviewer])
+            self.assertIn("FACTORY_TELEMETRY_LANE: review", jobs[reviewer])
+            self.assertIn(f"FACTORY_TELEMETRY_REVIEWER: {label}", jobs[reviewer])
+            self.assertIn(f"factory-review-telemetry-{label}", jobs[reviewer])
+
+        self.assertIn("telemetry", jobs)
+        self.assertTrue(grants_contents_write(jobs["telemetry"]))
+        self.assertIn("actions: read", jobs["telemetry"])
+        self.assertIn("needs: [admit, april, plat]", jobs["telemetry"])
+        self.assertIn("scripts/factory-cost-append.py", jobs["telemetry"])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_run_contributor.py
+++ b/scripts/tests/test_run_contributor.py
@@ -1376,6 +1376,43 @@ class CostTelemetryTests(unittest.TestCase):
             # Must not raise even though the telemetry dir cannot be created.
             self.assertIsNone(run_contributor.record_run_telemetry(raw, phase="action", env=env))
 
+    def test_redaction_scrubs_encoded_secret_variants(self) -> None:
+        import base64 as b64mod
+        from urllib.parse import quote as urlquote
+
+        secret = "sekret%value+12345"
+        encodings = [
+            b64mod.b64encode(secret.encode()).decode(),
+            b64mod.b64encode(secret.encode()).decode().rstrip("="),
+            b64mod.urlsafe_b64encode(secret.encode()).decode(),
+            secret.encode().hex(),
+            urlquote(secret, safe=""),
+        ]
+        raw = (
+            _stream_transcript(total_cost_usd=6.0, model_usage=self.HAIKU_1M)
+            + json.dumps({"leaks": encodings})
+            + "\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {"FACTORY_TELEMETRY_DIR": tmp, "CLAUDE_CODE_OAUTH_TOKEN": secret}
+            run_contributor.record_run_telemetry(raw, phase="action", env=env)
+            transcript = (Path(tmp) / "transcripts" / "0001-action.jsonl").read_text(
+                encoding="utf-8"
+            )
+        for encoded in encodings:
+            self.assertNotIn(encoded, transcript)
+
+    def test_run_checked_reports_failure_output(self) -> None:
+        captured: list[str] = []
+        with self.assertRaises(SystemExit):
+            run_contributor.run_checked(
+                [sys.executable, "-c", "print('partial stream'); raise SystemExit(3)"],
+                timeout=30,
+                on_failure_output=captured.append,
+            )
+        self.assertEqual(len(captured), 1)
+        self.assertIn("partial stream", captured[0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_run_contributor.py
+++ b/scripts/tests/test_run_contributor.py
@@ -1300,6 +1300,18 @@ class CostTelemetryTests(unittest.TestCase):
         self.assertEqual(row["cost_source"], "reported_unpriced")
         self.assertAlmostEqual(row["cost_usd"], 3.0)
 
+    def test_zero_derivation_with_positive_report_keeps_reported(self) -> None:
+        # An empty modelUsage entry derives $0; that means missing usage data,
+        # not the inflation bug — the positive reported cost must survive.
+        raw = _stream_transcript(
+            total_cost_usd=2.5,
+            model_usage={"claude-haiku-4-5": {}},
+        )
+        row = run_contributor.build_cost_row(raw, "action", {})
+        self.assertEqual(row["cost_source"], "reported_unpriced")
+        self.assertAlmostEqual(row["cost_usd"], 2.5)
+        self.assertAlmostEqual(row["cost_usd_derived"], 0.0)
+
     def test_telemetry_dir_writes_transcript_and_row(self) -> None:
         raw = _stream_transcript(total_cost_usd=6.0, model_usage=self.HAIKU_1M)
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/tests/test_run_contributor.py
+++ b/scripts/tests/test_run_contributor.py
@@ -1222,5 +1222,148 @@ class MergeabilitySeedTests(unittest.TestCase):
         )
 
 
+def _stream_transcript(
+    *,
+    total_cost_usd: float,
+    model_usage: dict[str, dict[str, int]],
+    subtype: str = "success",
+    assistant_model: str | None = None,
+) -> str:
+    lines = []
+    if assistant_model is not None:
+        lines.append(
+            json.dumps(
+                {"type": "assistant", "message": {"model": assistant_model, "content": []}}
+            )
+        )
+    aggregate = {
+        "input_tokens": sum(u.get("inputTokens", 0) for u in model_usage.values()),
+        "output_tokens": sum(u.get("outputTokens", 0) for u in model_usage.values()),
+        "cache_creation_input_tokens": sum(
+            u.get("cacheCreationInputTokens", 0) for u in model_usage.values()
+        ),
+        "cache_read_input_tokens": sum(
+            u.get("cacheReadInputTokens", 0) for u in model_usage.values()
+        ),
+    }
+    lines.append(
+        json.dumps(
+            {
+                "type": "result",
+                "subtype": subtype,
+                "total_cost_usd": total_cost_usd,
+                "usage": aggregate,
+                "modelUsage": model_usage,
+                "duration_ms": 4321,
+                "num_turns": 3,
+            }
+        )
+    )
+    return "\n".join(lines) + "\n"
+
+
+class CostTelemetryTests(unittest.TestCase):
+    HAIKU_1M = {
+        "claude-haiku-4-5": {
+            "inputTokens": 1_000_000,
+            "outputTokens": 1_000_000,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0,
+        }
+    }
+
+    def test_derived_cost_wins_when_reported_is_inflated(self) -> None:
+        # Haiku at 1M in + 1M out prices to $1 + $5 = $6; a ~10x-high report
+        # (the known upstream bug) must fall back to the derived value.
+        raw = _stream_transcript(total_cost_usd=60.0, model_usage=self.HAIKU_1M)
+        row = run_contributor.build_cost_row(raw, "action", {})
+        self.assertEqual(row["cost_source"], "derived")
+        self.assertAlmostEqual(row["cost_usd"], 6.0)
+        self.assertAlmostEqual(row["cost_usd_derived"], 6.0)
+        self.assertAlmostEqual(row["cost_usd_reported"], 60.0)
+        self.assertEqual(row["model"], "claude-haiku-4-5")
+        self.assertEqual(row["input_tokens"], 1_000_000)
+
+    def test_reported_cost_kept_when_values_agree(self) -> None:
+        raw = _stream_transcript(total_cost_usd=6.2, model_usage=self.HAIKU_1M)
+        row = run_contributor.build_cost_row(raw, "action", {})
+        self.assertEqual(row["cost_source"], "reported")
+        self.assertAlmostEqual(row["cost_usd"], 6.2)
+        self.assertAlmostEqual(row["cost_usd_derived"], 6.0)
+
+    def test_unknown_model_marks_reported_unpriced(self) -> None:
+        raw = _stream_transcript(
+            total_cost_usd=3.0,
+            model_usage={"claude-zeta-9": {"inputTokens": 1_000_000, "outputTokens": 0}},
+        )
+        row = run_contributor.build_cost_row(raw, "action", {})
+        self.assertEqual(row["cost_source"], "reported_unpriced")
+        self.assertAlmostEqual(row["cost_usd"], 3.0)
+
+    def test_telemetry_dir_writes_transcript_and_row(self) -> None:
+        raw = _stream_transcript(total_cost_usd=6.0, model_usage=self.HAIKU_1M)
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {
+                "FACTORY_TELEMETRY_DIR": tmp,
+                "FACTORY_TELEMETRY_LANE": "implement",
+                "GITHUB_RUN_ID": "42",
+                "GITHUB_RUN_ATTEMPT": "1",
+                "GITHUB_WORKFLOW": "Factory Implement",
+                "ISSUE_NUMBER": "1138",
+            }
+            run_contributor.record_run_telemetry(raw, phase="action", env=env)
+
+            transcript = Path(tmp) / "transcripts" / "0001-action.jsonl"
+            self.assertTrue(transcript.is_file())
+
+            rows_file = Path(tmp) / "cost-rows.jsonl"
+            lines = rows_file.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 1)
+            row = json.loads(lines[0])
+            self.assertEqual(row["id"], "42-1-action")
+            self.assertEqual(row["phase"], "action")
+            self.assertEqual(row["lane"], "implement")
+            self.assertEqual(row["issue"], 1138)
+            self.assertIsNone(row["pr"])
+
+    def test_telemetry_unset_writes_nothing(self) -> None:
+        raw = _stream_transcript(total_cost_usd=6.0, model_usage=self.HAIKU_1M)
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_contributor.record_run_telemetry(
+                raw, phase="action", env={"FACTORY_TELEMETRY_LANE": "implement"}
+            )
+            self.assertIsNone(result)
+            self.assertEqual(list(Path(tmp).iterdir()), [])
+
+    def test_redaction_scrubs_env_value_and_credential_patterns(self) -> None:
+        secret = "SECRETVALUE12345"
+        ghp = "ghp_" + "a" * 36
+        bearer = "Bearer " + "b" * 25
+        raw = (
+            _stream_transcript(total_cost_usd=6.0, model_usage=self.HAIKU_1M)
+            + json.dumps({"leak": f"{secret} {ghp} {bearer}"})
+            + "\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {"FACTORY_TELEMETRY_DIR": tmp, "GH_TOKEN": secret}
+            run_contributor.record_run_telemetry(raw, phase="action", env=env)
+            transcript = (Path(tmp) / "transcripts" / "0001-action.jsonl").read_text(
+                encoding="utf-8"
+            )
+        self.assertNotIn(secret, transcript)
+        self.assertNotIn(ghp, transcript)
+        self.assertNotIn(bearer, transcript)
+        self.assertIn("[REDACTED]", transcript)
+
+    def test_telemetry_write_failure_is_swallowed(self) -> None:
+        raw = _stream_transcript(total_cost_usd=6.0, model_usage=self.HAIKU_1M)
+        with tempfile.TemporaryDirectory() as tmp:
+            blocker = Path(tmp) / "blocker"
+            blocker.write_text("not a directory", encoding="utf-8")
+            env = {"FACTORY_TELEMETRY_DIR": str(blocker / "telemetry")}
+            # Must not raise even though the telemetry dir cannot be created.
+            self.assertIsNone(run_contributor.record_run_telemetry(raw, phase="action", env=env))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #1138.

The factory metered run counts but not spend. This persists both halves of the telemetry the caps never had: **per-invocation cost rows** appended to `factory/ops-data` at `docs/ops/cost/runs.jsonl` from the implement and review lanes, and **full stream-json transcripts** uploaded as workflow artifacts (the durable system of record — CI-side OTLP was rejected as lossy). Also bumps the shared Claude CLI pin 2.1.200 → 2.1.212 (event-log↔trace-id correlation, the standing "next runner-touching PR" item).

How it works:
- `telemetry.py` (new contributor domain module): parses the stream-json `result` event, derives cost independently from per-model API pricing (verified 2026-07-17 against the platform pricing page), and — only when `FACTORY_TELEMETRY_DIR` is set — writes a secret-redacted transcript plus one cost row per `run_claude` invocation (selector/action phase). Known ~10× `total_cost_usd` inflation bug (anthropics/claude-code#53371): rows keep `cost_usd_reported` and `cost_usd_derived`; a >2× disagreement resolves to derived, a zero derivation against a positive report resolves to reported (`reported_unpriced`). Telemetry never fails a run, and failure paths (CLI timeout/nonzero exit) still record a partial transcript.
- `scripts/factory-cost-append.py` (new): idempotent append to the ops-data branch — dedupe by row `id`, 3× retry on push contention, github-actions[bot] identity matching the monitor lane, credential-scrubbed error text. Branch creation stays owned by the monitor lane.
- Workflows: the model-running jobs stay read-only; a separate `telemetry` job per lane carries job-level `contents: write` + `actions: read`, downloads the artifact, and appends. Jobs skip when no model job ran. Transcript artifacts: 14-day retention, `if-no-files-found: ignore`.

Digest/efficiency surfacing (cost-per-merged-PR) is deferred to the #1142 dashboard arc, per the claim comment on the issue.

## Review loop

Orchestrator QC (1 finding, `6236c07`):
- git failure text echoed the remote URL — token included — into public job logs; error paths now scrub URL userinfo (modern git strips this itself; the scrub is the backstop, with a regression test).

Codex (gpt-5.6-sol, xhigh), two passes — full-diff review + focused security re-check. Findings and dispositions:
- **High — transcript redaction bypassable via encoded secrets** (`d1dba7f`): a model driven by untrusted PR content can re-encode a secret it can read before emitting it into the world-downloadable transcript. Redaction now also scrubs base64/urlsafe-base64/hex/percent-encoded variants of each secret env value. Residual (accepted, named below): arbitrary transforms and fragmentation are beyond any redaction pass — the boundary that holds is the sanitized model env, which carries only the OAuth token.
- **Med — zero-derivation cost selection** (`93bfef7`): an empty `modelUsage` entry derived $0 and the >2× rule then *preferred* the zero over a positive reported cost; zero-derived-vs-positive-reported now keeps reported as `reported_unpriced`, with a regression test.
- **Low — failed runs left no transcript** (`d1dba7f`): `run_checked` gains an `on_failure_output` hook; timeouts and nonzero exits record the partial transcript before exiting.
- **Low — telemetry jobs ran (privileged) when the model job was skipped** (`93bfef7`): both lanes now gate on the model job having actually run.
- **Test gap — scalar `permissions: write-all` not caught** (`93bfef7`): `grants_contents_write` now recognizes it.
- **Info — append boundary validates only a truthy row `id`**: declined. The artifact producer is trusted default-branch runner code; rows re-serialize through `json.dumps` (no JSONL injection); codex confirmed no current model-influenced path reaches the boundary. Schema validation there would add rigidity without closing a live path.
- Confirmed by review, no change needed: the `workflow_run`-triggered telemetry job executes the append script from the default branch, not the PR head; `needs: [admit, april, plat]` covers every contributor-model job post-#1136/#1137; append dedupe is idempotent across reruns including applied-but-reported-failed pushes; secret-bearing env vars in the runner steps are all covered by `SECRET_ENV_VARS`.

## Mergeability

- **Surface:** Factory CI lanes only — contributor runner + new telemetry/append scripts, `factory-implement.yml`, `factory-review-execute.yml`, the CLI pin in those runners plus `factory-comment-responder.yml`, and their tests. No app or web code.
- **Behavior changed:** Runs now upload redacted transcripts as artifacts and append cost rows to `factory/ops-data` via a new per-lane job; the model subprocess and its permissions are untouched. CLI pin moves to 2.1.212 in both lanes and the responder.
- **Non-happy paths:** Telemetry is best-effort — write failures log and never fail a run; missing artifact → append job exits 0; missing ops-data branch → hard error by design (monitor owns creation); push contention → 3× fresh-clone retry, dedupe keeps reruns idempotent; CLI failure still records a partial transcript.
- **Residual risk:** Transcripts on a public repo can leak a secret the model deliberately fragments or transforms beyond the encoded-variant scrub — bounded by the sanitized model env (OAuth token only) and 14-day artifact retention. Concurrent push contention has no live test (sequential-rerun idempotency is tested). The 2.1.212 CLI pin is validated by fixture tests, not a live lane run; first factory runs after merge are the real validation.

## Evidence

- [Full test matrix + actionlint, 214 tests OK](https://evidence.cloudcompute.com/workspaces/pr-1145/20260718-071636-cost-telemetry-tests.png) at the rebased head (77 contributor + 6 append + 18 workflow + 113 planner; actionlint clean on all three touched workflows)

![cost-telemetry-tests](https://evidence.cloudcompute.com/workspaces/pr-1145/20260718-071636-cost-telemetry-tests.png)
