### PR TITLE
fix(factory): enable evidence-verify lane and guard FACTORY_*_ENABLED vars

### DIFF
--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".agents/**"
       - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
       - "scripts/tests/**"
       - "scripts/agent-triage-request.py"
       - "config/github/repo-variables.json"
@@ -25,6 +26,7 @@ on:
     paths:
       - ".agents/**"
       - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
       - "scripts/tests/**"
       - "scripts/agent-triage-request.py"
       - "config/github/repo-variables.json"

--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -88,12 +88,3 @@ jobs:
 
       - name: Run CD failure notifier tests
         run: node --test .github/workflows/cd-fail-notify.test.js
-
-      - name: TEMP - probe toJSON(vars) for repo-variables-drift design (removed before PR)
-        env:
-          REPO_VARS_JSON: ${{ toJSON(vars) }}
-        run: |
-          echo "raw REPO_VARS_JSON:"
-          echo "$REPO_VARS_JSON"
-          echo "check-repo-variables.py against it:"
-          python3 scripts/check-repo-variables.py

--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -5,10 +5,10 @@ on:
     branches: [main]
     paths:
       - ".agents/**"
-      - ".github/workflows/ci-agents.yml"
+      - ".github/workflows/*.yml"
       - "scripts/tests/**"
       - "scripts/agent-triage-request.py"
-      - ".github/workflows/factory-*.yml"
+      - "config/github/repo-variables.json"
       - "scripts/factory-implement.py"
       - "scripts/factory-janitor.py"
       - "scripts/factory-review.py"
@@ -24,10 +24,10 @@ on:
     branches: [main]
     paths:
       - ".agents/**"
-      - ".github/workflows/ci-agents.yml"
+      - ".github/workflows/*.yml"
       - "scripts/tests/**"
       - "scripts/agent-triage-request.py"
-      - ".github/workflows/factory-*.yml"
+      - "config/github/repo-variables.json"
       - "scripts/factory-implement.py"
       - "scripts/factory-janitor.py"
       - "scripts/factory-review.py"

--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -88,3 +88,12 @@ jobs:
 
       - name: Run CD failure notifier tests
         run: node --test .github/workflows/cd-fail-notify.test.js
+
+      - name: TEMP - probe toJSON(vars) for repo-variables-drift design (removed before PR)
+        env:
+          REPO_VARS_JSON: ${{ toJSON(vars) }}
+        run: |
+          echo "raw REPO_VARS_JSON:"
+          echo "$REPO_VARS_JSON"
+          echo "check-repo-variables.py against it:"
+          python3 scripts/check-repo-variables.py

--- a/.github/workflows/repo-variables-drift.yml
+++ b/.github/workflows/repo-variables-drift.yml
@@ -1,0 +1,35 @@
+# Drift gate for config/github/repo-variables.json — verifies every
+# FACTORY_*_ENABLED kill switch a workflow gates on still exists as a live
+# repo variable (#1149: factory-evidence-verify.yml shipped gated on an
+# unset variable and sat 100% dead for two weeks). Read-only: the `vars`
+# context is populated by Actions for every job, so no elevated GITHUB_TOKEN
+# permission is needed the way `gh variable list` would require.
+name: Repo Variables Drift
+
+on:
+  schedule:
+    - cron: "41 13 * * *"
+  pull_request:
+    paths:
+      - "config/github/repo-variables.json"
+      - "scripts/check-repo-variables.py"
+      - ".github/workflows/*.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repo-variables-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Check live repo variables against config/github/repo-variables.json
+        env:
+          REPO_VARS_JSON: ${{ toJSON(vars) }}
+        run: python3 scripts/check-repo-variables.py

--- a/.github/workflows/repo-variables-drift.yml
+++ b/.github/workflows/repo-variables-drift.yml
@@ -14,6 +14,7 @@ on:
       - "config/github/repo-variables.json"
       - "scripts/check-repo-variables.py"
       - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
   workflow_dispatch:
 
 permissions:

--- a/.mise.toml
+++ b/.mise.toml
@@ -160,6 +160,10 @@ run = "uv run --script scripts/factory-dashboard.py --sync --render"
 description = "Diff live GitHub repo settings (rulesets) against config/github/; exit 1 on drift."
 run = "uv run --script scripts/github-settings.py check"
 
+[tasks."repo-variables-check"]
+description = "Diff config/github/repo-variables.json against live GitHub repo variables; runs unattended in repo-variables-drift.yml via toJSON(vars), or locally against gh variable list."
+run = "uv run --script scripts/check-repo-variables.py"
+
 [tasks."repo-settings-apply"]
 description = "Push config/github/ ruleset files to GitHub (needs repo admin)."
 run = "uv run --script scripts/github-settings.py apply"

--- a/config/github/README.md
+++ b/config/github/README.md
@@ -22,3 +22,36 @@ default Actions token (rulesets are visible to anyone with read access);
 
 To manage an additional ruleset, create `rulesets/<name>.json` containing
 `{"name": "<live-name>"}` and run `snapshot`.
+
+## Repo variables (`repo-variables.json`)
+
+`repo-variables.json` lists every `FACTORY_*_ENABLED` kill-switch variable a
+workflow under `.github/workflows/` gates on (name → which workflow it
+gates). A workflow can reference `vars.FACTORY_FOO_ENABLED` in an `if:` and
+ship green with the lane 100% dead if nobody ever runs `gh variable set
+FACTORY_FOO_ENABLED --body true` — that's what happened to
+`factory-evidence-verify.yml` (#1149).
+
+Two checks close that gap, both running unattended in CI:
+
+```bash
+uv run --script scripts/tests/test_factory_workflows.py   # every vars.FACTORY_*_ENABLED reference has a manifest entry
+mise run repo-variables-check                              # every manifest entry exists as a live repo variable
+```
+
+The first reads only local files (workflow YAML + the manifest) and runs in
+`ci-agents.yml`'s `contents: read` job on any workflow-file change. The
+second needs live variable values; `.github/workflows/repo-variables-drift.yml`
+supplies them via `${{ toJSON(vars) }}` — the `vars` context is populated by
+Actions for every job, so unlike the rulesets read above (which also works
+off the default token) *and* unlike `gh variable list`'s REST endpoint (which
+needs a PAT — Actions variables aren't among `GITHUB_TOKEN`'s permission
+scopes), no elevated token is needed here either. That workflow runs on a
+daily schedule plus PRs touching the manifest or any workflow file. Running
+`mise run repo-variables-check` locally (no `REPO_VARS_JSON` set) falls back
+to `gh variable list`, so it still needs a `gh` authenticated with
+variable-read access there.
+
+Adding a new `FACTORY_*_ENABLED` gate: add its name to `repo-variables.json`,
+then `gh variable set <name> --body true` before merging (or `--body false`
+to ship it dark on purpose).

--- a/config/github/repo-variables.json
+++ b/config/github/repo-variables.json
@@ -1,0 +1,7 @@
+{
+  "FACTORY_EVIDENCE_VERIFY_ENABLED": "Gates .github/workflows/factory-evidence-verify.yml.",
+  "FACTORY_IMPLEMENT_ENABLED": "Gates .github/workflows/factory-implement.yml and the standing-queue sweep step in factory-monitor.yml.",
+  "FACTORY_MONITOR_ENABLED": "Gates .github/workflows/factory-monitor.yml.",
+  "FACTORY_RESPONDER_ENABLED": "Gates .github/workflows/factory-comment-responder.yml.",
+  "FACTORY_REVIEW_ENABLED": "Gates .github/workflows/factory-review.yml and factory-review-execute.yml."
+}

--- a/docs/development/factory-current-state.md
+++ b/docs/development/factory-current-state.md
@@ -1,6 +1,6 @@
 # Agent Factory: Current State
 
-What is actually wired and running today, verified against the workflow YAML and live `gh variable list` output on 2026-08-03. `docs/development/agent-factory-v2-plan.md` is the design record — why the pipeline looks like this. This doc is the operational reference — which of it is live, how to turn a lane on or off, and where the telemetry lives. Update it whenever a lane's trigger, guard, or status changes; it will drift otherwise.
+What is actually wired and running today, verified against the workflow YAML and live `gh variable list` output on 2026-08-04. `docs/development/agent-factory-v2-plan.md` is the design record — why the pipeline looks like this. This doc is the operational reference — which of it is live, how to turn a lane on or off, and where the telemetry lives. Update it whenever a lane's trigger, guard, or status changes; it will drift otherwise.
 
 ## Lane table
 
@@ -10,7 +10,7 @@ What is actually wired and running today, verified against the workflow YAML and
 | Review (signal) | `factory-review.yml` | PR opened / `ready_for_review` / synchronize; or `workflow_dispatch` | `AGENT_AUTOMATIONS_ENABLED` + `FACTORY_REVIEW_ENABLED` on the PR-event path only — **`workflow_dispatch` bypasses both switches** (the `if:` uses boolean OR, not AND) | **Live** — untrusted, writes a context artifact only |
 | Review (execute) | `factory-review-execute.yml` | `workflow_run` of Factory Review completing | same switches, same bypass — if the upstream Review run's triggering event was `workflow_dispatch`, this job runs regardless of either switch; otherwise gated, plus `FACTORY_REVIEW_DAILY_CAP` | **Live** — trusted, runs from default-branch code |
 | Monitor | `factory-monitor.yml` | daily cron (13:30 UTC); or `workflow_dispatch` | `AGENT_AUTOMATIONS_ENABLED` + `FACTORY_MONITOR_ENABLED` on the cron path only — **`workflow_dispatch` bypasses both switches** (same OR-not-AND pattern) | **Live** — telemetry, Digest, reconciliation janitor |
-| Evidence Verify | `factory-evidence-verify.yml` | `check_suite` completed; or `workflow_dispatch` | `AGENT_AUTOMATIONS_ENABLED` + `FACTORY_EVIDENCE_VERIFY_ENABLED`, both branches (dispatch does not bypass here) | **Wired but effectively off** — `FACTORY_EVIDENCE_VERIFY_ENABLED` is unset in `gh variable list`, and an unset repo variable reads as empty in Actions expressions, so the guard never passes. Nothing currently sets this switch. |
+| Evidence Verify | `factory-evidence-verify.yml` | `check_suite` completed; or `workflow_dispatch` | `AGENT_AUTOMATIONS_ENABLED` + `FACTORY_EVIDENCE_VERIFY_ENABLED`, both branches (dispatch does not bypass here) | **Live** — `FACTORY_EVIDENCE_VERIFY_ENABLED` was set `true` 2026-08-04 (#1149); the lane shipped green with #1136/#1137 but sat 100% skipped for two weeks because nobody had run `gh variable set` yet. `config/github/repo-variables.json` now guards against a repeat: any workflow referencing an unset `vars.FACTORY_*_ENABLED` fails `scripts/tests/test_factory_workflows.py` in CI. |
 | Owner Comment Responder | `factory-comment-responder.yml` | `issue_comment` created by the owner; or owner `workflow_dispatch` | `AGENT_AUTOMATIONS_ENABLED` + `FACTORY_RESPONDER_ENABLED`, both branches (dispatch does not bypass here) | **Live** |
 | Mention Triage → Executor | `agent-mention.yml` → `agent-executor.yml` | `@april-clearwater` / `@plat` / `@peter` / `@claude` mentions on issues/PRs/reviews | `AGENT_AUTOMATIONS_ENABLED`; execution additionally requires the `safe-to-run-agent` label, server-verified | **Live** — this is a distinct lane from the "Triage" pipeline Stage below; naming collision, not the same code path |
 | Milestone Legibility | `milestone-legibility.yml` | daily cron (13:37 UTC); PR touching the check script; `workflow_dispatch` | none (no Factory switch — always runs) | **Live** |
@@ -28,7 +28,7 @@ What is actually wired and running today, verified against the workflow YAML and
 
 ## Switch inventory
 
-Live values as of 2026-08-03 (`gh variable list --repo fairchild/workspaces`):
+Live values as of 2026-08-04 (`gh variable list --repo fairchild/workspaces`):
 
 | Variable | Value | Gates |
 |---|---|---|
@@ -39,7 +39,7 @@ Live values as of 2026-08-03 (`gh variable list --repo fairchild/workspaces`):
 | `FACTORY_REVIEW_DAILY_CAP` | `12` | Review (execute) lane — max executor attempts per UTC day, including reruns |
 | `FACTORY_MONITOR_ENABLED` | `true` | Monitor lane |
 | `FACTORY_RESPONDER_ENABLED` | `true` | Owner Comment Responder lane |
-| `FACTORY_EVIDENCE_VERIFY_ENABLED` | *(unset)* | Evidence Verify lane — unset means off; set it to `true` to activate |
+| `FACTORY_EVIDENCE_VERIFY_ENABLED` | `true` | Evidence Verify lane |
 
 `APPLE_ID`, `APPLE_TEAM_ID`, and `PREFERRED_RUNNER` also show up in `gh variable list` but are release/runner configuration, not Factory switches.
 

--- a/scripts/check-repo-variables.py
+++ b/scripts/check-repo-variables.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Diff config/github/repo-variables.json against live GitHub repo variables.
+
+Desired state is the manifest's key set: every FACTORY_*_ENABLED kill switch
+a workflow gates on. `scripts/tests/test_factory_workflows.py` covers half of
+this contract (every vars.FACTORY_*_ENABLED referenced under
+.github/workflows/ has a manifest entry) from local files only. This script
+covers the other half: does each manifest entry actually exist as a live repo
+variable. Two sources for "live," picked automatically:
+
+- CI: `.github/workflows/repo-variables-drift.yml` sets REPO_VARS_JSON to
+  `${{ toJSON(vars) }}` before calling this script. The `vars` context is
+  populated by Actions for every job — unlike the `gh variable list` REST
+  endpoint, no elevated GITHUB_TOKEN permission is needed, so this runs
+  unattended (`vars` context: https://docs.github.com/actions/reference/workflows-and-actions/contexts#vars-context).
+- Local/manual: REPO_VARS_JSON is normally unset, so this falls back to
+  `gh variable list` (needs a `gh` authenticated with variable-read access —
+  a PAT, not the ambient Actions token).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "config" / "github" / "repo-variables.json"
+
+
+def live_variable_names() -> set[str]:
+    raw = os.environ.get("REPO_VARS_JSON")
+    if raw:
+        live = json.loads(raw)
+        if not isinstance(live, dict):
+            sys.exit("REPO_VARS_JSON did not decode to an object")
+        # An unset repo variable reads as empty string in Actions expressions,
+        # so it can show up as a key with an empty value rather than being
+        # absent — either way it can't gate a workflow to true.
+        return {name for name, value in live.items() if value}
+
+    result = subprocess.run(
+        ["gh", "variable", "list", "--json", "name", "-q", ".[].name"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.exit(f"gh variable list failed: {result.stderr.strip()}")
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def main() -> int:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    desired = set(manifest.keys())
+    live = live_variable_names()
+    missing = sorted(desired - live)
+    if missing:
+        print("In config/github/repo-variables.json but not live/unset (gate can never fire):")
+        for name in missing:
+            print(f"  - {name}   fix: gh variable set {name} --body true")
+        return 1
+    print(f"OK — all {len(desired)} manifest variables exist live.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_factory_workflows.py
+++ b/scripts/tests/test_factory_workflows.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import re
 import sys
 import unittest
@@ -19,6 +20,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 IMPLEMENT_SCRIPT = REPO_ROOT / "scripts" / "factory-implement.py"
 IMPLEMENT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "factory-implement.yml"
 REVIEW_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "factory-review-execute.yml"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+REPO_VARIABLES_MANIFEST = REPO_ROOT / "config" / "github" / "repo-variables.json"
+FACTORY_ENABLED_VAR_DOT_REF = re.compile(r"vars\.(FACTORY_[A-Z0-9_]*_ENABLED)\b")
+FACTORY_ENABLED_VAR_BRACKET_REF = re.compile(r"vars\[\s*['\"](FACTORY_[A-Z0-9_]*_ENABLED)['\"]\s*\]")
 
 
 def load_module(name: str, path: Path):
@@ -994,6 +999,46 @@ class FactoryTelemetryContractTests(unittest.TestCase):
         self.assertIn("actions: read", jobs["telemetry"])
         self.assertIn("needs: [admit, april, plat]", jobs["telemetry"])
         self.assertIn("scripts/factory-cost-append.py", jobs["telemetry"])
+
+
+def referenced_factory_enabled_vars() -> set[str]:
+    """Every vars.FACTORY_*_ENABLED name gated on by any workflow file.
+
+    Covers both accessor styles (`vars.NAME` and `vars['NAME']`/`vars["NAME"]`)
+    across both workflow extensions GitHub Actions recognizes."""
+    names: set[str] = set()
+    paths = sorted(WORKFLOWS_DIR.glob("*.yml")) + sorted(WORKFLOWS_DIR.glob("*.yaml"))
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        names.update(FACTORY_ENABLED_VAR_DOT_REF.findall(text))
+        names.update(FACTORY_ENABLED_VAR_BRACKET_REF.findall(text))
+    return names
+
+
+class RepoVariableContractTests(unittest.TestCase):
+    """A workflow gate on an unset repo variable ships green and never runs
+    (#1149: factory-evidence-verify.yml gated on FACTORY_EVIDENCE_VERIFY_ENABLED
+    for two PRs before anyone noticed the variable didn't exist). This is the
+    local-files half of the contract — no network, so it runs unattended in
+    ci-agents.yml on any workflow-file change. The other half (does the
+    manifest name actually exist as a live repo variable) is
+    `.github/workflows/repo-variables-drift.yml` + `scripts/check-repo-variables.py`,
+    which also runs unattended (via the `vars` context, not a `gh` call — see
+    config/github/README.md)."""
+
+    def test_every_referenced_factory_enabled_var_has_a_manifest_entry(self) -> None:
+        referenced = referenced_factory_enabled_vars()
+        self.assertTrue(referenced, "expected at least one vars.FACTORY_*_ENABLED reference under .github/workflows/")
+
+        manifest = json.loads(REPO_VARIABLES_MANIFEST.read_text(encoding="utf-8"))
+        missing = sorted(referenced - set(manifest.keys()))
+        self.assertEqual(
+            missing,
+            [],
+            f"vars.FACTORY_*_ENABLED referenced in a workflow with no entry in "
+            f"{REPO_VARIABLES_MANIFEST.relative_to(REPO_ROOT)} (gate can never fire "
+            f"since nobody is prompted to `gh variable set`): {missing}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `factory-evidence-verify.yml` gated on `vars.FACTORY_EVIDENCE_VERIFY_ENABLED`, which was never created — the lane shipped green with #1136/#1137 and sat 100% skipped for two weeks. Set the repo variable to `true` (matching the `== 'true'` convention every other `FACTORY_*_ENABLED` gate and repo variable already uses — not `--body "1"`, which wouldn't match).
- Added a two-layer guard against a repeat, since this bug class is silent by construction:
  - `config/github/repo-variables.json` — manifest of every `FACTORY_*_ENABLED` kill switch a workflow gates on.
  - `RepoVariableContractTests` in `scripts/tests/test_factory_workflows.py` — local files only, asserts every `vars.FACTORY_*_ENABLED` reference under `.github/workflows/` has a manifest entry. Runs unattended in `ci-agents.yml` (paths widened from `.github/workflows/factory-*.yml` to `.github/workflows/*.yml` so it fires on any workflow file, not just factory-prefixed ones).
  - `.github/workflows/repo-variables-drift.yml` + `scripts/check-repo-variables.py` — the other half of the contract: does each manifest entry actually exist as a live repo variable. Runs unattended too, via `${{ toJSON(vars) }}` (the `vars` context is populated by Actions for every job — no elevated `GITHUB_TOKEN` permission needed, unlike `gh variable list`'s REST endpoint). Daily schedule + PRs touching the manifest or any workflow file. Empirically verified with a real dispatched run before opening this PR (see Evidence).
- Updated `docs/development/factory-current-state.md`, which is the canonical "what's actually live" doc and still said the lane was unset/off.

## Review loop

Ran `codex-review-loop` (gpt-5.6-sol, xhigh) directed at: regex/glob correctness of the reference scanner, whether the CI-safe manifest test actually closes the dead-lane bug class end to end, safety of re-enabling the lane, and manifest accuracy.

- **Blocker — manifest⇒live not enforced in CI.** My first pass made `scripts/check-repo-variables.py` a local-only `gh variable list` check (a PAT is genuinely needed for that REST endpoint), so a contributor could add a workflow gate *and* a manifest entry but never run `gh variable set`, and CI would stay green with the lane still dead — the same bug, one layer down. Codex proposed `${{ toJSON(vars) }}`, which needs no elevated token. **Fixed**: rewrote the script to accept live values via `REPO_VARS_JSON` (CI) with a `gh variable list` fallback (local), added `repo-variables-drift.yml`, and empirically confirmed it on a real dispatched run before trusting it (see Evidence).
- **Important — scanner narrower than its claim.** Regex missed `vars['NAME']` bracket notation and `.yaml`-extension workflow files; `ci-agents.yml`'s old `factory-*.yml` path filter wouldn't trigger for a hypothetically-named non-factory-prefixed workflow. **Fixed**: added bracket-notation regex + `.yaml` glob, widened `ci-agents.yml`'s path filters to `.github/workflows/*.yml`.
- **Important — stale doc.** `docs/development/factory-current-state.md` still said the lane was unset/off. **Fixed**.
- **Minor — manifest description inaccurate.** `FACTORY_IMPLEMENT_ENABLED`'s description only named `factory-implement.yml`; it also gates the standing-queue sweep step in `factory-monitor.yml`. **Fixed**.
- **Blocker — `factory-evidence-verify.py` PR-body write race.** The verifier's re-check before writing compares only the head SHA, not whether the body itself changed (e.g. an owner edits the PR description via the UI between read and write, at a stable SHA) — a real gap, but in code from #1136/#1137 that this diff doesn't touch, and unreachable in practice until this PR turns the lane on. **Declined here, filed as #1183** rather than scope-creeping into an unrelated script.
- **Minor — no reverse check for stale/unreferenced manifest entries.** Declined: the issue's ask is "referenced ⇒ has an entry," not the converse; an unreferenced entry is inert, not a false-negative risk.

Full transcript available on request; not attaching raw codex log to keep the PR focused.

**Post-open follow-up (april-clearwater PR review, Approved with follow-ups):** the scanner checks both `.yml` and `.yaml`, but `ci-agents.yml` and `repo-variables-drift.yml`'s own path triggers only widened to `.yml` — a `.yaml`-extension workflow wouldn't re-trigger either check on the introducing PR. Low risk today (every workflow here is `.yml`), but fixed for consistency (10d17060).

## Mergeability

- **Surface**: infra — CI config only (workflow YAML, a new drift workflow, a checked-in manifest, a new local/CI script, one doc). No app or web code touched.
- **User-facing behavior changed**: None for end users. For factory-lane operators: `factory-evidence-verify.yml` starts actually running (it was previously 100% skipped) — named-CI/diff evidence items on factory PRs complete automatically instead of staying pending forever, and machine-applied `blocked:evidence` labels clear once evidence is complete and SHA-current, matching the #1136/#1137 design that already went through review and shipped dark.
- **Non-happy paths considered**: existing manifest entries checked against every live var (`gh variable list`) before opening — all 5 present with `true`. The CI-safe test was verified to actually fail closed (a synthetic missing-entry run reproduced the assertion failure, then restored). The `toJSON(vars)`-based drift check was verified against a real dispatched Actions run on this branch, not just reasoned about (see Evidence) — confirmed it returns the full live variable set with no elevated token. `check-repo-variables.py`'s empty-string-vs-missing-key ambiguity (unset vars can appear as an empty-string value rather than being absent) is handled explicitly (`if value` truthiness check, not just key presence).
- **Residual risk or follow-up**: #1183 (pre-existing PR-body write race in the now-live verifier, filed above, not fixed here). The re-enabled lane's other accepted risks (check_suite volume, stale-check-name-pends-forever) were already reviewed and accepted in #1136/#1137's own Mergeability section and are unchanged by this PR.

## Validation

- [x] `uv run --script scripts/tests/test_factory_workflows.py` — 29/29 (was 28; new `RepoVariableContractTests`)
- [x] `uv run --script scripts/tests/test_factory_evidence_verify.py` — 12/12 (unchanged, confirms the now-live verifier script itself is untouched)
- [x] Full `scripts/tests/*.py` sweep (mirrors `ci-agents.yml`'s loop step) — all pass
- [x] `actionlint` clean on `ci-agents.yml` and `repo-variables-drift.yml`
- [x] `mise run repo-variables-check` (local `gh`-backed path) — OK, all 5 manifest variables exist live
- [x] Real dispatched Actions run on this branch (30877877639) confirming `toJSON(vars)` — reverted from the diff before opening this PR, kept as evidence

## Evidence

- [Consolidated test run + drift-check + actionlint log](https://evidence.cloudcompute.com/workspaces/pr-1185/20260804-043337-factory-evidence-verify-final.png)
- [Empirical toJSON(vars) probe — real dispatched Actions run](https://github.com/fairchild/workspaces/actions/runs/30877877639) (temporary diagnostic step, added then reverted on this branch — confirms the drift workflow's design works before merge, not just in theory)

## Blockers

- [x] None

Closes #1149

Made with [Orca](https://github.com/stablyai/orca) 🐋

