### PR TITLE
refactor(logging): unify os.Logger categories within bracket-tag families

### DIFF
--- a/Sources/WorkspaceManager/Diagnostics/InvestigationDiagnostics.swift
+++ b/Sources/WorkspaceManager/Diagnostics/InvestigationDiagnostics.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os.log
 
-private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "InvestigationDiagnostics")
+private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "PerformanceSignposts")
 
 enum InvestigationDiagnostics {
     private enum InputMode: String {

--- a/Sources/WorkspaceManager/Diagnostics/TerminalReadinessDiagnostics.swift
+++ b/Sources/WorkspaceManager/Diagnostics/TerminalReadinessDiagnostics.swift
@@ -2,7 +2,7 @@ import Foundation
 import WorkspaceManagerCore
 import os.log
 
-private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "TerminalReadinessDiagnostics")
+private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "PerformanceSignposts")
 
 final class TerminalReadinessDiagnostics {
     enum Signal: String {

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -16,12 +16,12 @@ private let creationLog = Logger(
     category: "WorkspaceCreation"
 )
 private let workspaceProviderLog = Logger(subsystem: "com.cloudcompute.workspaces", category: "WorkspaceProvider")
-private let uiFixtureLog = Logger(subsystem: "com.cloudcompute.workspaces", category: "UIFixture")
+private let uiFixtureLog = Logger(subsystem: "com.cloudcompute.workspaces", category: "UIFixtureSeeder")
 private let archivedWorkspacePurgeLog = Logger(
     subsystem: "com.cloudcompute.workspaces",
     category: "ArchivedWorkspacePurge"
 )
-private let perfLog = Logger(subsystem: "com.cloudcompute.workspaces", category: "Perf")
+private let perfLog = Logger(subsystem: "com.cloudcompute.workspaces", category: "PerformanceSignposts")
 private let terminalContinuityLog = Logger(subsystem: "com.cloudcompute.workspaces", category: "TerminalContinuity")
 private let hostSessionLog = Logger(subsystem: "com.cloudcompute.workspaces", category: "HostSession")
 private let restoreLog = Logger(subsystem: "com.cloudcompute.workspaces", category: "Restore")

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowTerminalSessionController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowTerminalSessionController.swift
@@ -2,7 +2,7 @@ import Foundation
 import WorkspaceManagerCore
 import os.log
 
-private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "MainWindowTerminalSessionController")
+private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "HostSession")
 
 @MainActor
 struct MainWindowTerminalSessionController {

--- a/Sources/WorkspaceManager/Views/MainWindow/TerminalFocusCoordinator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/TerminalFocusCoordinator.swift
@@ -3,7 +3,7 @@ import Foundation
 import WorkspaceManagerCore
 import os.log
 
-private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "TerminalFocusCoordinator")
+private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "SplitRoutingController")
 
 /// Single entry point for all terminal focus restoration flows.
 ///

--- a/Sources/WorkspaceManager/Views/MainWindow/WorkspaceEnvironmentOptionsController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/WorkspaceEnvironmentOptionsController.swift
@@ -2,7 +2,7 @@ import Foundation
 import WorkspaceManagerCore
 import os.log
 
-private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "WorkspaceEnvironmentOptionsController")
+private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "PerformanceSignposts")
 
 struct WorkspaceProviderSheetState: Sendable, Equatable {
     let providerID: String


### PR DESCRIPTION
## Summary

Follow-up from PR #1173 review (April, item 2): `os.Logger` category strings drift within the
same bracket-tag message family — e.g. `[Perf]`-tagged messages logged under category `"Perf"` in
`ContentView.swift` but `"PerformanceSignposts"` in `PerformanceSignposts.swift`. Message text
(what greps/Console.app searches target) is uniform; the `category:` argument is not. This is a
mechanical, cosmetic pass: **only `category:` string literals changed, no message text, no logger
call sites, no behavior.**

Method: enumerated every bracket tag appearing in log message text, then every `Logger(...)`
declaration emitting it. A logger only counts as "in a family" when its entire current log output
(100%) belongs to that one tag — loggers that mix two or more tag families under a single shared
`Logger` declaration were left untouched (splitting them would be a structural change beyond a
category-string swap). Among eligible loggers, aligned to the category used by the majority of
call sites.

## Family → category mapping

| Bracket tag | Canonical category | Changed | Notes |
|---|---|---|---|
| `[Perf]` | `PerformanceSignposts` | `ContentView.swift:perfLog` (`Perf`→`PerformanceSignposts`), `InvestigationDiagnostics.swift:log`, `TerminalReadinessDiagnostics.swift:log`, `WorkspaceEnvironmentOptionsController.swift:log` | `PerformanceSignposts.swift:log` (18 sites) was already canonical |
| `[UIFixture]` | `UIFixtureSeeder` | `ContentView.swift:uiFixtureLog` (`UIFixture`→`UIFixtureSeeder`) | `UIFixtureSeeder.swift:log` (10 sites) was already canonical |
| `[HostSession]` | `HostSession` | `MainWindowTerminalSessionController.swift:log` (`MainWindowTerminalSessionController`→`HostSession`) | `ContentView.swift:hostSessionLog` (2 sites) was already canonical |
| `[SplitRouting]` | `SplitRoutingController` | `TerminalFocusCoordinator.swift:log` (`TerminalFocusCoordinator`→`SplitRoutingController`) | `SplitRoutingController.swift:log` (1 site) was already canonical |

**Already consistent, no change needed** (single-category families): `[Restore]`,
`[WorkspaceProvider]`, `[TerminalContinuity]`, `[ArchivedWorkspacePurge]`, `[ClaudeIntegration]`,
`[ModelStore]`, `[WebView]`, `[LocalStateStore]`, `[AutomationIntegration]`, `[GhosttyTerminal]`,
`[GhosttySurfaceView]`, `[TileTreeStore]`, `[SurfaceStore]`, `[LumeRuntime]`, `[LumeCLIRunner]`,
`[HostLumeSmokeAutomation]`, `[ExternalEditor]`, `[EditorLaunch]`, `[DesktopUISmokeAutomation]`,
`[CodePreview]`, `[AutomationOperator]`, `[AutomationAudit]`, `[TabRouting]` (pure logger side),
`[AppDelegate]`. Multi-file families that already agreed: `[GhosttyAppManager]` →
`GhosttyAppManager` (2 files), `[AutomationListener]` → `AutomationListener` (2 declarations),
`[AgentHookListener]` → `AgentHookListener` (2 declarations).

`[INFO]` in `WorkspaceManagerCLI/main.swift` uses `print()`, not `os.Logger` — out of scope.
`DiagnosticReportExporter.swift:7` references the literal `"[Perf]"` inside an `eventMessage
CONTAINS` log-stream predicate (not a `Logger` category) — unaffected since message text didn't
change.

**Known exceptions — mixed-tag loggers left untouched** (would need a new `Logger` declaration to
fully separate, which is out of scope for a cosmetic pass; flagging for a possible follow-up):
- `LumeRuntimeService.swift:log` (`LumeRuntimeService`) — 7×`[Perf]` + 1×`[LumeRuntime]`
- `MainWindowLaunchActionHandler.swift:log` (`MainWindowLaunchActionHandler`) — 4×`[UIFixture]` + 5×`[DeepLink]`
- `WorkspaceManagerApp.swift:log` (`WorkspaceManagerApp`) — 5×`[AppDelegate]` + 2×`[DeepLink]`
- `GhosttyTerminalIntentRouter.swift:log` (`GhosttyTerminalIntentRouter`) — 13×`[SplitRouting]` + 5×`[TabRouting]` (majority of both families' volume)

## Verification

- `swift build` — passed
- `swift test` — 1326 tests / 198 suites, all passed
- `mise run lint` (`swift-format lint --strict --recursive`) — clean
- Directed codex review (gpt-5.6-sol, xhigh) — no findings; independently re-verified the diff only touches `category:` literals, confirmed no scripts/docs/tests/CI filter on the old category strings, and spot-checked the "mixed logger, left alone" classification for `GhosttyTerminalIntentRouter` and `LumeRuntimeService`

Evidence:
- [Test + lint results](https://evidence.cloudcompute.com/workspaces/pr-1184/20260804-043255-test-and-lint-results.png)
- [Family → category mapping table](https://evidence.cloudcompute.com/workspaces/pr-1184/20260804-043255-category-mapping-table.png)

## Review loop

Ran codex-review-loop (reflect → directed codex → react) before opening. Reflection pass checked
for external category-string dependents (none found). Codex review (gpt-5.6-sol, xhigh) returned
**no findings** — diff confirmed minimal/correct, scope decisions (which loggers to leave mixed)
independently verified against source. No fix commits needed.

## Mergeability

- **Surface:** macOS app (Swift), `Sources/WorkspaceManager/` — logging infrastructure only, no UI/product surface touched.
- **Behavior changed:** None. Only `Logger(subsystem:category:)` `category:` string literals changed (7 edits, 6 files). Message text, log levels, call sites, and control flow are byte-for-byte identical.
- **Non-happy paths:** N/A — no runtime logic changed; nothing to exercise beyond confirming the app still builds/logs normally (it does, per `swift build`/`swift test`).
- **Residual risk:** Low. A handful of realigned loggers (`InvestigationDiagnostics`, `TerminalReadinessDiagnostics`, `WorkspaceEnvironmentOptionsController`, `MainWindowTerminalSessionController`, `TerminalFocusCoordinator`) are general per-file loggers whose *current* traffic happens to be 100% one tag family; if a future unrelated log line is added to one of these files, it would inherit the family's category name rather than a file-specific one until someone notices. Four loggers that mix two tag families (listed above) were deliberately left inconsistent — flagged as a possible fast-follow, not fixed here to keep this pass mechanical.

Closes #1177