### PR TITLE
ci: run all scripts/tests/*.py via a directory loop, not hand enumeration

### DIFF
--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -69,18 +69,20 @@ jobs:
       - name: Run gh-discuss tests
         run: uv run .agents/skills/gh-discuss/scripts/test_gh_discuss.py
 
-      # Loops the whole directory instead of hand-enumerating scripts here so
+      # Recurses scripts/tests/ instead of hand-enumerating scripts here so
       # "add a test, forget the run step" can't leave a script gating nothing.
+      # find (not a glob) so a future nested scripts/tests/**/test_*.py — which
+      # the paths filter above already covers — isn't silently skipped.
       - name: Run scripts/tests/*.py
         run: |
           failed=()
-          for test_file in scripts/tests/*.py; do
+          while IFS= read -r -d '' test_file; do
             echo "::group::${test_file}"
             if ! uv run --script "$test_file"; then
               failed+=("$test_file")
             fi
             echo "::endgroup::"
-          done
+          done < <(find scripts/tests -type f -name '*.py' -print0 | sort -z)
           if [ "${#failed[@]}" -gt 0 ]; then
             echo "Failed: ${failed[*]}" >&2
             exit 1

--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -6,30 +6,18 @@ on:
     paths:
       - ".agents/**"
       - ".github/workflows/ci-agents.yml"
+      - "scripts/tests/**"
       - "scripts/agent-triage-request.py"
-      - "scripts/tests/test_agent_triage.py"
-      - "scripts/tests/test_run_contributor.py"
-      - "scripts/tests/test_validate_agent_output.py"
       - ".github/workflows/factory-*.yml"
       - "scripts/factory-implement.py"
       - "scripts/factory-janitor.py"
       - "scripts/factory-review.py"
       - "scripts/factory-evidence-verify.py"
-      - "scripts/tests/test_factory_evidence_kinds.py"
-      - "scripts/tests/test_factory_evidence_verify.py"
-      - "scripts/tests/test_factory_evidence_review.py"
       - "scripts/factory-responder-payload.py"
-      - "scripts/tests/test_factory_workflows.py"
-      - "scripts/tests/test_factory_janitor.py"
-      - "scripts/tests/test_factory_review.py"
-      - "scripts/tests/test_factory_comment_responder.py"
       - "fixtures/factory-janitor/**"
       - "scripts/fable-orchestrator.py"
-      - "scripts/tests/test_fable_orchestrator.py"
       - "scripts/carl-community.py"
-      - "scripts/tests/test_carl_community.py"
       - "scripts/close-v1-discussions.py"
-      - "scripts/tests/test_close_v1_discussions.py"
       - "fixtures/close-v1-discussions/**"
       - ".github/workflows/cd-fail-notify.js"
       - ".github/workflows/cd-fail-notify.test.js"
@@ -38,30 +26,18 @@ on:
     paths:
       - ".agents/**"
       - ".github/workflows/ci-agents.yml"
+      - "scripts/tests/**"
       - "scripts/agent-triage-request.py"
-      - "scripts/tests/test_agent_triage.py"
-      - "scripts/tests/test_run_contributor.py"
-      - "scripts/tests/test_validate_agent_output.py"
       - ".github/workflows/factory-*.yml"
       - "scripts/factory-implement.py"
       - "scripts/factory-janitor.py"
       - "scripts/factory-review.py"
       - "scripts/factory-evidence-verify.py"
-      - "scripts/tests/test_factory_evidence_kinds.py"
-      - "scripts/tests/test_factory_evidence_verify.py"
-      - "scripts/tests/test_factory_evidence_review.py"
       - "scripts/factory-responder-payload.py"
-      - "scripts/tests/test_factory_workflows.py"
-      - "scripts/tests/test_factory_janitor.py"
-      - "scripts/tests/test_factory_review.py"
-      - "scripts/tests/test_factory_comment_responder.py"
       - "fixtures/factory-janitor/**"
       - "scripts/fable-orchestrator.py"
-      - "scripts/tests/test_fable_orchestrator.py"
       - "scripts/carl-community.py"
-      - "scripts/tests/test_carl_community.py"
       - "scripts/close-v1-discussions.py"
-      - "scripts/tests/test_close_v1_discussions.py"
       - "fixtures/close-v1-discussions/**"
       - ".github/workflows/cd-fail-notify.js"
       - ".github/workflows/cd-fail-notify.test.js"
@@ -77,7 +53,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
@@ -93,36 +69,22 @@ jobs:
       - name: Run gh-discuss tests
         run: uv run .agents/skills/gh-discuss/scripts/test_gh_discuss.py
 
-      - name: Run public agent triage tests
-        run: uv run --script scripts/tests/test_agent_triage.py
-
-      - name: Run contributor runner policy tests
-        run: uv run --script scripts/tests/test_run_contributor.py
-
-      - name: Run contributor output validation tests
-        run: uv run --script scripts/tests/test_validate_agent_output.py
-
-      - name: Run Factory workflow policy tests
+      # Loops the whole directory instead of hand-enumerating scripts here so
+      # "add a test, forget the run step" can't leave a script gating nothing.
+      - name: Run scripts/tests/*.py
         run: |
-          uv run --script scripts/tests/test_factory_workflows.py
-          uv run --script scripts/tests/test_factory_janitor.py
-          uv run --script scripts/tests/test_factory_review.py
-
-      - name: Run Factory evidence tests
-        run: |
-          uv run --script scripts/tests/test_factory_evidence_kinds.py
-          uv run --script scripts/tests/test_factory_evidence_verify.py
-          uv run --script scripts/tests/test_factory_evidence_review.py
-          uv run --script scripts/tests/test_factory_comment_responder.py
-
-      - name: Run Fable orchestrator tests
-        run: uv run --script scripts/tests/test_fable_orchestrator.py
-
-      - name: Run Carl community tests
-        run: uv run --script scripts/tests/test_carl_community.py
-
-      - name: Run v1 discussion cleanup tests
-        run: uv run --script scripts/tests/test_close_v1_discussions.py
+          failed=()
+          for test_file in scripts/tests/*.py; do
+            echo "::group::${test_file}"
+            if ! uv run --script "$test_file"; then
+              failed+=("$test_file")
+            fi
+            echo "::endgroup::"
+          done
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo "Failed: ${failed[*]}" >&2
+            exit 1
+          fi
 
       - name: Run CD failure notifier tests
         run: node --test .github/workflows/cd-fail-notify.test.js

--- a/scripts/factory-dashboard.py
+++ b/scripts/factory-dashboard.py
@@ -565,8 +565,9 @@ def sync_settings(conn: sqlite3.Connection, fetcher: Any) -> None:
         meta_set(conn, "cap_review", variables["FACTORY_REVIEW_DAILY_CAP"])
 
 
-def sync_all(conn: sqlite3.Connection, fetcher: Any, *, days: int) -> dict[str, Any]:
-    floor = (now_utc() - timedelta(days=days)).isoformat().replace("+00:00", "Z")
+def sync_all(conn: sqlite3.Connection, fetcher: Any, *, days: int, now: datetime | None = None) -> dict[str, Any]:
+    now = now or now_utc()
+    floor = (now - timedelta(days=days)).isoformat().replace("+00:00", "Z")
     stats: dict[str, Any] = {"errors": []}
     steps: list[tuple[str, Callable[[], int | None]]] = [
         ("runs", lambda: sync_runs(conn, fetcher, floor)),
@@ -582,7 +583,7 @@ def sync_all(conn: sqlite3.Connection, fetcher: Any, *, days: int) -> dict[str, 
             stats["errors"].append(f"{name}: {error}")
             print(f"[factory-dashboard] {name} sync failed: {error}", file=sys.stderr)
     ok = not stats["errors"]
-    meta_set(conn, "last_sync_at", now_utc().isoformat())
+    meta_set(conn, "last_sync_at", now.isoformat())
     meta_set(conn, "last_sync_ok", "1" if ok else "0")
     if stats["errors"]:
         meta_set(conn, "last_sync_error", "; ".join(stats["errors"]))
@@ -1349,9 +1350,10 @@ def main(argv: list[str] | None = None) -> int:
 
     conn = connect(db_path)
     try:
+        now = now_utc()
         if do_sync:
             fetcher = GitHubFetcher(args.repo)
-            stats = sync_all(conn, fetcher, days=args.days)
+            stats = sync_all(conn, fetcher, days=args.days, now=now)
             summary = ", ".join(
                 f"{name}={stats[name]}" for name in ("runs", "issues", "prs", "cost_rows") if name in stats
             )
@@ -1359,7 +1361,7 @@ def main(argv: list[str] | None = None) -> int:
             if stats["errors"]:
                 print(f"[factory-dashboard] {len(stats['errors'])} source(s) degraded to cache")
         if do_render:
-            metrics = build_metrics(conn, days=args.days, now=now_utc())
+            metrics = build_metrics(conn, days=args.days, now=now)
             out_path.parent.mkdir(parents=True, exist_ok=True)
             out_path.write_text(render_html(metrics), encoding="utf-8")
             print(f"[factory-dashboard] wrote {out_path}")

--- a/scripts/factory-dashboard.py
+++ b/scripts/factory-dashboard.py
@@ -583,7 +583,7 @@ def sync_all(conn: sqlite3.Connection, fetcher: Any, *, days: int, now: datetime
             stats["errors"].append(f"{name}: {error}")
             print(f"[factory-dashboard] {name} sync failed: {error}", file=sys.stderr)
     ok = not stats["errors"]
-    meta_set(conn, "last_sync_at", now.isoformat())
+    meta_set(conn, "last_sync_at", now_utc().isoformat())
     meta_set(conn, "last_sync_ok", "1" if ok else "0")
     if stats["errors"]:
         meta_set(conn, "last_sync_error", "; ".join(stats["errors"]))
@@ -1350,10 +1350,9 @@ def main(argv: list[str] | None = None) -> int:
 
     conn = connect(db_path)
     try:
-        now = now_utc()
         if do_sync:
             fetcher = GitHubFetcher(args.repo)
-            stats = sync_all(conn, fetcher, days=args.days, now=now)
+            stats = sync_all(conn, fetcher, days=args.days)
             summary = ", ".join(
                 f"{name}={stats[name]}" for name in ("runs", "issues", "prs", "cost_rows") if name in stats
             )
@@ -1361,7 +1360,7 @@ def main(argv: list[str] | None = None) -> int:
             if stats["errors"]:
                 print(f"[factory-dashboard] {len(stats['errors'])} source(s) degraded to cache")
         if do_render:
-            metrics = build_metrics(conn, days=args.days, now=now)
+            metrics = build_metrics(conn, days=args.days, now=now_utc())
             out_path.parent.mkdir(parents=True, exist_ok=True)
             out_path.write_text(render_html(metrics), encoding="utf-8")
             print(f"[factory-dashboard] wrote {out_path}")

--- a/scripts/perf_schema.py
+++ b/scripts/perf_schema.py
@@ -188,7 +188,10 @@ def detect_environment(
 
 
 def read_command_text(command: list[str]) -> str | None:
-    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+    except FileNotFoundError:
+        return None
     if result.returncode != 0:
         return None
     value = result.stdout.strip()

--- a/scripts/tests/test_factory_dashboard.py
+++ b/scripts/tests/test_factory_dashboard.py
@@ -251,7 +251,7 @@ class SyncTests(unittest.TestCase):
             conn = dashboard.connect(db)
             fake = FakeFetcher()
 
-            dashboard.sync_all(conn, fake, days=30)
+            dashboard.sync_all(conn, fake, days=30, now=NOW)
             first = table_counts(conn)
             self.assertEqual(first["workflow_runs"], 3)
             self.assertEqual(first["jobs"], 3)
@@ -265,14 +265,14 @@ class SyncTests(unittest.TestCase):
             self.assertEqual(runs_cursor, max(r["created_at"] for r in all_runs))
             self.assertEqual(dashboard.get_cursor(conn, "prs"), fake.prs[0]["updated_at"])
 
-            dashboard.sync_all(conn, fake, days=30)
+            dashboard.sync_all(conn, fake, days=30, now=NOW)
             self.assertEqual(table_counts(conn), first, "re-sync must not duplicate rows")
             conn.close()
 
     def test_metrics_reflect_synced_fixture(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             conn = dashboard.connect(Path(tmp) / "cache.sqlite3")
-            dashboard.sync_all(conn, FakeFetcher(), days=30)
+            dashboard.sync_all(conn, FakeFetcher(), days=30, now=NOW)
             metrics = dashboard.build_metrics(conn, days=30, now=NOW)
             self.assertEqual(metrics["throughput"]["agent_prs_merged"], 1)
             self.assertEqual(metrics["cost"]["row_count"], 2)
@@ -322,11 +322,11 @@ class CursorTests(unittest.TestCase):
             conn = dashboard.connect(Path(tmp) / "cache.sqlite3")
             fake = FakeFetcher()
 
-            dashboard.sync_all(conn, fake, days=1)
+            dashboard.sync_all(conn, fake, days=1, now=NOW)
             narrow = conn.execute("SELECT COUNT(*) FROM workflow_runs").fetchone()[0]
             self.assertEqual(narrow, 1, "days=1 excludes the two runs from 2 days ago")
 
-            dashboard.sync_all(conn, fake, days=30)
+            dashboard.sync_all(conn, fake, days=30, now=NOW)
             wide = conn.execute("SELECT COUNT(*) FROM workflow_runs").fetchone()[0]
             self.assertEqual(wide, 3, "widening --days backfills the older runs")
             conn.close()
@@ -347,8 +347,8 @@ class CursorTests(unittest.TestCase):
                     return super().runs_for_workflow(workflow_id, since_date)
 
             fake = Recording()
-            dashboard.sync_all(conn, fake, days=30)
-            dashboard.sync_all(conn, fake, days=30)
+            dashboard.sync_all(conn, fake, days=30, now=NOW)
+            dashboard.sync_all(conn, fake, days=30, now=NOW)
             first, second = fake.run_since[0], fake.run_since[-1]
             self.assertGreater(second, first, "second sync starts at the cursor")
             totals = conn.execute("SELECT COUNT(*) FROM workflow_runs").fetchone()[0]
@@ -363,7 +363,7 @@ class CursorTests(unittest.TestCase):
                 def prs_since(self, since_date):
                     raise ValueError("rate limited")  # non-FetchError
 
-            stats = dashboard.sync_all(conn, Boom(), days=30)
+            stats = dashboard.sync_all(conn, Boom(), days=30, now=NOW)
             self.assertTrue(any("prs" in e for e in stats["errors"]))
             # Other sources still synced despite the PR-source failure.
             self.assertEqual(conn.execute("SELECT COUNT(*) FROM workflow_runs").fetchone()[0], 3)
@@ -383,7 +383,7 @@ class CursorTests(unittest.TestCase):
                 def repo_variables(self):
                     raise dashboard.FetchError("variables unreadable")
 
-            stats = dashboard.sync_all(conn, NoVars(), days=30)
+            stats = dashboard.sync_all(conn, NoVars(), days=30, now=NOW)
             self.assertTrue(any("settings" in e for e in stats["errors"]))
             self.assertEqual(dashboard.meta_get(conn, "last_sync_ok"), "0")
             conn.close()

--- a/scripts/tests/test_security_hardening.py
+++ b/scripts/tests/test_security_hardening.py
@@ -19,6 +19,7 @@ import re
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 import tomllib
 import unittest
@@ -545,8 +546,8 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("WORKSPACES_WEBHOOK_CANARY_SECRET is required", result.stderr)
 
     def test_sparkle_appcast_verifier_accepts_valid_ed25519_signature(self) -> None:
-        if shutil.which("swift") is None:
-            self.skipTest("swift is required for Sparkle appcast verifier")
+        if sys.platform != "darwin" or shutil.which("swift") is None:
+            self.skipTest("verify-sparkle-appcast.swift imports CryptoKit, which is Apple-only")
 
         # RFC 8032 Ed25519 test vector 1: signature for an empty message.
         public_key = "11qYAYKxCrfVS/7TyWQHOg7hcvPapiMlrwIaaPcHURo="
@@ -597,6 +598,8 @@ class SecurityHardeningTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_release_manifest_script_validates_hash_bound_assets(self) -> None:
+        if not Path("/usr/libexec/PlistBuddy").exists():
+            self.skipTest("release-manifest.sh requires macOS's PlistBuddy")
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
             app = tmp / "WorkSpaces.app"


### PR DESCRIPTION
## Summary

`ci-agents.yml` hand-enumerated 13 of 32 `scripts/tests/*.py` files in its run steps and per-file path filters. The other 19 either never ran anywhere (15, per the issue), or ran in a different specialized workflow whose path filter referenced the test file without ever executing it (`mise-security.yml` lists `scripts/tests/test_security_hardening.py` in its `paths:` but only runs `verify-mise-security.sh`) — the exact "job triggers, test never runs" failure mode the issue describes.

- Replaced the 13 hand-enumerated `uv run --script scripts/tests/test_X.py` steps with a loop that recurses `scripts/tests/` and runs every `*.py` file, failing the job on **any** individual script failure (all scripts still run first; failures are collected and reported together, then the job exits non-zero).
- Collapsed the ~13 individual `scripts/tests/test_X.py` path-filter entries down to one `scripts/tests/**` glob, so a newly added test file triggers the workflow without a second edit.
- Bumped the job timeout 5 → 10 min (32 scripts vs. 13; ~55s locally, headroom for CI variance).

## Orphaned-test audit (this issue's ask + april-clearwater's review comment)

Read all 15 previously-orphaned scripts before wiring them in, specifically checking for secrets/network/macOS-only assumptions per april's flag (she named `test_release_preflight.py`, `test_release_workflow.py`, `test_codespaces_claude_launch.py` as candidates to check). Those three are clean — mocked `gh`, no network, pure YAML/text parsing. All 32 scripts declare empty PEP 723 deps and pass locally with `uv run --script` on macOS with no secrets or network access.

**Codex's directed review caught what my own audit missed**: `test_security_hardening.py` (the flagship orphan named in the issue) has two sub-tests that are silently macOS-only and would have broken the new Ubuntu job on the very first push:
- `test_sparkle_appcast_verifier_accepts_valid_ed25519_signature` only skipped when `swift` was absent — but Swift 6.3 is preinstalled on `ubuntu-latest`, so it would run and fail: `scripts/verify-sparkle-appcast.swift` does a bare `import CryptoKit`, which is Apple-only (confirmed via GitHub's runner-images doc + reading the script).
- `test_release_manifest_script_validates_hash_bound_assets` shells out to `release-manifest.sh generate`, which hard-requires `/usr/libexec/PlistBuddy`.

Fixed by platform-gating both (`sys.platform != "darwin"` / `Path("/usr/libexec/PlistBuddy").exists()`), matching the file's existing skip-guard pattern. Verified the guards actually trip by monkeypatching `sys.platform`/`Path.exists` under `uv run --python 3.11` (see evidence). The other 27 security checks in that file are platform-portable and now run in CI for the first time.

**Trivial breakage fixed**: the loop surfaced a real, deterministic bug in `test_factory_dashboard.py` (added 2026-08-02, so nobody had caught this yet) — `CursorTests.test_widening_days_backfills_via_min_cursor_floor` compared a fixture frozen at a hardcoded `NOW` against `sync_all()`'s real wall-clock `now_utc()`, so the `days=1` assertion only ever held on the day the fixture was authored. Threaded an optional `now: datetime | None = None` through `sync_all` (mirroring the existing `build_metrics(..., now=...)` pattern already in that file) and pinned the 9 test call sites to `now=NOW`.

## Caught by real CI (not local, not codex)

The first push to this PR's own `ci-agents.yml` run failed: `test_perf_tools.py` — already running elsewhere (`perf-validation.yml`, `[self-hosted, tart-ui]`) but never before on Linux — crashed with `FileNotFoundError: 'sw_vers'`. `scripts/perf_schema.py`'s `detect_environment()` calls `sw_vers`/`sysctl` unconditionally via `read_command_text()`, which already treated a nonzero exit as "value unknown" (returns `None`) but didn't catch the binary being absent from `PATH` entirely — Linux has neither command. My local macOS box has both, so this was invisible until it ran on `ubuntu-latest` for real. Fixed by catching `FileNotFoundError` in `read_command_text` and returning `None`, extending the function's existing degrade-gracefully contract; no macOS behavior change. Verified by simulating a missing-binary `subprocess.run` locally (see commit `ecf42c83`) — this is exactly the class of gap this issue exists to close, it just took an actual CI run to surface it.

## Review loop

Directed codex review (`gpt-5.6-sol`, xhigh) against `git diff origin/main...HEAD`, focused on loop correctness, path-filter completeness, the `now=` threading, cross-PR interaction, and an independent macOS/secrets/network audit of all 32 scripts.

| Finding | Severity | Disposition |
|---|---|---|
| `test_security_hardening.py` has two macOS-only sub-tests (Swift/CryptoKit, PlistBuddy) that would fail unconditionally on the new `ubuntu-latest` loop | Blocker | **Fixed** — platform-gated both, verified skips trip on simulated Linux |
| Sharing one `now` between `sync_all()` and `build_metrics()` in `main()` shifted `last_sync_at` from completion-time to start-time and moved the render metrics boundary earlier by the sync duration — observable production behavior beyond what the test fix needed | Minor | **Fixed** — reverted to independent `now_utc()` calls in production; only the test-injectable parameter remains |
| The loop's `scripts/tests/*.py` shell glob doesn't match nested directories, but the new `scripts/tests/**` path filter is recursive — a future nested test file would trigger the workflow and then be silently skipped by the loop | Minor | **Fixed** — swapped the glob for `find scripts/tests -type f -name '*.py'` |
| Loop correctness (fails job on any failure, no `set -e` short-circuit), path-filter recursion, `sync_all` callers, cross-PR interaction with recent factory/dashboard merges | — | **Verified sound**, no changes needed |

Full transcript: `/tmp/codex-review-1150.log` (local to this session).

## Evidence

Local dry-run of the exact `find`-based loop (all 32 scripts, pass/test-count per file), the full `test_security_hardening.py` run, and the two codex-flagged macOS-only sub-tests re-run under a simulated Linux/no-PlistBuddy environment to prove the skip guards actually trip:

![orphan-ci-tests-directory-loop](https://evidence.cloudcompute.com/workspaces/pr-1169/20260803-061444-orphan-ci-tests-directory-loop.png)

https://evidence.cloudcompute.com/workspaces/pr-1169/20260803-061444-orphan-ci-tests-directory-loop.png

## Mergeability

- **Surface:** CI workflow (`.github/workflows/ci-agents.yml`) + two production scripts (`scripts/factory-dashboard.py`, test-only-visible `now` param; `scripts/perf_schema.py`, missing-binary tolerance) + one test file's platform guards (`scripts/tests/test_security_hardening.py`). No app/UI surface touched.
- **Behavior changed:** `ci-agents.yml`'s `test` job now runs all 32 `scripts/tests/*.py` instead of 13, and its path filters trigger on any `scripts/tests/**` change instead of an enumerated list. `sync_all()` gained an optional `now` parameter used only by tests; production call sites are behaviorally unchanged (verified via review loop — see table above). Two `test_security_hardening.py` sub-tests now skip on non-macOS/no-PlistBuddy environments instead of failing.
- **Non-happy paths:** any future `scripts/tests/*.py` failure now fails `ci-agents.yml` instead of being silently unwired; the loop collects and reports every failing script, not just the first. A future test file needing secrets/network/macOS would fail this shared `ubuntu-latest` job the same way `test_security_hardening.py` almost did — the fix here is a per-test skip guard, not a job-level allowlist, since that's what already existed in this file and keeps the bulk of each file running everywhere.
- **Residual risk:** the `scripts/tests/**` path filter doesn't extend to the ~15 non-test source scripts that back the previously-orphaned tests (e.g. `scripts/ops-report.py`, `scripts/factory-dashboard.py` itself) — editing one of those without touching its test file still won't trigger `ci-agents.yml`. This gap pre-dates this PR (those source scripts were never in the filter) and isn't worsened by it; closing it fully would mean hand-enumerating ~15 more entries, the same anti-pattern this issue is fixing, so I left it as a known gap rather than papering over it. Also: this PR does not deduplicate `test_security_hardening.py`, `test_perf_tools.py`, `test_pr_reviewer_broker.py`, `test_pr_review_health.py`, or `test_pr_reviewer_runs.py` out of the other specialized workflows that already run them — `ci-agents.yml`'s loop is meant as a comprehensive backstop, so that duplication is intentional.

Closes #1150

Made with [Orca](https://github.com/stablyai/orca) 🐋

