### PR TITLE
feat(cd): close rolling CD-failure issues on green validation

### DIFF
--- a/.github/workflows/cd-fail-notify.js
+++ b/.github/workflows/cd-fail-notify.js
@@ -1,17 +1,36 @@
-// Shared logic for the fail-notify-{playwright,lighthouse} jobs in cd.yml.
+// Shared logic for the fail-notify-{playwright,lighthouse} and
+// close-on-green-{playwright,lighthouse} jobs in cd.yml.
 //
 // Called from github-script@v7 as:
-//   const { default: failNotify } = await import('./.github/workflows/cd-fail-notify.js');
+//   const { default: failNotify, closeOnGreen } = await import('./.github/workflows/cd-fail-notify.js');
 //   await failNotify({ github, context, core });
+//   await closeOnGreen({ github, context, core });
 //
 // Env inputs:
 //   VALIDATOR    — "playwright" or "lighthouse"
-//   PREVIEW_URL  — preview deployment URL
-//   REPRO_HINT   — shell command to reproduce locally
+//   PREVIEW_URL  — preview deployment URL (failNotify only)
+//   REPRO_HINT   — shell command to reproduce locally (failNotify only)
 //
 // Reads findings.md from the current working directory (downloaded artifact).
 
 import nodeFs from "node:fs";
+
+function markerFor(validator) {
+	return `<!-- cd-failure:${validator} -->`;
+}
+
+function runUrl(context) {
+	return `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+}
+
+async function findRollingIssue(github, context, validator) {
+	const q = `repo:${context.repo.owner}/${context.repo.repo} in:body "${markerFor(validator)}" is:issue`;
+	const found = await github.rest.search.issuesAndPullRequests({
+		q,
+		per_page: 1,
+	});
+	return found.data.items[0];
+}
 
 export default async function failNotify({
 	github,
@@ -21,25 +40,18 @@ export default async function failNotify({
 	fs = nodeFs,
 }) {
 	const validator = env.VALIDATOR;
-	const marker = `<!-- cd-failure:${validator} -->`;
+	const marker = markerFor(validator);
 	const findings = fs.existsSync("findings.md")
 		? fs.readFileSync("findings.md", "utf8")
 		: "_No findings file produced._";
 
 	const title = `CD: ${validator} failures on main`;
-	const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-	const q = `repo:${context.repo.owner}/${context.repo.repo} in:body "${marker}" is:issue`;
-	const found = await github.rest.search.issuesAndPullRequests({
-		q,
-		per_page: 1,
-	});
-	const existing = found.data.items[0];
+	const existing = await findRollingIssue(github, context, validator);
 
 	const body = [
 		marker,
 		`**Commit:** ${context.sha}`,
-		`**Run:** ${runUrl}`,
+		`**Run:** ${runUrl(context)}`,
 		`**Preview URL:** ${env.PREVIEW_URL || "(not available)"}`,
 		"",
 		"## Findings",
@@ -91,4 +103,38 @@ export default async function failNotify({
 	});
 	core.notice(`Created rolling issue #${created.data.number}`);
 	return { issueNumber: created.data.number };
+}
+
+export async function closeOnGreen({ github, context, core, env = process.env }) {
+	const validator = env.VALIDATOR;
+	const existing = await findRollingIssue(github, context, validator);
+
+	if (!existing || existing.state !== "open") {
+		core.notice(`No open rolling ${validator} issue to close`);
+		return { closed: null };
+	}
+
+	const body = [
+		markerFor(validator),
+		`CD ${validator} validation is green for \`${context.sha}\` in ${runUrl(context)}.`,
+		"",
+		`Closing this auto-opened rolling issue. The CD auto-opener will reopen it or open a new one if ${validator} regresses again.`,
+	].join("\n");
+
+	await github.rest.issues.createComment({
+		owner: context.repo.owner,
+		repo: context.repo.repo,
+		issue_number: existing.number,
+		body,
+	});
+	await github.rest.issues.update({
+		owner: context.repo.owner,
+		repo: context.repo.repo,
+		issue_number: existing.number,
+		state: "closed",
+		state_reason: "completed",
+	});
+
+	core.notice(`Closed rolling issue #${existing.number}`);
+	return { closed: existing.number };
 }

--- a/.github/workflows/cd-fail-notify.test.js
+++ b/.github/workflows/cd-fail-notify.test.js
@@ -5,7 +5,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import failNotify from "./cd-fail-notify.js";
+import failNotify, { closeOnGreen } from "./cd-fail-notify.js";
 
 function makeContext() {
 	return {
@@ -95,4 +95,66 @@ test("failNotify opens the first CD failure issue for Factory triage", async () 
 	]);
 	assert.match(create.body, /issue triage inlet/);
 	assert.match(create.body, /Reproduce locally: `mise run web:e2e`/);
+});
+
+test("closeOnGreen closes the open rolling CD failure issue", async () => {
+	const github = makeGithub([{ number: 630, state: "open" }]);
+
+	const result = await closeOnGreen({
+		github,
+		context: makeContext(),
+		core,
+		env: { VALIDATOR: "playwright" },
+	});
+
+	assert.deepEqual(result, { closed: 630 });
+	assert.deepEqual(
+		github.calls.map(([name]) => name),
+		["search", "createComment", "update"],
+	);
+	assert.match(github.calls[0][1].q, /"<!-- cd-failure:playwright -->"/);
+	assert.equal(github.calls[0][1].per_page, 1);
+	assert.equal(github.calls[1][1].issue_number, 630);
+	assert.match(github.calls[1][1].body, /<!-- cd-failure:playwright -->/);
+	assert.match(github.calls[1][1].body, /CD playwright validation is green/);
+	assert.equal(github.calls[2][1].issue_number, 630);
+	assert.equal(github.calls[2][1].state, "closed");
+	assert.equal(github.calls[2][1].state_reason, "completed");
+});
+
+test("closeOnGreen is a no-op when there is no rolling issue", async () => {
+	const github = makeGithub([]);
+
+	const result = await closeOnGreen({
+		github,
+		context: makeContext(),
+		core,
+		env: { VALIDATOR: "playwright" },
+	});
+
+	assert.deepEqual(result, { closed: null });
+	assert.deepEqual(
+		github.calls.map(([name]) => name),
+		["search"],
+	);
+});
+
+test("closeOnGreen leaves an already-closed rolling issue alone", async () => {
+	// Flap protection: a fail → green → fail sequence can leave a closed
+	// issue matching the marker if a later run already reopened and
+	// re-closed it. Don't double-comment or re-close.
+	const github = makeGithub([{ number: 630, state: "closed" }]);
+
+	const result = await closeOnGreen({
+		github,
+		context: makeContext(),
+		core,
+		env: { VALIDATOR: "playwright" },
+	});
+
+	assert.deepEqual(result, { closed: null });
+	assert.deepEqual(
+		github.calls.map(([name]) => name),
+		["search"],
+	);
 });

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -374,6 +374,46 @@ jobs:
             const { default: failNotify } = await import(pathToFileURL(abs).href);
             await failNotify({ github, context, core });
 
+  close-on-green-playwright:
+    needs: [playwright-validate]
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout is required so the github-script step can import the shared
+      # fail-notify logic at .github/workflows/cd-fail-notify.js.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          VALIDATOR: playwright
+        with:
+          script: |
+            // github-script runs from its own dist dir; relative imports look
+            // there, not at the workspace. Resolve via GITHUB_WORKSPACE + file URL.
+            const path = require('node:path');
+            const { pathToFileURL } = require('node:url');
+            const abs = path.join(process.env.GITHUB_WORKSPACE, '.github/workflows/cd-fail-notify.js');
+            const { closeOnGreen } = await import(pathToFileURL(abs).href);
+            await closeOnGreen({ github, context, core });
+
+  close-on-green-lighthouse:
+    needs: [lighthouse]
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          VALIDATOR: lighthouse
+        with:
+          script: |
+            // github-script runs from its own dist dir; relative imports look
+            // there, not at the workspace. Resolve via GITHUB_WORKSPACE + file URL.
+            const path = require('node:path');
+            const { pathToFileURL } = require('node:url');
+            const abs = path.join(process.env.GITHUB_WORKSPACE, '.github/workflows/cd-fail-notify.js');
+            const { closeOnGreen } = await import(pathToFileURL(abs).href);
+            await closeOnGreen({ github, context, core });
+
   validate-prod:
     needs: promote
     if: success()


### PR DESCRIPTION
## Summary

- Add `closeOnGreen` to `.github/workflows/cd-fail-notify.js`: when the search for a validator's rolling CD-failure issue (marker `<!-- cd-failure:VALIDATOR -->`) finds one that is still `open`, it comments with the passing run/commit and closes it (`state_reason: completed`); no-op when there's no rolling issue or it's already closed.
- Extract the shared `findRollingIssue` search helper out of `failNotify` (behavior-preserving — same query, same `per_page: 1`, same call ordering; existing `failNotify` tests pass unmodified) so both paths use identical marker/search logic.
- Wire `close-on-green-playwright` and `close-on-green-lighthouse` jobs into `cd.yml`, gated on their respective validator job succeeding (mirrors the existing `fail-notify-{playwright,lighthouse}` / `resolve-prod-alert` job shape).
- Add 3 new cases to `cd-fail-notify.test.js` covering closeOnGreen's three branches: open issue found → closes, no issue found → no-op, issue already closed → no-op (flap-safe).

Before this change, `cd-fail-notify.js` only opened/reopened the rolling issue on failure — nothing ever closed it, so a rolling CD-failure issue stayed open indefinitely once CD went green (#356/#357 sat open for 3.5 months). Closes #1153.

## Mergeability

- Surface: infra/CI — `.github/workflows/cd-fail-notify.js` (shared notifier logic) and `.github/workflows/cd.yml` (job graph)
- User-facing behavior changed: No end-user product surface. Operationally: rolling CD-failure issues (per validator: playwright, lighthouse) now auto-close when that validator goes green on `main`, instead of staying open forever.
- Non-happy paths considered: no rolling issue exists (no-op, logged via `core.notice`); rolling issue already closed (no-op, no double-comment/re-close — this is the fail→green→fail flap case); a validator job that is skipped or cancelled fires neither `fail-notify-*` nor `close-on-green-*`, which correctly preserves the last known (non-green) state rather than silently closing on missing information. Cross-run races between a close and a later failure's reopen are prevented by the workflow's existing `concurrency: group: cd-main, cancel-in-progress: false`, which serializes CD runs.
- Residual risk or follow-up: None identified as blocking. `github.rest.search.issuesAndPullRequests` is eventually consistent (pre-existing characteristic already relied on by `failNotify`, not newly introduced) — worst case under index lag is a missed/delayed close, not an incorrect close, since `closeOnGreen` only ever acts on an issue it found and confirmed `open`.

## Validation

- [x] `node --test .github/workflows/cd-fail-notify.test.js` — 5/5 passing (2 pre-existing `failNotify` cases unmodified + 3 new `closeOnGreen` cases)
- [x] `actionlint .github/workflows/cd.yml` — clean
- [ ] `swift build` / `swift test` — not applicable (no Swift changed)

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (test output)

Evidence links:

- [`node --test cd-fail-notify.test.js` — 5/5 passing](https://evidence.cloudcompute.com/workspaces/pr-1165/20260803-050957-close-on-green-tests.png)

## Review loop

Ran the `codex-review-loop` skill (directed review, `gpt-5.6-sol`, xhigh) against this diff before opening. Findings:

- MINOR — `cd-fail-notify.test.js` — the `closeOnGreen` success test didn't assert the search request's `q`/`per_page` or the comment's `issue_number`, so a regression targeting the wrong validator marker or issue could still pass. **Fixed** in this PR: added those assertions.
- No BLOCKER or MAJOR findings. Codex independently verified `findRollingIssue` preserves the original search query/params/ordering, `runUrl(context)` has no stale references, the two new jobs gate only on their own validator, and the `concurrency: cd-main` group prevents the adjacent-run reopen/close race.

## Blockers

- [x] None
