### PR TITLE
web-next: prove Folio with an external consumer

### DIFF
--- a/web-next/docs/decisions/folio-package-boundary.md
+++ b/web-next/docs/decisions/folio-package-boundary.md
@@ -87,7 +87,8 @@ both production and test imports for package-private paths.
 3. #1052 makes Folio styles and assets independently installable.
 4. #1053 proves Workspaces has no privileged internal path.
 5. #1054 creates the versioned install artifact and clean fixture.
-6. #1055 proves a real external consumer without publishing private details.
+6. #1055 proves a real external consumer and checks in only its anonymized
+   compatibility fixture and evidence summary.
 
 ## Non-goals
 

--- a/web-next/docs/external-consumer-evidence.md
+++ b/web-next/docs/external-consumer-evidence.md
@@ -1,6 +1,6 @@
 # Folio 0.1 External Consumer Evidence
 
-Status: accepted compatibility proof for W7 (2026-07-12)
+Status: accepted compatibility proof for W7 (2026-07-18)
 
 ## Artifact under test
 
@@ -31,8 +31,12 @@ only the portable contract evidence.
 | Stop and terminal failure | Passed with host-calculated capabilities | External fixture stop/failure test |
 | Artifact and review projection | Passed with consumer-owned evidence | External fixture artifact/review test |
 | Workspace and publication authority | Passed without package-side credentials or Git access | External fixture authority-command test |
-| Responsive and accessible session surface | Passed at desktop and 390 by 844 phone viewports | Folio browser suite plus standalone consumer build |
+| Responsive session layout | Owner-observed private browser pass at desktop and 390 by 844 phone viewports | `tests/e2e/mobile.spec.ts` verifies 375 by 812 overflow, hit areas, compose, streaming, and actionable failure behavior |
+| Keyboard and semantic accessibility | Owner-observed role, accessible-name, focus, and keyboard-flow pass; private artifacts withheld | `tests/e2e/sessions-demo.spec.ts` verifies semantic heading and keyboard-revealed controls; the standalone consumer build verifies integration |
 | Workspaces strict consumer | Passed with the same `0.1.0` API | Workspaces adapter and package-boundary tests |
+
+The accessibility result is deliberately limited to the exercised browser
+flows above. It does not claim a screen-reader session or automated WCAG audit.
 
 ## Outcome
 

--- a/web-next/docs/external-consumer-evidence.md
+++ b/web-next/docs/external-consumer-evidence.md
@@ -1,0 +1,43 @@
+# Folio 0.1 External Consumer Evidence
+
+Status: accepted compatibility proof for W7 (2026-07-12)
+
+## Artifact under test
+
+- Release: `folio-v0.1.0`
+- Package: `@fairchild/folio@0.1.0`
+- Source commit: `ac2b5bb8bd74dbba34401d50eeb4304eb87c55e0`
+- Compressed SHA-256: `f5da5f28ee25e952681fca92b183700958670483215fde6436fed67c5238bde4`
+- Tar payload SHA-256: `68b1383f7ce3ceb4db682b271a9ead9f5032fc50c49404cc334a582418c175a9`
+
+The canonical release asset carries the compressed checksum above. Local
+rebuilds may produce a different outer gzip stream, so the public package gate
+also decompresses the tarball and requires its payload to match the accepted
+release payload exactly.
+
+The consumer is private. Its name, repository, routes, hostnames, screenshots,
+and operational configuration are intentionally omitted. This document records
+only the portable contract evidence.
+
+## Compatibility matrix
+
+| Contract | Private consumer result | Public regression encoding |
+|---|---|---|
+| Install without source copy or workspace link | Passed from the released tarball | `pnpm folio:package` standalone install and build |
+| Consumer-owned conversation adapter | Passed through the public port | `fixtures/external-consumer/host-adapter.mjs` |
+| Create and durable reload | Passed across server restart and browser reload | External fixture create, serialize, restore test |
+| Send and ordered stream | Passed through the consumer's real deterministic runner | External fixture public-event replay test |
+| Disconnect and cursor resume | Passed without duplicate message content | External fixture disconnect/resume test |
+| Stop and terminal failure | Passed with host-calculated capabilities | External fixture stop/failure test |
+| Artifact and review projection | Passed with consumer-owned evidence | External fixture artifact/review test |
+| Workspace and publication authority | Passed without package-side credentials or Git access | External fixture authority-command test |
+| Responsive and accessible session surface | Passed at desktop and 390 by 844 phone viewports | Folio browser suite plus standalone consumer build |
+| Workspaces strict consumer | Passed with the same `0.1.0` API | Workspaces adapter and package-boundary tests |
+
+## Outcome
+
+No consumer-specific conditional import, source fork, or private package change
+was required. The reusable fixes landed in the public package and adapter
+contracts before the consumer cutover. Remaining consumer policy stays in its
+host: authentication, persistence, agent execution, workspaces, review, and
+publication.

--- a/web-next/fixtures/external-consumer/README.md
+++ b/web-next/fixtures/external-consumer/README.md
@@ -20,9 +20,11 @@ The fixture covers:
 
 - host-owned conversation creation and durable reload;
 - ordered send/stream projection;
-- disconnect at a durable cursor and duplicate-free resume;
+- conversation-scoped cursors, disconnect at a durable cursor, duplicate-free
+  resume, and restore-time event-log validation;
 - cancellation and fail-closed errors;
-- queued-message, review, workspace, and publication authority; and
+- transitional stop/active-turn invariants plus queued-message, approval,
+  review, workspace, and publication authority; and
 - foreign-cursor and abort handling.
 
 The real private-consumer browser evidence is summarized in

--- a/web-next/fixtures/external-consumer/README.md
+++ b/web-next/fixtures/external-consumer/README.md
@@ -21,7 +21,8 @@ The fixture covers:
 - host-owned conversation creation and durable reload;
 - ordered send/stream projection;
 - conversation-scoped cursors, disconnect at a durable cursor, duplicate-free
-  resume, and restore-time event-log validation;
+  resume, and restore-time cursor sequence/order validation (event content
+  remains host-owned and trusted);
 - cancellation and fail-closed errors;
 - transitional stop/active-turn invariants plus queued-message, approval,
   review, workspace, and publication authority; and

--- a/web-next/fixtures/external-consumer/README.md
+++ b/web-next/fixtures/external-consumer/README.md
@@ -1,0 +1,29 @@
+# Anonymized External Consumer Fixture
+
+This fixture records the reusable part of Folio's first private-consumer proof.
+It contains no private repository name, URL, data, credentials, or operational
+details. The host is intentionally generic and imports only the installed
+`@fairchild/folio/conversation` entry.
+
+`pnpm folio:package` copies `host-adapter.mjs` and `contract.test.mjs` into a
+temporary standalone Next application beside the packed tarball. It installs
+that tarball without a workspace link, runs these contract tests, and then runs
+a production build using the package's component, stylesheet, theme, format,
+and testing exports.
+
+For the accepted `0.1.0` release, `accepted-release.json` also pins the source,
+release-asset checksum, and uncompressed tar-payload checksum. The package gate
+requires a locally rebuilt `0.1.0` payload to match that accepted payload
+exactly; the outer gzip stream may differ between packaging environments.
+
+The fixture covers:
+
+- host-owned conversation creation and durable reload;
+- ordered send/stream projection;
+- disconnect at a durable cursor and duplicate-free resume;
+- cancellation and fail-closed errors;
+- queued-message, review, workspace, and publication authority; and
+- foreign-cursor and abort handling.
+
+The real private-consumer browser evidence is summarized in
+[`../../docs/external-consumer-evidence.md`](../../docs/external-consumer-evidence.md).

--- a/web-next/fixtures/external-consumer/accepted-release.json
+++ b/web-next/fixtures/external-consumer/accepted-release.json
@@ -3,5 +3,9 @@
 	"packageVersion": "0.1.0",
 	"sourceCommit": "ac2b5bb8bd74dbba34401d50eeb4304eb87c55e0",
 	"compressedSha256": "f5da5f28ee25e952681fca92b183700958670483215fde6436fed67c5238bde4",
-	"tarPayloadSha256": "68b1383f7ce3ceb4db682b271a9ead9f5032fc50c49404cc334a582418c175a9"
+	"tarPayloadSha256": "68b1383f7ce3ceb4db682b271a9ead9f5032fc50c49404cc334a582418c175a9",
+	"packToolchain": {
+		"nodeMajor": 22,
+		"pnpmMajor": 10
+	}
 }

--- a/web-next/fixtures/external-consumer/accepted-release.json
+++ b/web-next/fixtures/external-consumer/accepted-release.json
@@ -1,0 +1,7 @@
+{
+	"release": "folio-v0.1.0",
+	"packageVersion": "0.1.0",
+	"sourceCommit": "ac2b5bb8bd74dbba34401d50eeb4304eb87c55e0",
+	"compressedSha256": "f5da5f28ee25e952681fca92b183700958670483215fde6436fed67c5238bde4",
+	"tarPayloadSha256": "68b1383f7ce3ceb4db682b271a9ead9f5032fc50c49404cc334a582418c175a9"
+}

--- a/web-next/fixtures/external-consumer/contract.test.mjs
+++ b/web-next/fixtures/external-consumer/contract.test.mjs
@@ -151,6 +151,7 @@ test("rejects foreign cursors and aborted commands without guessing", async () =
 
 	const abort = new AbortController();
 	abort.abort();
+	const beforeAbort = host.serialize();
 	await assert.rejects(
 		host.port().send(
 			{ text: "Do not send", requestId: "request-aborted" },
@@ -158,4 +159,5 @@ test("rejects foreign cursors and aborted commands without guessing", async () =
 		),
 		(error) => error?.name === "AbortError",
 	);
+	assert.equal(host.serialize(), beforeAbort);
 });

--- a/web-next/fixtures/external-consumer/contract.test.mjs
+++ b/web-next/fixtures/external-consumer/contract.test.mjs
@@ -1,0 +1,112 @@
+/* End-to-end compatibility checks run against the installed Folio tarball. */
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	FolioConversationController,
+	FolioUnknownCursorError,
+} from "@fairchild/folio/conversation";
+import { AnonymizedDurableHost } from "./host-adapter.mjs";
+
+test("creates, streams, disconnects, resumes, and reloads durable host state", async () => {
+	const host = AnonymizedDurableHost.createConversation();
+	const disconnected = new FolioConversationController(
+		host.port({ disconnectAfterCursor: "external:3" }),
+	);
+	const created = await disconnected.hydrate();
+	assert.equal(created.conversationId, "conversation-external-1");
+	assert.equal(created.view.messages.length, 0);
+
+	const receipt = await disconnected.send({
+		text: "Prove the external boundary.",
+		requestId: "request-external-1",
+	});
+	assert.equal(receipt.cursor, "external:8");
+	await assert.rejects(disconnected.follow(), /transport disconnected/);
+	assert.equal(disconnected.snapshot?.cursor, "external:3");
+
+	const resumed = FolioConversationController.fromSnapshot(
+		host.port(),
+		disconnected.snapshot,
+	);
+	const completed = await resumed.follow();
+	assert.equal(completed.cursor, "external:8");
+	assert.deepEqual(
+		completed.view.messages.map((message) => message.role),
+		["user", "assistant"],
+	);
+	assert.equal(completed.artifacts[0].label, "Host-owned validation report");
+	assert.equal(completed.review?.state, "pending");
+	assert.equal(completed.view.activeTurn, undefined);
+
+	const reloadedHost = AnonymizedDurableHost.restore(host.serialize());
+	const reloaded = await new FolioConversationController(reloadedHost.port()).hydrate();
+	assert.equal(reloaded.cursor, completed.cursor);
+	assert.deepEqual(reloaded.view.messages, completed.view.messages);
+	assert.deepEqual(reloaded.artifacts, completed.artifacts);
+});
+
+test("keeps stop, failure, review, workspace, and publication authority in the host", async () => {
+	const host = AnonymizedDurableHost.createConversation();
+	const controller = new FolioConversationController(host.port());
+	await controller.hydrate();
+
+	await controller.cancelQueuedMessage("queue-1");
+	await controller.updateConversation({ title: "Host-renamed conversation" });
+	await controller.requestWorkspaceAction("recover");
+	await controller.send({ text: "Prepare evidence.", requestId: "request-external-2" });
+	await controller.decideReview("accept", "Ship it");
+	await controller.requestPublication("publish");
+
+	const projected = await new FolioConversationController(host.port()).hydrate();
+	assert.equal(projected.queuedMessages.length, 0);
+	assert.equal(projected.view.masthead.title, "Host-renamed conversation");
+	assert.equal(projected.workspace?.state, "attached");
+	assert.equal(projected.review?.state, "accepted");
+	assert.equal(projected.publication?.state, "open");
+	assert.equal(projected.failure, null);
+	assert.deepEqual(
+		host.calls
+			.filter((call) => !["readSnapshot", "readEvents"].includes(call.command))
+			.map((call) => call.command),
+		[
+			"cancelQueuedMessage",
+			"updateConversation",
+			"requestWorkspaceAction",
+			"send",
+			"decideReview",
+			"requestPublication",
+		],
+	);
+
+	const stoppedHost = AnonymizedDurableHost.createActiveConversation();
+	const stoppedController = new FolioConversationController(stoppedHost.port());
+	const active = await stoppedController.hydrate();
+	assert.equal(active.capabilities.stop, true);
+	assert.notEqual(active.view.activeTurn, undefined);
+	await stoppedController.stop();
+	const stopped = await new FolioConversationController(stoppedHost.port()).hydrate();
+	assert.equal(stopped.failure, "Turn stopped by the host");
+	assert.equal(stopped.capabilities.stop, false);
+	assert.equal(stopped.view.activeTurn, undefined);
+
+	const failedHost = AnonymizedDurableHost.createConversation();
+	failedHost.recordFailure("Host execution failed safely");
+	const failed = await new FolioConversationController(failedHost.port()).hydrate();
+	assert.equal(failed.failure, "Host execution failed safely");
+});
+
+test("rejects foreign cursors and aborted commands without guessing", async () => {
+	const host = AnonymizedDurableHost.createConversation();
+	const iterator = host.port().readEvents("foreign:9")[Symbol.asyncIterator]();
+	await assert.rejects(iterator.next(), FolioUnknownCursorError);
+
+	const abort = new AbortController();
+	abort.abort();
+	await assert.rejects(
+		host.port().send(
+			{ text: "Do not send", requestId: "request-aborted" },
+			abort.signal,
+		),
+		(error) => error?.name === "AbortError",
+	);
+});

--- a/web-next/fixtures/external-consumer/contract.test.mjs
+++ b/web-next/fixtures/external-consumer/contract.test.mjs
@@ -7,29 +7,59 @@ import {
 } from "@fairchild/folio/conversation";
 import { AnonymizedDurableHost } from "./host-adapter.mjs";
 
+const conversationId = "conversation-external-1";
+const cursor = (ordinal, id = conversationId) => `${id}:generation-1:${ordinal}`;
+
+function assertStopAuthorityInvariant(snapshots) {
+	for (const snapshot of snapshots) {
+		assert.equal(
+			snapshot.capabilities.stop && snapshot.view.activeTurn === undefined,
+			false,
+			`stop authority requires an active turn at ${snapshot.cursor}`,
+		);
+	}
+}
+
 test("creates, streams, disconnects, resumes, and reloads durable host state", async () => {
 	const host = AnonymizedDurableHost.createConversation();
 	const disconnected = new FolioConversationController(
-		host.port({ disconnectAfterCursor: "external:3" }),
+		host.port({ disconnectAfterCursor: cursor(3) }),
 	);
 	const created = await disconnected.hydrate();
-	assert.equal(created.conversationId, "conversation-external-1");
+	assert.equal(created.conversationId, conversationId);
 	assert.equal(created.view.messages.length, 0);
 
 	const receipt = await disconnected.send({
 		text: "Prove the external boundary.",
 		requestId: "request-external-1",
 	});
-	assert.equal(receipt.cursor, "external:8");
-	await assert.rejects(disconnected.follow(), /transport disconnected/);
-	assert.equal(disconnected.snapshot?.cursor, "external:3");
+	assert.equal(receipt.cursor, cursor(8));
+	const transitions = [];
+	const observedCursors = [];
+	await assert.rejects(
+		disconnected.follow((snapshot) => {
+			transitions.push(snapshot);
+			observedCursors.push(snapshot.cursor);
+		}),
+		/transport disconnected/,
+	);
+	assert.equal(disconnected.snapshot?.cursor, cursor(3));
 
 	const resumed = FolioConversationController.fromSnapshot(
 		host.port(),
 		disconnected.snapshot,
 	);
-	const completed = await resumed.follow();
-	assert.equal(completed.cursor, "external:8");
+	const completed = await resumed.follow((snapshot) => {
+		transitions.push(snapshot);
+		observedCursors.push(snapshot.cursor);
+	});
+	assert.equal(completed.cursor, cursor(8));
+	assert.deepEqual(
+		observedCursors,
+		Array.from({ length: 8 }, (_, index) => cursor(index + 1)),
+	);
+	assert.equal(new Set(observedCursors).size, observedCursors.length);
+	assertStopAuthorityInvariant(transitions);
 	assert.deepEqual(
 		completed.view.messages.map((message) => message.role),
 		["user", "assistant"],
@@ -54,6 +84,7 @@ test("keeps stop, failure, review, workspace, and publication authority in the h
 	await controller.updateConversation({ title: "Host-renamed conversation" });
 	await controller.requestWorkspaceAction("recover");
 	await controller.send({ text: "Prepare evidence.", requestId: "request-external-2" });
+	await controller.decideApproval("approval-external-1", "allow");
 	await controller.decideReview("accept", "Ship it");
 	await controller.requestPublication("publish");
 
@@ -73,6 +104,7 @@ test("keeps stop, failure, review, workspace, and publication authority in the h
 			"updateConversation",
 			"requestWorkspaceAction",
 			"send",
+			"decideApproval",
 			"decideReview",
 			"requestPublication",
 		],
@@ -84,6 +116,9 @@ test("keeps stop, failure, review, workspace, and publication authority in the h
 	assert.equal(active.capabilities.stop, true);
 	assert.notEqual(active.view.activeTurn, undefined);
 	await stoppedController.stop();
+	const stopTransitions = [];
+	await stoppedController.follow((snapshot) => stopTransitions.push(snapshot));
+	assertStopAuthorityInvariant(stopTransitions);
 	const stopped = await new FolioConversationController(stoppedHost.port()).hydrate();
 	assert.equal(stopped.failure, "Turn stopped by the host");
 	assert.equal(stopped.capabilities.stop, false);
@@ -96,9 +131,23 @@ test("keeps stop, failure, review, workspace, and publication authority in the h
 });
 
 test("rejects foreign cursors and aborted commands without guessing", async () => {
-	const host = AnonymizedDurableHost.createConversation();
-	const iterator = host.port().readEvents("foreign:9")[Symbol.asyncIterator]();
+	const host = AnonymizedDurableHost.createConversation(conversationId);
+	const foreignHost = AnonymizedDurableHost.createConversation("conversation-external-2");
+	await host.port().send({ text: "Local history", requestId: "request-local" });
+	const foreignReceipt = await foreignHost.port().send({
+		text: "Foreign history",
+		requestId: "request-foreign",
+	});
+	assert.equal(foreignReceipt.cursor, cursor(8, "conversation-external-2"));
+	const iterator = host.port().readEvents(foreignReceipt.cursor)[Symbol.asyncIterator]();
 	await assert.rejects(iterator.next(), FolioUnknownCursorError);
+
+	const tampered = JSON.parse(host.serialize());
+	tampered.events[0].cursor = cursor(1, "conversation-external-2");
+	assert.throws(
+		() => AnonymizedDurableHost.restore(JSON.stringify(tampered)),
+		/event cursor .* does not match/,
+	);
 
 	const abort = new AbortController();
 	abort.abort();

--- a/web-next/fixtures/external-consumer/host-adapter.mjs
+++ b/web-next/fixtures/external-consumer/host-adapter.mjs
@@ -1,0 +1,355 @@
+/*
+ * An anonymized durable host for the external-consumer compatibility fixture.
+ * It intentionally imports only Folio's installed public conversation entry.
+ */
+import {
+	FolioCapabilityUnavailableError,
+	FolioUnknownCursorError,
+	applyConversationEvent,
+} from "@fairchild/folio/conversation";
+
+const clone = (value) => structuredClone(value);
+
+function initialSnapshot() {
+	return {
+		conversationId: "conversation-external-1",
+		cursor: "external:0",
+		view: {
+			masthead: {
+				repo: "example/private-host",
+				branch: "conversation/external-1",
+				title: "External consumer",
+				agentName: "Host agent",
+				stateLabel: "ready",
+			},
+			messages: [],
+			statusLine: {
+				model: "host-model",
+				modelLabel: "Host model",
+			},
+			empty: {
+				title: "Ready for a host-owned conversation.",
+				hint: "Folio supplies the interface; this fixture owns the runtime.",
+			},
+		},
+		queuedMessages: [
+			{
+				queueId: "queue-1",
+				text: "A host-owned queued message",
+				queuedAt: "2026-01-01T00:00:00.000Z",
+				position: 1,
+			},
+		],
+		capabilities: {
+			send: true,
+			stop: false,
+			retry: true,
+			cancelQueuedMessage: true,
+			decideApproval: true,
+			decideReview: true,
+			updateConversation: true,
+		},
+		artifacts: [],
+		review: null,
+		workspace: {
+			id: "workspace-external-1",
+			label: "Host workspace",
+			state: "needs-recovery",
+			actions: ["recover"],
+		},
+		publication: {
+			id: null,
+			state: null,
+			url: null,
+			actions: ["publish"],
+		},
+		failure: null,
+	};
+}
+
+export class AnonymizedDurableHost {
+	#snapshot;
+	#events;
+
+	constructor(state) {
+		this.#snapshot = clone(state?.snapshot ?? initialSnapshot());
+		this.#events = clone(state?.events ?? []);
+		this.calls = clone(state?.calls ?? []);
+	}
+
+	static createConversation() {
+		return new AnonymizedDurableHost();
+	}
+
+	static createActiveConversation() {
+		const host = new AnonymizedDurableHost();
+		host.#append({
+			type: "message-upsert",
+			message: {
+				id: "external-active-user",
+				role: "user",
+				metadata: { author: "You" },
+				parts: [{ type: "text", text: "Stop this active turn safely." }],
+			},
+		});
+		host.#append({
+			type: "capabilities",
+			capabilities: { ...host.#snapshot.capabilities, stop: true },
+		});
+		host.#append({
+			type: "active-turn",
+			activeTurn: {
+				agentName: "Host agent",
+				action: "Working",
+				details: ["Awaiting a host stop command"],
+			},
+		});
+		return host;
+	}
+
+	static restore(serialized) {
+		return new AnonymizedDurableHost(JSON.parse(serialized));
+	}
+
+	serialize() {
+		return JSON.stringify({
+			snapshot: this.#snapshot,
+			events: this.#events,
+			calls: this.calls,
+		});
+	}
+
+	readDurableSnapshot() {
+		return clone(this.#snapshot);
+	}
+
+	recordFailure(message) {
+		this.#append({ type: "failure", message });
+		this.#append({ type: "complete" });
+	}
+
+	port({ disconnectAfterCursor } = {}) {
+		// Port methods are deliberately detached from their object receiver; the
+		// durable host remains the sole state and authority owner.
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
+		const host = this;
+		return {
+			async readSnapshot(signal) {
+				signal?.throwIfAborted();
+				host.calls.push({ command: "readSnapshot" });
+				return host.readDurableSnapshot();
+			},
+
+			async *readEvents(after, signal) {
+				signal?.throwIfAborted();
+				host.calls.push({ command: "readEvents", payload: after });
+				const cursors = ["external:0", ...host.#events.map((event) => event.cursor)];
+				const cursorIndex = cursors.indexOf(after);
+				if (cursorIndex < 0) {
+					throw new FolioUnknownCursorError(`unknown external cursor: ${after}`);
+				}
+				for (const event of host.#events.slice(cursorIndex)) {
+					signal?.throwIfAborted();
+					yield clone(event);
+					if (event.cursor === disconnectAfterCursor) {
+						throw new Error("anonymized transport disconnected");
+					}
+				}
+			},
+
+			async send(request, signal) {
+				host.#require(
+					request.retryOf
+						? host.#snapshot.capabilities.retry
+						: host.#snapshot.capabilities.send,
+					request.retryOf ? "retry" : "send",
+					signal,
+				);
+				host.calls.push({ command: "send", payload: clone(request) });
+				const turn = host.#events.length + 1;
+				host.#append({
+					type: "message-upsert",
+					message: {
+						id: `external-user-${turn}`,
+						role: "user",
+						metadata: { author: "You" },
+						parts: [{ type: "text", text: request.text }],
+					},
+				});
+				host.#append({
+					type: "capabilities",
+					capabilities: { ...host.#snapshot.capabilities, stop: true },
+				});
+				host.#append({
+					type: "active-turn",
+					activeTurn: {
+						agentName: "Host agent",
+						action: "Working",
+						details: ["Streaming through the host adapter"],
+					},
+				});
+				host.#append({
+					type: "message-upsert",
+					message: {
+						id: `external-assistant-${turn}`,
+						role: "assistant",
+						metadata: { author: "Host agent" },
+						parts: [{ type: "text", text: "Completed by the external host." }],
+					},
+				});
+				host.#append({
+					type: "artifact",
+					artifact: {
+						id: `artifact-${turn}`,
+						kind: "report",
+						label: "Host-owned validation report",
+					},
+				});
+				host.#append({
+					type: "review",
+					review: {
+						id: `review-${turn}`,
+						summary: "Ready for host review",
+						changedFiles: ["docs/example.md"],
+						state: "pending",
+					},
+				});
+				host.#append({
+					type: "capabilities",
+					capabilities: { ...host.#snapshot.capabilities, stop: false },
+				});
+				host.#append({ type: "complete" });
+				return host.#receipt();
+			},
+
+			async stop(signal) {
+				host.#require(host.#snapshot.capabilities.stop, "stop", signal);
+				host.calls.push({ command: "stop" });
+				host.#append({ type: "failure", message: "Turn stopped by the host" });
+				host.#append({
+					type: "capabilities",
+					capabilities: { ...host.#snapshot.capabilities, stop: false },
+				});
+				host.#append({ type: "complete" });
+				return host.#receipt();
+			},
+
+			async cancelQueuedMessage(queueId, signal) {
+				host.#require(
+					host.#snapshot.capabilities.cancelQueuedMessage,
+					"cancelQueuedMessage",
+					signal,
+				);
+				host.calls.push({ command: "cancelQueuedMessage", payload: queueId });
+				host.#append({
+					type: "queued-messages",
+					messages: host.#snapshot.queuedMessages.filter(
+						(message) => message.queueId !== queueId,
+					),
+				});
+				return host.#receipt();
+			},
+
+			async decideApproval(requestId, decision, signal) {
+				host.#require(
+					host.#snapshot.capabilities.decideApproval,
+					"decideApproval",
+					signal,
+				);
+				host.calls.push({
+					command: "decideApproval",
+					payload: { requestId, decision },
+				});
+				return host.#receipt();
+			},
+
+			async decideReview(decision, note, signal) {
+				host.#require(
+					host.#snapshot.capabilities.decideReview,
+					"decideReview",
+					signal,
+				);
+				host.calls.push({ command: "decideReview", payload: { decision, note } });
+				if (host.#snapshot.review) {
+					host.#append({
+						type: "review",
+						review: {
+							...host.#snapshot.review,
+							state: decision === "accept" ? "accepted" : "rejected",
+						},
+					});
+				}
+				return host.#receipt();
+			},
+
+			async updateConversation(update, signal) {
+				host.#require(
+					host.#snapshot.capabilities.updateConversation,
+					"updateConversation",
+					signal,
+				);
+				host.calls.push({ command: "updateConversation", payload: clone(update) });
+				host.#append({ type: "conversation-updated", ...update });
+				return host.#receipt();
+			},
+
+			async requestWorkspaceAction(action, signal) {
+				host.#require(
+					host.#snapshot.workspace?.actions.includes(action) === true,
+					`workspace ${action}`,
+					signal,
+				);
+				host.calls.push({ command: "requestWorkspaceAction", payload: action });
+				host.#append({
+					type: "workspace",
+					workspace: {
+						...host.#snapshot.workspace,
+						state: "attached",
+						actions: [],
+					},
+				});
+				return host.#receipt();
+			},
+
+			async requestPublication(action, signal) {
+				host.#require(
+					host.#snapshot.publication?.actions.includes(action) === true,
+					`publication ${action}`,
+					signal,
+				);
+				host.calls.push({ command: "requestPublication", payload: action });
+				host.#append({
+					type: "publication",
+					publication: {
+						id: "publication-external-1",
+						state: "open",
+						url: null,
+						actions: [],
+					},
+				});
+				return host.#receipt();
+			},
+		};
+	}
+
+	#append(event) {
+		const durableEvent = {
+			...clone(event),
+			cursor: `external:${this.#events.length + 1}`,
+		};
+		this.#events.push(durableEvent);
+		this.#snapshot = applyConversationEvent(this.#snapshot, durableEvent);
+		return durableEvent;
+	}
+
+	#receipt() {
+		return { cursor: this.#snapshot.cursor };
+	}
+
+	#require(available, command, signal) {
+		signal?.throwIfAborted();
+		if (!available) {
+			throw new FolioCapabilityUnavailableError(`${command} is unavailable`);
+		}
+	}
+}

--- a/web-next/fixtures/external-consumer/host-adapter.mjs
+++ b/web-next/fixtures/external-consumer/host-adapter.mjs
@@ -10,10 +10,16 @@ import {
 
 const clone = (value) => structuredClone(value);
 
-function initialSnapshot() {
+const DEFAULT_CONVERSATION_ID = "conversation-external-1";
+
+function cursorFor(conversationId, ordinal) {
+	return `${conversationId}:generation-1:${ordinal}`;
+}
+
+function initialSnapshot(conversationId = DEFAULT_CONVERSATION_ID) {
 	return {
-		conversationId: "conversation-external-1",
-		cursor: "external:0",
+		conversationId,
+		cursor: cursorFor(conversationId, 0),
 		view: {
 			masthead: {
 				repo: "example/private-host",
@@ -68,17 +74,31 @@ function initialSnapshot() {
 }
 
 export class AnonymizedDurableHost {
+	#initialSnapshot;
 	#snapshot;
 	#events;
 
 	constructor(state) {
-		this.#snapshot = clone(state?.snapshot ?? initialSnapshot());
+		this.#initialSnapshot = clone(state?.initialSnapshot ?? initialSnapshot());
 		this.#events = clone(state?.events ?? []);
 		this.calls = clone(state?.calls ?? []);
+		if (
+			this.#initialSnapshot.cursor !== cursorFor(this.#initialSnapshot.conversationId, 0)
+		) {
+			throw new Error("external host initial cursor does not match its conversation");
+		}
+		this.#snapshot = clone(this.#initialSnapshot);
+		for (const [index, event] of this.#events.entries()) {
+			const expected = cursorFor(this.#initialSnapshot.conversationId, index + 1);
+			if (event.cursor !== expected) {
+				throw new Error(`external host event cursor ${event.cursor} does not match ${expected}`);
+			}
+			this.#snapshot = applyConversationEvent(this.#snapshot, event);
+		}
 	}
 
-	static createConversation() {
-		return new AnonymizedDurableHost();
+	static createConversation(conversationId = DEFAULT_CONVERSATION_ID) {
+		return new AnonymizedDurableHost({ initialSnapshot: initialSnapshot(conversationId) });
 	}
 
 	static createActiveConversation() {
@@ -93,16 +113,16 @@ export class AnonymizedDurableHost {
 			},
 		});
 		host.#append({
-			type: "capabilities",
-			capabilities: { ...host.#snapshot.capabilities, stop: true },
-		});
-		host.#append({
 			type: "active-turn",
 			activeTurn: {
 				agentName: "Host agent",
 				action: "Working",
 				details: ["Awaiting a host stop command"],
 			},
+		});
+		host.#append({
+			type: "capabilities",
+			capabilities: { ...host.#snapshot.capabilities, stop: true },
 		});
 		return host;
 	}
@@ -113,7 +133,7 @@ export class AnonymizedDurableHost {
 
 	serialize() {
 		return JSON.stringify({
-			snapshot: this.#snapshot,
+			initialSnapshot: this.#initialSnapshot,
 			events: this.#events,
 			calls: this.calls,
 		});
@@ -143,7 +163,10 @@ export class AnonymizedDurableHost {
 			async *readEvents(after, signal) {
 				signal?.throwIfAborted();
 				host.calls.push({ command: "readEvents", payload: after });
-				const cursors = ["external:0", ...host.#events.map((event) => event.cursor)];
+				const cursors = [
+					host.#initialSnapshot.cursor,
+					...host.#events.map((event) => event.cursor),
+				];
 				const cursorIndex = cursors.indexOf(after);
 				if (cursorIndex < 0) {
 					throw new FolioUnknownCursorError(`unknown external cursor: ${after}`);
@@ -177,16 +200,16 @@ export class AnonymizedDurableHost {
 					},
 				});
 				host.#append({
-					type: "capabilities",
-					capabilities: { ...host.#snapshot.capabilities, stop: true },
-				});
-				host.#append({
 					type: "active-turn",
 					activeTurn: {
 						agentName: "Host agent",
 						action: "Working",
 						details: ["Streaming through the host adapter"],
 					},
+				});
+				host.#append({
+					type: "capabilities",
+					capabilities: { ...host.#snapshot.capabilities, stop: true },
 				});
 				host.#append({
 					type: "message-upsert",
@@ -225,11 +248,11 @@ export class AnonymizedDurableHost {
 			async stop(signal) {
 				host.#require(host.#snapshot.capabilities.stop, "stop", signal);
 				host.calls.push({ command: "stop" });
-				host.#append({ type: "failure", message: "Turn stopped by the host" });
 				host.#append({
 					type: "capabilities",
 					capabilities: { ...host.#snapshot.capabilities, stop: false },
 				});
+				host.#append({ type: "failure", message: "Turn stopped by the host" });
 				host.#append({ type: "complete" });
 				return host.#receipt();
 			},
@@ -335,7 +358,10 @@ export class AnonymizedDurableHost {
 	#append(event) {
 		const durableEvent = {
 			...clone(event),
-			cursor: `external:${this.#events.length + 1}`,
+			cursor: cursorFor(
+				this.#initialSnapshot.conversationId,
+				this.#events.length + 1,
+			),
 		};
 		this.#events.push(durableEvent);
 		this.#snapshot = applyConversationEvent(this.#snapshot, durableEvent);

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -16,6 +16,7 @@
 		"clean": "node scripts/clean.mjs",
 		"folio:build": "pnpm --filter @fairchild/folio build",
 		"folio:package": "node scripts/folio-artifact.mjs",
+		"folio:package:candidate": "node scripts/folio-artifact.mjs --candidate",
 		"evidence": "node scripts/evidence.mjs",
 		"evidence:upload": "bash scripts/upload-evidence.sh",
 		"demo:scroll-turn": "playwright test --config=playwright.scroll-turn.config.ts",

--- a/web-next/packages/folio/RELEASING.md
+++ b/web-next/packages/folio/RELEASING.md
@@ -14,12 +14,13 @@ pnpm folio:package
 It independently clean-builds and stages the compiled ESM, declarations,
 JavaScript/CSS source maps, and standalone stylesheet twice; packs both staging
 trees and requires identical SHA-256 checksums; enforces the file and size
-allowlists; then copies the tarball into a temporary project, installs with no
-workspace link, and runs a production Next build. Review artifacts are written
-under `artifacts/folio/`.
+allowlists; then copies the tarball and the anonymized external-host fixture into
+a temporary project, installs with no workspace link, runs the public port
+contract, and runs a production Next build. Review artifacts are written under
+`artifacts/folio/`.
 
-The artifact remains `private: true`. Public-registry publication is a separate
-owner decision after the first external-consumer proof (#1055). That gate must
+The artifact remains `private: true`. The first external-consumer proof (#1055)
+does not itself authorize registry publication. A future publication gate must
 decide package scope/ownership, provenance signing, npm trusted publishing, and
 support expectations before removing `private` or adding a publish command.
 

--- a/web-next/packages/folio/RELEASING.md
+++ b/web-next/packages/folio/RELEASING.md
@@ -15,8 +15,12 @@ It independently clean-builds and stages the compiled ESM, declarations,
 JavaScript/CSS source maps, and standalone stylesheet twice; packs both staging
 trees and requires identical SHA-256 checksums; enforces the file and size
 allowlists; then copies the tarball and the anonymized external-host fixture into
-a temporary project, installs with no workspace link, runs the public port
-contract, and runs a production Next build. Review artifacts are written under
+a temporary project. For an accepted package version, the gate fails closed
+unless the checked-in release receipt matches the remote Git tag, downloaded
+release-asset checksum, and uncompressed tar payload. It installs that canonical
+release asset with no workspace link, runs the public port contract, and runs a
+production Next build. This provenance step requires network access to the
+public Git remote and GitHub release. Review artifacts are written under
 `artifacts/folio/`.
 
 The artifact remains `private: true`. The first external-consumer proof (#1055)

--- a/web-next/packages/folio/RELEASING.md
+++ b/web-next/packages/folio/RELEASING.md
@@ -15,13 +15,40 @@ It independently clean-builds and stages the compiled ESM, declarations,
 JavaScript/CSS source maps, and standalone stylesheet twice; packs both staging
 trees and requires identical SHA-256 checksums; enforces the file and size
 allowlists; then copies the tarball and the anonymized external-host fixture into
-a temporary project. For an accepted package version, the gate fails closed
-unless the checked-in release receipt matches the remote Git tag, downloaded
-release-asset checksum, and uncompressed tar payload. It installs that canonical
-release asset with no workspace link, runs the public port contract, and runs a
-production Next build. This provenance step requires network access to the
+a temporary project. Every package version requires an accepted release record;
+the default gate fails closed unless that record matches the canonical remote
+Git tag, downloaded release-asset checksum, and uncompressed tar payload. It
+installs that canonical release asset with no workspace link, runs the public
+port contract, and runs a production Next build. The record also names the
+release packing toolchain so a payload mismatch can distinguish source changes
+from toolchain drift. This strict provenance step requires network access to the
 public Git remote and GitHub release. Review artifacts are written under
 `artifacts/folio/`.
+
+## Advancing the accepted version
+
+The strict command intentionally cannot mint its own trust record. Advancing a
+version is a serialized operator flow:
+
+1. On a release branch, update Folio source, `CHANGELOG.md`, and the package
+   version, then commit with a clean worktree.
+2. Run `pnpm folio:package:candidate`. This explicit local-only command refuses
+   CI and an already accepted version. It writes the candidate source commit,
+   compressed checksum, and tar-payload checksum to `artifacts/folio/manifest.json`
+   and proves the local candidate in the clean consumer.
+3. Tag that exact candidate commit as `folio-vX.Y.Z`, push the tag, and create a
+   GitHub prerelease carrying the generated `.tgz`. Do not rebuild the asset
+   after recording its hashes.
+4. Update `fixtures/external-consumer/accepted-release.json` with the tag,
+   candidate commit, both checksums, and Node/pnpm major versions. Commit the
+   receipt and rerun the strict `pnpm folio:package`; it must now verify the
+   canonical tag and downloaded prerelease asset.
+5. Merge the release PR with a merge commit, not squash or rebase, so the tagged
+   candidate remains an ancestor of `main`. Promote the prerelease only after
+   the merge and post-merge strict gate pass.
+
+Intermediate branch CI may be red between steps 1 and 4; the branch is not
+mergeable until the strict gate passes. Candidate mode is never a CI bypass.
 
 The artifact remains `private: true`. The first external-consumer proof (#1055)
 does not itself authorize registry publication. A future publication gate must

--- a/web-next/scripts/folio-artifact-core.mjs
+++ b/web-next/scripts/folio-artifact-core.mjs
@@ -109,6 +109,12 @@ export function validateAcceptedReleaseRecord(accepted, manifest) {
 			errors.push(`accepted release ${field} must be a full lowercase SHA-256`);
 		}
 	}
+	if (!Number.isInteger(accepted?.packToolchain?.nodeMajor)) {
+		errors.push("accepted release packToolchain.nodeMajor must be an integer");
+	}
+	if (!Number.isInteger(accepted?.packToolchain?.pnpmMajor)) {
+		errors.push("accepted release packToolchain.pnpmMajor must be an integer");
+	}
 	return errors;
 }
 

--- a/web-next/scripts/folio-artifact-core.mjs
+++ b/web-next/scripts/folio-artifact-core.mjs
@@ -91,6 +91,27 @@ export function tarballFilename(name, version) {
 	return `${name.replace(/^@/, "").replaceAll("/", "-")}-${version}.tgz`;
 }
 
+export function validateAcceptedReleaseRecord(accepted, manifest) {
+	const errors = [];
+	if (accepted?.packageVersion !== manifest.version) {
+		errors.push(
+			`Folio ${manifest.version} has no accepted release record (found ${accepted?.packageVersion ?? "none"})`,
+		);
+	}
+	if (accepted?.release !== `folio-v${accepted?.packageVersion}`) {
+		errors.push("accepted release tag must match its package version");
+	}
+	if (!/^[0-9a-f]{40}$/.test(accepted?.sourceCommit ?? "")) {
+		errors.push("accepted release source commit must be a full lowercase SHA-1");
+	}
+	for (const field of ["compressedSha256", "tarPayloadSha256"]) {
+		if (!/^[0-9a-f]{64}$/.test(accepted?.[field] ?? "")) {
+			errors.push(`accepted release ${field} must be a full lowercase SHA-256`);
+		}
+	}
+	return errors;
+}
+
 function packageName(specifier) {
 	if (specifier.startsWith("@")) return specifier.split("/").slice(0, 2).join("/");
 	return specifier.split("/")[0];

--- a/web-next/scripts/folio-artifact-core.test.mjs
+++ b/web-next/scripts/folio-artifact-core.test.mjs
@@ -7,6 +7,7 @@ import {
 	PACKED_FILES,
 	runtimeImports,
 	tarballFilename,
+	validateAcceptedReleaseRecord,
 	validateBuildOutput,
 	validatePackedArtifact,
 } from "./folio-artifact-core.mjs";
@@ -59,6 +60,38 @@ describe("Folio artifact contract", () => {
 		expect(tarballFilename("@fairchild/folio", "0.1.0")).toBe(
 			"fairchild-folio-0.1.0.tgz",
 		);
+	});
+
+	test("fails closed until package provenance has an accepted release record", () => {
+		const manifest = createArtifactManifest(sourceManifest);
+		const accepted = {
+			release: "folio-v0.1.0",
+			packageVersion: "0.1.0",
+			sourceCommit: "a".repeat(40),
+			compressedSha256: "b".repeat(64),
+			tarPayloadSha256: "c".repeat(64),
+		};
+
+		expect(validateAcceptedReleaseRecord(accepted, manifest)).toEqual([]);
+		expect(
+			validateAcceptedReleaseRecord(
+				{
+					...accepted,
+					release: "wrong-tag",
+					packageVersion: "0.2.0",
+					sourceCommit: "short",
+					compressedSha256: "invalid",
+					tarPayloadSha256: "invalid",
+				},
+				manifest,
+			),
+		).toEqual([
+			"Folio 0.1.0 has no accepted release record (found 0.2.0)",
+			"accepted release tag must match its package version",
+			"accepted release source commit must be a full lowercase SHA-1",
+			"accepted release compressedSha256 must be a full lowercase SHA-256",
+			"accepted release tarPayloadSha256 must be a full lowercase SHA-256",
+		]);
 	});
 
 	test("detects undeclared imports, uncompiled CSS, unpacked assets, and incomplete maps", () => {

--- a/web-next/scripts/folio-artifact-core.test.mjs
+++ b/web-next/scripts/folio-artifact-core.test.mjs
@@ -70,6 +70,7 @@ describe("Folio artifact contract", () => {
 			sourceCommit: "a".repeat(40),
 			compressedSha256: "b".repeat(64),
 			tarPayloadSha256: "c".repeat(64),
+			packToolchain: { nodeMajor: 22, pnpmMajor: 10 },
 		};
 
 		expect(validateAcceptedReleaseRecord(accepted, manifest)).toEqual([]);
@@ -82,6 +83,7 @@ describe("Folio artifact contract", () => {
 					sourceCommit: "short",
 					compressedSha256: "invalid",
 					tarPayloadSha256: "invalid",
+					packToolchain: {},
 				},
 				manifest,
 			),
@@ -91,6 +93,8 @@ describe("Folio artifact contract", () => {
 			"accepted release source commit must be a full lowercase SHA-1",
 			"accepted release compressedSha256 must be a full lowercase SHA-256",
 			"accepted release tarPayloadSha256 must be a full lowercase SHA-256",
+			"accepted release packToolchain.nodeMajor must be an integer",
+			"accepted release packToolchain.pnpmMajor must be an integer",
 		]);
 	});
 

--- a/web-next/scripts/folio-artifact.mjs
+++ b/web-next/scripts/folio-artifact.mjs
@@ -16,6 +16,7 @@ import {
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import { gunzipSync } from "node:zlib";
 import { execFile } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import {
@@ -28,6 +29,8 @@ import {
 const exec = promisify(execFile);
 const WEB_NEXT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const PACKAGE = path.join(WEB_NEXT, "packages", "folio");
+const EXTERNAL_FIXTURE = path.join(WEB_NEXT, "fixtures", "external-consumer");
+const ACCEPTED_RELEASE = path.join(EXTERNAL_FIXTURE, "accepted-release.json");
 const ARTIFACTS = path.join(WEB_NEXT, "artifacts", "folio");
 const STAGE_A = path.join(ARTIFACTS, "stage-a");
 const STAGE_B = path.join(ARTIFACTS, "stage-b");
@@ -48,6 +51,20 @@ async function runPnpm(args, options = {}) {
 
 async function sha256(file) {
 	return createHash("sha256").update(await readFile(file)).digest("hex");
+}
+
+async function verifyAcceptedReleasePayload(tarball, manifest) {
+	const accepted = JSON.parse(await readFile(ACCEPTED_RELEASE, "utf8"));
+	if (accepted.packageVersion !== manifest.version) return null;
+	const payloadSha256 = createHash("sha256")
+		.update(gunzipSync(await readFile(tarball)))
+		.digest("hex");
+	if (payloadSha256 !== accepted.tarPayloadSha256) {
+		throw new Error(
+			`Folio ${manifest.version} tar payload ${payloadSha256} differs from accepted release ${accepted.tarPayloadSha256}`,
+		);
+	}
+	return payloadSha256;
 }
 
 async function stagePackage(destination) {
@@ -130,7 +147,10 @@ function fixtureFiles(tarballName) {
 				version: "0.0.0",
 				private: true,
 				type: "module",
-				scripts: { build: "next build" },
+				scripts: {
+					build: "next build",
+					test: "node --test test/*.test.mjs",
+				},
 				dependencies: {
 					"@fairchild/folio": `file:./${tarballName}`,
 					ai: "7.0.15",
@@ -187,6 +207,10 @@ async function verifyCleanConsumer(tarball) {
 			await mkdir(path.dirname(target), { recursive: true });
 			await writeFile(target, contents);
 		}
+		await mkdir(path.join(fixture, "test"), { recursive: true });
+		for (const file of ["host-adapter.mjs", "contract.test.mjs"]) {
+			await cp(path.join(EXTERNAL_FIXTURE, file), path.join(fixture, "test", file));
+		}
 		const install = await runPnpm(["install", "--prefer-offline", "--ignore-workspace"], {
 			cwd: fixture,
 		});
@@ -210,6 +234,11 @@ async function verifyCleanConsumer(tarball) {
 		log.push(
 			`IDENTITY\n${identity.stdout}${identity.stderr}shared conversation runtime identity verified`,
 		);
+		stage = "external contract";
+		const contract = await runPnpm(["--ignore-workspace", "test"], {
+			cwd: fixture,
+		});
+		log.push(`EXTERNAL CONTRACT\n${contract.stdout}${contract.stderr}`);
 		stage = "build";
 		const build = await runPnpm(["--ignore-workspace", "run", "build"], {
 			cwd: fixture,
@@ -255,6 +284,7 @@ if (errors.length > 0) throw new Error(errors.join("\n"));
 
 const finalTarball = path.join(ARTIFACTS, filename);
 await cp(first, finalTarball);
+const acceptedPayloadSha256 = await verifyAcceptedReleasePayload(finalTarball, manifest);
 await writeFile(path.join(ARTIFACTS, "files.txt"), `${files.join("\n")}\n`);
 await writeFile(
 	path.join(ARTIFACTS, "manifest.json"),
@@ -275,5 +305,10 @@ await verifyCleanConsumer(finalTarball);
 
 console.log(`packed ${path.relative(WEB_NEXT, finalTarball)}`);
 console.log(`sha256 ${firstSha256}`);
+if (acceptedPayloadSha256) {
+	console.log(`tar payload sha256 ${acceptedPayloadSha256} matches the accepted release`);
+}
 console.log(`${packedStat.size} bytes, ${files.length} intentional files`);
-console.log("clean standalone Next fixture installed without a workspace link and built successfully");
+console.log(
+	"clean standalone Next fixture installed without a workspace link, passed the external-host contract, and built successfully",
+);

--- a/web-next/scripts/folio-artifact.mjs
+++ b/web-next/scripts/folio-artifact.mjs
@@ -22,6 +22,7 @@ import { fileURLToPath } from "node:url";
 import {
 	createArtifactManifest,
 	tarballFilename,
+	validateAcceptedReleaseRecord,
 	validateBuildOutput,
 	validatePackedArtifact,
 } from "./folio-artifact-core.mjs";
@@ -53,18 +54,77 @@ async function sha256(file) {
 	return createHash("sha256").update(await readFile(file)).digest("hex");
 }
 
-async function verifyAcceptedReleasePayload(tarball, manifest) {
+function bufferSha256(buffer) {
+	return createHash("sha256").update(buffer).digest("hex");
+}
+
+async function verifyAcceptedRelease(tarball, manifest, filename) {
 	const accepted = JSON.parse(await readFile(ACCEPTED_RELEASE, "utf8"));
-	if (accepted.packageVersion !== manifest.version) return null;
-	const payloadSha256 = createHash("sha256")
-		.update(gunzipSync(await readFile(tarball)))
-		.digest("hex");
-	if (payloadSha256 !== accepted.tarPayloadSha256) {
+	const recordErrors = validateAcceptedReleaseRecord(accepted, manifest);
+	if (recordErrors.length > 0) throw new Error(recordErrors.join("\n"));
+
+	const repo = path.resolve(WEB_NEXT, "..");
+	const { stdout: remoteTags } = await exec(
+		"git",
+		[
+			"ls-remote",
+			"--tags",
+			"origin",
+			`refs/tags/${accepted.release}`,
+			`refs/tags/${accepted.release}^{}`,
+		],
+		{ cwd: repo, timeout: 20_000 },
+	);
+	const remoteCommit = remoteTags
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.find((line) => line.endsWith("^{}"))
+		?.split(/\s+/)[0] ?? remoteTags.trim().split(/\s+/)[0];
+	if (remoteCommit !== accepted.sourceCommit) {
 		throw new Error(
-			`Folio ${manifest.version} tar payload ${payloadSha256} differs from accepted release ${accepted.tarPayloadSha256}`,
+			`accepted release ${accepted.release} resolves to ${remoteCommit || "no remote tag"}, not ${accepted.sourceCommit}`,
 		);
 	}
-	return payloadSha256;
+
+	const localPayloadSha256 = bufferSha256(gunzipSync(await readFile(tarball)));
+	if (localPayloadSha256 !== accepted.tarPayloadSha256) {
+		throw new Error(
+			`Folio ${manifest.version} tar payload ${localPayloadSha256} differs from accepted release ${accepted.tarPayloadSha256}`,
+		);
+	}
+
+	const releaseUrl = `https://github.com/fairchild/workspaces/releases/download/${encodeURIComponent(accepted.release)}/${encodeURIComponent(filename)}`;
+	const response = await fetch(releaseUrl, {
+		redirect: "follow",
+		signal: AbortSignal.timeout(20_000),
+	});
+	if (!response.ok) {
+		throw new Error(
+			`could not download accepted Folio release (${response.status} ${response.statusText})`,
+		);
+	}
+	const canonicalBytes = Buffer.from(await response.arrayBuffer());
+	const canonicalCompressedSha256 = bufferSha256(canonicalBytes);
+	if (canonicalCompressedSha256 !== accepted.compressedSha256) {
+		throw new Error(
+			`accepted release asset checksum ${canonicalCompressedSha256} differs from ${accepted.compressedSha256}`,
+		);
+	}
+	const canonicalPayloadSha256 = bufferSha256(gunzipSync(canonicalBytes));
+	if (canonicalPayloadSha256 !== accepted.tarPayloadSha256) {
+		throw new Error(
+			`accepted release asset payload ${canonicalPayloadSha256} differs from ${accepted.tarPayloadSha256}`,
+		);
+	}
+	const canonicalTarball = path.join(ARTIFACTS, `accepted-${filename}`);
+	await writeFile(canonicalTarball, canonicalBytes);
+	return {
+		...accepted,
+		assetUrl: releaseUrl,
+		canonicalTarball,
+		localPayloadSha256,
+	};
 }
 
 async function stagePackage(destination) {
@@ -194,9 +254,9 @@ function fixtureFiles(tarballName) {
 	};
 }
 
-async function verifyCleanConsumer(tarball) {
+async function verifyCleanConsumer(tarball, provenance) {
 	const fixture = await mkdtemp(path.join(os.tmpdir(), "folio-clean-consumer-"));
-	const log = [];
+	const log = [`PROVENANCE\n${provenance}`];
 	let stage = "install";
 	try {
 		const fixtureRoot = await realpath(fixture);
@@ -284,7 +344,7 @@ if (errors.length > 0) throw new Error(errors.join("\n"));
 
 const finalTarball = path.join(ARTIFACTS, filename);
 await cp(first, finalTarball);
-const acceptedPayloadSha256 = await verifyAcceptedReleasePayload(finalTarball, manifest);
+const acceptedRelease = await verifyAcceptedRelease(finalTarball, manifest, filename);
 await writeFile(path.join(ARTIFACTS, "files.txt"), `${files.join("\n")}\n`);
 await writeFile(
 	path.join(ARTIFACTS, "manifest.json"),
@@ -296,19 +356,32 @@ await writeFile(
 			sha256: firstSha256,
 			packedBytes: packedStat.size,
 			files,
+			acceptedRelease: {
+				tag: acceptedRelease.release,
+				sourceCommit: acceptedRelease.sourceCommit,
+				assetUrl: acceptedRelease.assetUrl,
+				compressedSha256: acceptedRelease.compressedSha256,
+				tarPayloadSha256: acceptedRelease.tarPayloadSha256,
+			},
 		},
 		null,
 		"\t",
 	)}\n`,
 );
-await verifyCleanConsumer(finalTarball);
+await verifyCleanConsumer(
+	acceptedRelease.canonicalTarball,
+	`downloaded ${acceptedRelease.release} from its public release asset; tag, source commit, compressed checksum, and tar payload verified`,
+);
 
 console.log(`packed ${path.relative(WEB_NEXT, finalTarball)}`);
 console.log(`sha256 ${firstSha256}`);
-if (acceptedPayloadSha256) {
-	console.log(`tar payload sha256 ${acceptedPayloadSha256} matches the accepted release`);
-}
+console.log(
+	`tar payload sha256 ${acceptedRelease.localPayloadSha256} matches ${acceptedRelease.release}`,
+);
+console.log(
+	`accepted asset sha256 ${acceptedRelease.compressedSha256} downloaded and verified at source commit ${acceptedRelease.sourceCommit}`,
+);
 console.log(`${packedStat.size} bytes, ${files.length} intentional files`);
 console.log(
-	"clean standalone Next fixture installed without a workspace link, passed the external-host contract, and built successfully",
+	"clean standalone Next fixture installed the canonical release asset without a workspace link, passed the external-host contract, and built successfully",
 );

--- a/web-next/scripts/folio-artifact.mjs
+++ b/web-next/scripts/folio-artifact.mjs
@@ -15,6 +15,7 @@ import {
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
 import { gunzipSync } from "node:zlib";
 import { execFile } from "node:child_process";
@@ -37,9 +38,28 @@ const STAGE_A = path.join(ARTIFACTS, "stage-a");
 const STAGE_B = path.join(ARTIFACTS, "stage-b");
 const RUN_A = path.join(ARTIFACTS, "pack-a");
 const RUN_B = path.join(ARTIFACTS, "pack-b");
+const CANONICAL_GIT_REMOTE = "https://github.com/fairchild/workspaces.git";
+const RELEASE_BASE_URL = "https://github.com/fairchild/workspaces/releases/download";
 const PNPM = process.env.npm_execpath;
+const candidateMode = process.argv.includes("--candidate");
 
 if (!PNPM) throw new Error("run this script through pnpm so npm_execpath is defined");
+if (candidateMode && process.env.CI) {
+	throw new Error("Folio candidate packaging is operator-only and cannot run in CI");
+}
+
+async function withRetry(label, operation) {
+	let lastError;
+	for (let attempt = 1; attempt <= 2; attempt += 1) {
+		try {
+			return await operation();
+		} catch (error) {
+			lastError = error;
+			if (attempt < 2) await delay(500);
+		}
+	}
+	throw new Error(`${label} failed after two attempts`, { cause: lastError });
+}
 
 async function runPnpm(args, options = {}) {
 	const javascriptEntrypoint = /\.[cm]?js$/.test(PNPM);
@@ -64,16 +84,18 @@ async function verifyAcceptedRelease(tarball, manifest, filename) {
 	if (recordErrors.length > 0) throw new Error(recordErrors.join("\n"));
 
 	const repo = path.resolve(WEB_NEXT, "..");
-	const { stdout: remoteTags } = await exec(
-		"git",
-		[
-			"ls-remote",
-			"--tags",
-			"origin",
-			`refs/tags/${accepted.release}`,
-			`refs/tags/${accepted.release}^{}`,
-		],
-		{ cwd: repo, timeout: 20_000 },
+	const { stdout: remoteTags } = await withRetry("canonical Folio tag lookup", () =>
+		exec(
+			"git",
+			[
+				"ls-remote",
+				"--tags",
+				CANONICAL_GIT_REMOTE,
+				`refs/tags/${accepted.release}`,
+				`refs/tags/${accepted.release}^{}`,
+			],
+			{ cwd: repo, timeout: 20_000 },
+		),
 	);
 	const remoteCommit = remoteTags
 		.trim()
@@ -90,21 +112,21 @@ async function verifyAcceptedRelease(tarball, manifest, filename) {
 	const localPayloadSha256 = bufferSha256(gunzipSync(await readFile(tarball)));
 	if (localPayloadSha256 !== accepted.tarPayloadSha256) {
 		throw new Error(
-			`Folio ${manifest.version} tar payload ${localPayloadSha256} differs from accepted release ${accepted.tarPayloadSha256}`,
+			`Folio ${manifest.version} tar payload ${localPayloadSha256} differs from accepted release ${accepted.tarPayloadSha256}; check source changes and pack-toolchain drift (accepted Node ${accepted.packToolchain.nodeMajor}, pnpm ${accepted.packToolchain.pnpmMajor}; current ${process.version}, ${process.env.npm_config_user_agent ?? "unknown pnpm"})`,
 		);
 	}
 
-	const releaseUrl = `https://github.com/fairchild/workspaces/releases/download/${encodeURIComponent(accepted.release)}/${encodeURIComponent(filename)}`;
-	const response = await fetch(releaseUrl, {
-		redirect: "follow",
-		signal: AbortSignal.timeout(20_000),
+	const releaseUrl = `${RELEASE_BASE_URL}/${encodeURIComponent(accepted.release)}/${encodeURIComponent(filename)}`;
+	const canonicalBytes = await withRetry("accepted Folio asset download", async () => {
+		const result = await fetch(releaseUrl, {
+			redirect: "follow",
+			signal: AbortSignal.timeout(20_000),
+		});
+		if (!result.ok) {
+			throw new Error(`HTTP ${result.status} ${result.statusText}`);
+		}
+		return Buffer.from(await result.arrayBuffer());
 	});
-	if (!response.ok) {
-		throw new Error(
-			`could not download accepted Folio release (${response.status} ${response.statusText})`,
-		);
-	}
-	const canonicalBytes = Buffer.from(await response.arrayBuffer());
 	const canonicalCompressedSha256 = bufferSha256(canonicalBytes);
 	if (canonicalCompressedSha256 !== accepted.compressedSha256) {
 		throw new Error(
@@ -124,6 +146,35 @@ async function verifyAcceptedRelease(tarball, manifest, filename) {
 		assetUrl: releaseUrl,
 		canonicalTarball,
 		localPayloadSha256,
+	};
+}
+
+async function describeReleaseCandidate(tarball, manifest) {
+	const accepted = JSON.parse(await readFile(ACCEPTED_RELEASE, "utf8"));
+	if (accepted.packageVersion === manifest.version) {
+		throw new Error(
+			`Folio ${manifest.version} is already accepted; use the strict folio:package gate`,
+		);
+	}
+	const repo = path.resolve(WEB_NEXT, "..");
+	const { stdout: status } = await exec(
+		"git",
+		["status", "--porcelain", "--untracked-files=no"],
+		{ cwd: repo },
+	);
+	if (status.trim()) {
+		throw new Error("commit the Folio candidate before packaging so its source SHA is stable");
+	}
+	const { stdout: sourceCommit } = await exec("git", ["rev-parse", "HEAD"], {
+		cwd: repo,
+	});
+	return {
+		candidate: true,
+		packageVersion: manifest.version,
+		sourceCommit: sourceCommit.trim(),
+		compressedSha256: await sha256(tarball),
+		tarPayloadSha256: bufferSha256(gunzipSync(await readFile(tarball))),
+		canonicalTarball: tarball,
 	};
 }
 
@@ -344,7 +395,9 @@ if (errors.length > 0) throw new Error(errors.join("\n"));
 
 const finalTarball = path.join(ARTIFACTS, filename);
 await cp(first, finalTarball);
-const acceptedRelease = await verifyAcceptedRelease(finalTarball, manifest, filename);
+const releaseProof = candidateMode
+	? await describeReleaseCandidate(finalTarball, manifest)
+	: await verifyAcceptedRelease(finalTarball, manifest, filename);
 await writeFile(path.join(ARTIFACTS, "files.txt"), `${files.join("\n")}\n`);
 await writeFile(
 	path.join(ARTIFACTS, "manifest.json"),
@@ -356,32 +409,56 @@ await writeFile(
 			sha256: firstSha256,
 			packedBytes: packedStat.size,
 			files,
-			acceptedRelease: {
-				tag: acceptedRelease.release,
-				sourceCommit: acceptedRelease.sourceCommit,
-				assetUrl: acceptedRelease.assetUrl,
-				compressedSha256: acceptedRelease.compressedSha256,
-				tarPayloadSha256: acceptedRelease.tarPayloadSha256,
-			},
+			...(releaseProof.candidate
+				? {
+					candidateRelease: {
+						packageVersion: releaseProof.packageVersion,
+						sourceCommit: releaseProof.sourceCommit,
+						compressedSha256: releaseProof.compressedSha256,
+						tarPayloadSha256: releaseProof.tarPayloadSha256,
+					},
+				}
+				: {
+					acceptedRelease: {
+						tag: releaseProof.release,
+						sourceCommit: releaseProof.sourceCommit,
+						assetUrl: releaseProof.assetUrl,
+						compressedSha256: releaseProof.compressedSha256,
+						tarPayloadSha256: releaseProof.tarPayloadSha256,
+						packToolchain: releaseProof.packToolchain,
+					},
+				}),
 		},
 		null,
 		"\t",
 	)}\n`,
 );
 await verifyCleanConsumer(
-	acceptedRelease.canonicalTarball,
-	`downloaded ${acceptedRelease.release} from its public release asset; tag, source commit, compressed checksum, and tar payload verified`,
+	releaseProof.canonicalTarball,
+	releaseProof.candidate
+		? `UNACCEPTED CANDIDATE ${releaseProof.packageVersion} at ${releaseProof.sourceCommit}; local checks only`
+		: `downloaded ${releaseProof.release} from its public release asset; tag, source commit, compressed checksum, and tar payload verified`,
 );
 
 console.log(`packed ${path.relative(WEB_NEXT, finalTarball)}`);
 console.log(`sha256 ${firstSha256}`);
-console.log(
-	`tar payload sha256 ${acceptedRelease.localPayloadSha256} matches ${acceptedRelease.release}`,
-);
-console.log(
-	`accepted asset sha256 ${acceptedRelease.compressedSha256} downloaded and verified at source commit ${acceptedRelease.sourceCommit}`,
-);
+if (releaseProof.candidate) {
+	console.log(
+		`UNACCEPTED CANDIDATE ${releaseProof.packageVersion} at ${releaseProof.sourceCommit}`,
+	);
+	console.log(`candidate asset sha256 ${releaseProof.compressedSha256}`);
+	console.log(`candidate tar payload sha256 ${releaseProof.tarPayloadSha256}`);
+} else {
+	console.log(
+		`tar payload sha256 ${releaseProof.localPayloadSha256} matches ${releaseProof.release}`,
+	);
+	console.log(
+		`accepted asset sha256 ${releaseProof.compressedSha256} downloaded and verified at source commit ${releaseProof.sourceCommit}`,
+	);
+}
 console.log(`${packedStat.size} bytes, ${files.length} intentional files`);
 console.log(
-	"clean standalone Next fixture installed the canonical release asset without a workspace link, passed the external-host contract, and built successfully",
+	releaseProof.candidate
+		? "clean standalone Next fixture installed the local unaccepted candidate without a workspace link, passed the external-host contract, and built successfully"
+		: "clean standalone Next fixture installed the canonical release asset without a workspace link, passed the external-host contract, and built successfully",
 );


### PR DESCRIPTION
## Summary

- prove `@fairchild/folio@0.1.0` through a real external-consumer compatibility matrix while keeping the consumer private
- add an anonymized durable host fixture covering creation, streaming, conversation-scoped cursor resume, reload, stop/failure, approvals, review, workspace actions, and publication authority
- make `pnpm folio:package` fail closed on unaccepted versions, verify the remote tag and source commit, download the canonical GitHub release asset, verify both compressed and tar-payload checksums, and install that released artifact in a clean standalone Next application
- document the package/release boundary and the deliberately limited responsive, keyboard, and semantic-accessibility evidence

Closes #1055

## Evidence

- [Canonical release install, external-host contract, and standalone production build](https://evidence.cloudcompute.com/workspaces/pr-1147/20260719-033600-folio-external-consumer.txt)
- The public evidence matrix records the private consumer result without publishing its name, repository, routes, hostnames, screenshots, data, or credentials.
- The rebuilt package payload is identical to the accepted `folio-v0.1.0` payload: `68b1383f7ce3ceb4db682b271a9ead9f5032fc50c49404cc334a582418c175a9`.
- The downloaded canonical asset matches SHA-256 `f5da5f28ee25e952681fca92b183700958670483215fde6436fed67c5238bde4` and source commit `ac2b5bb8bd74dbba34401d50eeb4304eb87c55e0`.

## Validation

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` — 67 files, 667 tests passed (host-authorized because the harness test binds loopback)
- `pnpm folio:package` — remote tag/source, release checksum, payload checksum, clean install, 3 external-host contracts, and standalone Next build passed
- `env CI=true pnpm folio:package:candidate` — failed closed as expected; candidate packaging cannot bypass CI
- `pnpm run build`
- `pnpm exec playwright test tests/e2e/mobile.spec.ts tests/e2e/sessions-demo.spec.ts` — 49 browser tests passed, including 375×812 responsive, hit-area, focus, keyboard, streaming, reload, failure, and approval flows
- `git diff --check`

## Review loop

Self-reflection first corrected two weaknesses before review: it restored byte-identical package contents instead of changing the released payload, and it separated active-turn stop testing from an already-completed turn.

Directed review: `codex` with `gpt-5.6-sol`, `xhigh` (session `019f784b-402e-7b81-abf3-7fc2bbd1e9d5`). No blockers; four important findings, all accepted and fixed in commit `69a4749e`:

1. **Release provenance failed open for future versions** — package versions now require an accepted record; the gate verifies the remote tag/source, downloads the canonical asset, verifies both hashes, and installs that asset.
2. **Transient stop authority could exist without an active turn** — event ordering now establishes the active turn before granting stop and revokes stop before clearing the turn; every transitional snapshot is asserted.
3. **Global ordinal cursors could accept a foreign conversation cursor** — cursors are conversation/generation scoped, replay asserts each cursor exactly once, and restore rejects a tampered or inconsistent event log.
4. **Accessibility wording exceeded public evidence** — the matrix now distinguishes owner-observed private evidence from public regressions and limits the claim to tested responsive layout, accessible names/roles, focus, and keyboard behavior; it explicitly does not claim a screen-reader session or automated WCAG audit.

Post-PR targeted review: Claude CLI with `claude-fable-5`, `xhigh`, read-only and sanitized (session `72b1a669-20d1-484a-a2d1-990188688eec`). Fable reported no P1s, two P2s, four P3s, and `MERGE-READY: yes`; fixes and dispositions are recorded in commit `f747d1cd`:

1. **P2: future version advancement was undocumented and operationally circular** — added an explicit local-only candidate command plus a tag/prerelease/receipt/merge-commit procedure; strict CI still requires an accepted canonical release.
2. **P2: abort rejection did not prove non-mutation** — the contract now snapshots serialized host state and requires byte-for-byte equality after the aborted command.
3. **P3: tag provenance used clone-local `origin`** — tag lookup now uses the same canonical public repository as the release asset.
4. **P3: network checks were single-shot** — added one bounded retry around tag lookup and the complete asset-body download. Strict verification intentionally has no offline bypass; the separate candidate command provides an explicit local release-building path without weakening CI.
5. **P3: tar-payload drift lacked toolchain context** — the accepted record now names Node/pnpm major versions and mismatch diagnostics report accepted versus current tooling.
6. **P3: restore validation wording implied content integrity** — narrowed it to cursor sequence/order consistency; event content remains trusted host-owned state.

## Mergeability

- Surface: web / Folio packaging, release provenance, public conversation adapter fixture, and compatibility documentation
- User-facing behavior changed: No direct Workspaces UI change; this proves and hardens the reusable install surface used by the external consumer
- Non-happy paths considered: unaccepted version, missing or moved remote tag, corrupt release download, checksum or payload mismatch, workspace-link leakage, foreign cursor, duplicate replay, tampered restore, transport disconnect, abort, stop/failure, and unavailable host authority
- Residual risk or follow-up: The first consumer remains private, so its browser artifacts are summarized rather than published; public regression fixtures encode the portable behavior. Registry publication remains deliberately disabled.
- Release/ops preconditions: `folio-v0.1.0` is already published from `ac2b5bb8` with the accepted asset and payload hashes above. The gate requires network access to the public Git remote and GitHub release. No registry publication or secret change is authorized by this PR.
