### PR TITLE
fix(tests): security-hardening test asserts claude.yml stays deleted

### DIFF
--- a/scripts/tests/test_security_hardening.py
+++ b/scripts/tests/test_security_hardening.py
@@ -115,18 +115,11 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("main|release/*|releases/*", workflow)
         self.assertIn("Content-write probes must not target main or release branches.", workflow)
 
-    def test_claude_workflow_is_manual_dispatch_only(self) -> None:
-        workflow = (REPO_ROOT / ".github/workflows/claude.yml").read_text()
-        on_block, _ = workflow.split("\njobs:\n", 1)
-        self.assertIn("workflow_dispatch:", on_block)
-        self.assertIn("prompt:", workflow)
-        for trigger in (
-            "issue_comment",
-            "pull_request_review_comment",
-            "pull_request_review",
-            "issues",
-        ):
-            self.assertIsNone(re.search(rf"(?m)^  {re.escape(trigger)}:$", on_block))
+    def test_claude_workflow_stays_deleted(self) -> None:
+        # Retired in #1166: dormant since March yet granting id-token: write with
+        # no guard. The hardening property is now that it does not come back;
+        # @claude mentions are handled by agent-mention.yml.
+        self.assertFalse((REPO_ROOT / ".github/workflows/claude.yml").exists())
 
     def test_agent_executor_is_label_gated(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/agent-executor.yml").read_text()


### PR DESCRIPTION
Interaction hotfix: #1169 (directory test loop) began executing the previously-orphaned `test_security_hardening.py` at the same moment #1166 deleted `.github/workflows/claude.yml` — every open PR and the next main push now fail the `test` check on a `FileNotFoundError`.

The dispatch-only test is replaced with the stronger post-retirement assertion that the file stays deleted (rationale inline; `@claude` mentions are handled by `agent-mention.yml`).

Evidence: full suite locally green — `Ran 29 tests in 3.362s / OK` (was: FileNotFoundError). CI on this PR is the live proof: the `test` check passes here while failing on every other open branch.

## Mergeability
- **Surface**: CI script tests only (`scripts/tests/test_security_hardening.py`)
- **Behavior changed**: one test case — from asserting claude.yml is dispatch-only to asserting it does not exist
- **Non-happy paths**: if claude.yml is ever reintroduced, this test fails loudly, which is the intended guard
- **Residual risk**: none beyond the test itself; no production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)