### PR TITLE
refactor(app): extract workspace-orphan reconciliation from ContentView (#1160 slice 1)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -108,10 +108,7 @@ struct ContentView: View {
     @State private var workspaceEnvironmentSheetState = WorkspaceEnvironmentSheetState.empty
     @State private var didScheduleInitialWorkspaceStatusSync = false
     @State private var didPrewarmPerfTerminalSurfaces = false
-    @State private var workspaceOrphanItems: [WorkspaceOrphanItem] = []
-    @State private var dismissedWorkspaceOrphanItemIDs: Set<String> = []
-    @State private var cleaningWorkspaceOrphanItemIDs: Set<String> = []
-    @State private var pendingWorkspaceOrphanCleanup: WorkspaceOrphanItem?
+    @State private var workspaceOrphanState = WorkspaceOrphanReconciliationState()
     @State private var pendingRestorePlan: RestorePlan?
     @State private var restoreBannerDismissed = false
     @AppStorage(TerminalRestoreBannerStorage.handledRunIDKey)
@@ -149,6 +146,7 @@ struct ContentView: View {
     private let splitRoutingController = SplitRoutingController()
     private let tabRoutingController = TabRoutingController()
     private let workspaceEnvironmentOptionsController = WorkspaceEnvironmentOptionsController()
+    private let workspaceOrphanController = WorkspaceOrphanReconciliationController()
 
     private var launchRepositoryService: LaunchRepositoryService {
         LaunchRepositoryService(modelContext: modelContext)
@@ -221,10 +219,6 @@ struct ContentView: View {
             workspaceIDs: repos.flatMap(\.workspaces).map(\.id),
             webSourceIDs: webSources.map(\.id)
         )
-    }
-
-    private var visibleWorkspaceOrphanItems: [WorkspaceOrphanItem] {
-        workspaceOrphanItems.filter { !dismissedWorkspaceOrphanItemIDs.contains($0.id) }
     }
 
     private var normalizedRepoPathSnapshot: Set<String> {
@@ -780,17 +774,15 @@ struct ContentView: View {
             if modelStoreStatusController.shouldShowDegradedWarning {
                 ModelStoreDegradedBanner()
             }
-            if !visibleWorkspaceOrphanItems.isEmpty {
+            if !workspaceOrphanState.visibleItems.isEmpty {
                 WorkspaceOrphanReconciliationBanner(
-                    items: visibleWorkspaceOrphanItems,
-                    cleaningItemIDs: cleaningWorkspaceOrphanItemIDs,
+                    items: workspaceOrphanState.visibleItems,
+                    cleaningItemIDs: workspaceOrphanState.cleaningItemIDs,
                     onClean: { item in
-                        pendingWorkspaceOrphanCleanup = item
+                        workspaceOrphanState.pendingCleanup = item
                     },
                     onDismiss: {
-                        dismissedWorkspaceOrphanItemIDs.formUnion(
-                            visibleWorkspaceOrphanItems.map(\.id)
-                        )
+                        workspaceOrphanState.dismissVisibleItems()
                     }
                 )
             }
@@ -949,24 +941,26 @@ struct ContentView: View {
         splitViewWithLifecycleHandlers
             .mainWindowErrorAlert($errorPresenter)
             .alert(
-                workspaceOrphanCleanupTitle(for: pendingWorkspaceOrphanCleanup),
+                workspaceOrphanController.confirmationTitle(for: workspaceOrphanState.pendingCleanup),
                 isPresented: Binding(
-                    get: { pendingWorkspaceOrphanCleanup != nil },
-                    set: { if !$0 { pendingWorkspaceOrphanCleanup = nil } }
+                    get: { workspaceOrphanState.pendingCleanup != nil },
+                    set: { if !$0 { workspaceOrphanState.pendingCleanup = nil } }
                 )
             ) {
                 Button("Clean", role: .destructive) {
-                    guard let item = pendingWorkspaceOrphanCleanup else { return }
-                    pendingWorkspaceOrphanCleanup = nil
+                    guard let item = workspaceOrphanState.pendingCleanup else { return }
+                    workspaceOrphanState.pendingCleanup = nil
                     Task { @MainActor in
                         await cleanWorkspaceOrphan(item)
                     }
                 }
                 Button("Cancel", role: .cancel) {
-                    pendingWorkspaceOrphanCleanup = nil
+                    workspaceOrphanState.pendingCleanup = nil
                 }
             } message: {
-                Text(workspaceOrphanCleanupMessage(for: pendingWorkspaceOrphanCleanup))
+                Text(
+                    workspaceOrphanController.confirmationMessage(
+                        for: workspaceOrphanState.pendingCleanup))
             }
             .alert(
                 "Could Not Complete Provider Setup",
@@ -2486,18 +2480,11 @@ struct ContentView: View {
     @MainActor
     private func refreshWorkspaceOrphans(trigger: String) async {
         let scanStartedAt = Date()
-        let snapshots = workspaceOrphanRepositorySnapshots()
-        let workspacesRoot = await workspaceService.workspacesRoot
-        let lumeWorkspaceStorageURL = await LumeValidatedBaseService.shared.workspaceVMStorageDirectoryURL
-        let reconciler = WorkspaceOrphanReconciler(
-            workspacesRoot: workspacesRoot,
-            lumeWorkspaceStorageURL: lumeWorkspaceStorageURL
-        )
+        let snapshots = workspaceOrphanController.repositorySnapshots(repos: repos)
+        let reconciler = await makeWorkspaceOrphanReconciler()
 
         let result = await reconciler.scan(repositories: snapshots)
-        workspaceOrphanItems = result.items
-        let currentIDs = Set(result.items.map(\.id))
-        dismissedWorkspaceOrphanItemIDs = dismissedWorkspaceOrphanItemIDs.intersection(currentIDs)
+        workspaceOrphanState.applyScanResult(result.items)
 
         perfLog.info(
             "[Perf] metric=workspace_orphan_scan duration_ms=\(String(format: "%.2f", Date().timeIntervalSince(scanStartedAt) * 1000), privacy: .public) trigger=\(trigger, privacy: .public) repo_count=\(snapshots.count, privacy: .public) item_count=\(result.items.count, privacy: .public)"
@@ -2505,126 +2492,48 @@ struct ContentView: View {
     }
 
     @MainActor
-    private func workspaceOrphanRepositorySnapshots() -> [WorkspaceOrphanRepositorySnapshot] {
-        repos.map { repo in
-            WorkspaceOrphanRepositorySnapshot(
-                id: repo.id,
-                name: repo.name,
-                localPath: repo.localPath,
-                workspaces: repo.workspaces.map { workspace in
-                    WorkspaceOrphanWorkspaceSnapshot(
-                        id: workspace.id,
-                        name: workspace.name,
-                        path: workspace.path,
-                        gitBranch: workspace.gitBranch,
-                        backendIdentifier: workspace.backendIdentifier,
-                        remoteId: workspace.remoteId,
-                        backendMetadataRaw: workspace.backendMetadataRaw,
-                        usesHostWorkspaceFiles: workspace.usesHostWorkspaceFiles
-                    )
-                }
-            )
-        }
+    private func makeWorkspaceOrphanReconciler() async -> WorkspaceOrphanReconciler {
+        WorkspaceOrphanReconciler(
+            workspacesRoot: await workspaceService.workspacesRoot,
+            lumeWorkspaceStorageURL: await LumeValidatedBaseService.shared
+                .workspaceVMStorageDirectoryURL
+        )
     }
 
     @MainActor
     private func cleanWorkspaceOrphan(_ item: WorkspaceOrphanItem) async {
-        guard !cleaningWorkspaceOrphanItemIDs.contains(item.id) else { return }
-        cleaningWorkspaceOrphanItemIDs.insert(item.id)
+        guard workspaceOrphanState.beginCleaning(item) else { return }
         defer {
-            cleaningWorkspaceOrphanItemIDs.remove(item.id)
+            workspaceOrphanState.endCleaning(item)
         }
 
-        let workspacesRoot = await workspaceService.workspacesRoot
-        let lumeWorkspaceStorageURL = await LumeValidatedBaseService.shared.workspaceVMStorageDirectoryURL
-        let reconciler = WorkspaceOrphanReconciler(
-            workspacesRoot: workspacesRoot,
-            lumeWorkspaceStorageURL: lumeWorkspaceStorageURL
-        )
+        let reconciler = await makeWorkspaceOrphanReconciler()
 
         do {
-            switch item.kind {
-            case .gitWorktreeWithoutRecord:
-                try await reconciler.cleanupGitWorktree(item)
-            case .workspaceRecordMissingDirectory:
-                if item.hasPrunableGitMetadata {
+            for step in workspaceOrphanController.cleanupSteps(for: item) {
+                switch step {
+                case .pruneGitWorktree:
                     try await reconciler.cleanupGitWorktree(item)
+                case .deleteWorkspaceRecord:
+                    try workspaceOrphanController.deleteWorkspaceRecord(
+                        for: item,
+                        in: repos,
+                        modelContext: modelContext
+                    )
+                case .deleteLumeVM:
+                    try await workspaceOrphanController.deleteLumeVM(
+                        for: item,
+                        registry: workspaceProviderRegistry
+                    )
                 }
-                try deleteWorkspaceRecord(for: item)
-            case .lumeVMWithoutWorkspace:
-                try await cleanupLumeVMOrphan(item)
             }
 
-            workspaceOrphanItems.removeAll { $0.id == item.id }
-            dismissedWorkspaceOrphanItemIDs.remove(item.id)
+            workspaceOrphanState.removeCleanedItem(item)
             await refreshWorkspaceOrphans(trigger: "cleanup")
         } catch {
             presentWorkspaceOperationError(
-                "Could not clean '\(item.resourceName)': \(error.localizedDescription)"
+                workspaceOrphanController.cleanupFailureMessage(for: item, error: error)
             )
-        }
-    }
-
-    @MainActor
-    private func deleteWorkspaceRecord(for item: WorkspaceOrphanItem) throws {
-        guard let workspaceID = item.workspaceID,
-            let workspace = repos.flatMap(\.workspaces).first(where: { $0.id == workspaceID })
-        else {
-            throw WorkspaceOrphanReconciliationError.unsupportedCleanupItem
-        }
-
-        modelContext.delete(workspace)
-        do {
-            try modelContext.save()
-        } catch {
-            modelContext.rollback()
-            throw error
-        }
-    }
-
-    @MainActor
-    private func cleanupLumeVMOrphan(_ item: WorkspaceOrphanItem) async throws {
-        guard let target = item.lumeCleanupTarget(),
-            let provider = workspaceProviderRegistry.provider(for: LumeWorkspaceProvider.identifier)
-        else {
-            throw WorkspaceOrphanReconciliationError.unsupportedCleanupItem
-        }
-
-        do {
-            try await provider.deleteWorkspace(target)
-        } catch {
-            // The VM directory was just found on disk, so a Lume not-found here means the
-            // `workspaces` storage location isn't registered — surface that instead of "Not found".
-            guard let diagnostic = LumeErrorHeuristics.missingWorkspacesStorageDiagnostic(for: error) else {
-                throw error
-            }
-            throw WorkspaceProviderError.unavailable(diagnostic)
-        }
-    }
-
-    private func workspaceOrphanCleanupTitle(for item: WorkspaceOrphanItem?) -> String {
-        guard let item else { return "Clean Workspace Leftover?" }
-        switch item.kind {
-        case .gitWorktreeWithoutRecord:
-            return "Remove Orphaned Worktree?"
-        case .workspaceRecordMissingDirectory:
-            return "Remove Missing Workspace Record?"
-        case .lumeVMWithoutWorkspace:
-            return "Delete Orphaned Lume VM?"
-        }
-    }
-
-    private func workspaceOrphanCleanupMessage(for item: WorkspaceOrphanItem?) -> String {
-        guard let item else { return "" }
-        switch item.kind {
-        case .gitWorktreeWithoutRecord:
-            return
-                "This removes the git worktree '\(item.resourceName)' and its workspace branch when it is a workspace-owned branch."
-        case .workspaceRecordMissingDirectory:
-            return
-                "This removes the workspace record for '\(item.resourceName)'. No workspace directory exists at its saved path."
-        case .lumeVMWithoutWorkspace:
-            return "This deletes the Lume VM '\(item.resourceName)' from workspace VM storage."
         }
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2502,7 +2502,8 @@ struct ContentView: View {
 
     @MainActor
     private func cleanWorkspaceOrphan(_ item: WorkspaceOrphanItem) async {
-        guard workspaceOrphanState.beginCleaning(item) else { return }
+        guard !workspaceOrphanState.isCleaning(item) else { return }
+        workspaceOrphanState.beginCleaning(item)
         defer {
             workspaceOrphanState.endCleaning(item)
         }

--- a/Sources/WorkspaceManager/Views/MainWindow/WorkspaceOrphanReconciliationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/WorkspaceOrphanReconciliationController.swift
@@ -44,10 +44,10 @@ struct WorkspaceOrphanReconciliationState: Equatable {
         dismissedItemIDs.formUnion(visibleItems.map(\.id))
     }
 
-    /// Marks an item as in-flight. Returns `false` when a cleanup is already running for
-    /// it, which is how a repeat confirmation is ignored rather than run twice.
-    mutating func beginCleaning(_ item: WorkspaceOrphanItem) -> Bool {
-        cleaningItemIDs.insert(item.id).inserted
+    /// Marks an item as in-flight. Callers guard on `isCleaning(_:)` first so a repeat
+    /// confirmation returns without writing state back at all.
+    mutating func beginCleaning(_ item: WorkspaceOrphanItem) {
+        cleaningItemIDs.insert(item.id)
     }
 
     mutating func endCleaning(_ item: WorkspaceOrphanItem) {

--- a/Sources/WorkspaceManager/Views/MainWindow/WorkspaceOrphanReconciliationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/WorkspaceOrphanReconciliationController.swift
@@ -1,0 +1,185 @@
+//
+//  WorkspaceOrphanReconciliationController.swift
+//  WorkspaceManager
+//
+//  Main-window bookkeeping for the workspace-leftover cleanup banner: which scanned
+//  orphans are still visible, which are mid-cleanup, and what a confirmed cleanup does
+//  for each orphan kind. Scanning and worktree removal live in `WorkspaceOrphanReconciler`;
+//  this owns the view-facing state and the per-kind decision the main window acts on.
+//
+
+import Foundation
+import SwiftData
+import WorkspaceManagerCore
+
+/// Banner and confirmation state for workspace-leftover cleanup, held in one `@State`.
+///
+/// Dismissal is recorded per item id rather than as a single "banner hidden" flag, so a
+/// later scan that surfaces a leftover the user has not seen still shows the banner while
+/// previously dismissed items stay quiet.
+struct WorkspaceOrphanReconciliationState: Equatable {
+    private(set) var items: [WorkspaceOrphanItem] = []
+    private(set) var dismissedItemIDs: Set<String> = []
+    private(set) var cleaningItemIDs: Set<String> = []
+
+    /// The item awaiting destructive-action confirmation. Non-nil drives the alert.
+    var pendingCleanup: WorkspaceOrphanItem?
+
+    var visibleItems: [WorkspaceOrphanItem] {
+        items.filter { !dismissedItemIDs.contains($0.id) }
+    }
+
+    func isCleaning(_ item: WorkspaceOrphanItem) -> Bool {
+        cleaningItemIDs.contains(item.id)
+    }
+
+    /// Replaces the scanned set. Dismissals for items the scan no longer reports are
+    /// dropped, so a leftover that is cleaned and later reappears is offered again.
+    mutating func applyScanResult(_ scannedItems: [WorkspaceOrphanItem]) {
+        items = scannedItems
+        dismissedItemIDs.formIntersection(Set(scannedItems.map(\.id)))
+    }
+
+    mutating func dismissVisibleItems() {
+        dismissedItemIDs.formUnion(visibleItems.map(\.id))
+    }
+
+    /// Marks an item as in-flight. Returns `false` when a cleanup is already running for
+    /// it, which is how a repeat confirmation is ignored rather than run twice.
+    mutating func beginCleaning(_ item: WorkspaceOrphanItem) -> Bool {
+        cleaningItemIDs.insert(item.id).inserted
+    }
+
+    mutating func endCleaning(_ item: WorkspaceOrphanItem) {
+        cleaningItemIDs.remove(item.id)
+    }
+
+    /// Drops an item that was cleaned successfully, ahead of the confirming rescan.
+    mutating func removeCleanedItem(_ item: WorkspaceOrphanItem) {
+        items.removeAll { $0.id == item.id }
+        dismissedItemIDs.remove(item.id)
+    }
+}
+
+/// Decisions and copy for workspace-leftover cleanup. Every member is a projection or a
+/// scoped effect taking its dependencies as parameters, so the per-kind cleanup rule is
+/// assertable without a window.
+@MainActor
+struct WorkspaceOrphanReconciliationController {
+    /// One unit of destructive work in a confirmed cleanup, in execution order.
+    enum CleanupStep: Equatable {
+        case pruneGitWorktree
+        case deleteWorkspaceRecord
+        case deleteLumeVM
+    }
+
+    func repositorySnapshots(repos: [Repo]) -> [WorkspaceOrphanRepositorySnapshot] {
+        repos.map { repo in
+            WorkspaceOrphanRepositorySnapshot(
+                id: repo.id,
+                name: repo.name,
+                localPath: repo.localPath,
+                workspaces: repo.workspaces.map { workspace in
+                    WorkspaceOrphanWorkspaceSnapshot(
+                        id: workspace.id,
+                        name: workspace.name,
+                        path: workspace.path,
+                        gitBranch: workspace.gitBranch,
+                        backendIdentifier: workspace.backendIdentifier,
+                        remoteId: workspace.remoteId,
+                        backendMetadataRaw: workspace.backendMetadataRaw,
+                        usesHostWorkspaceFiles: workspace.usesHostWorkspaceFiles
+                    )
+                }
+            )
+        }
+    }
+
+    /// What a confirmed cleanup does for this item. A record whose directory is gone only
+    /// prunes the worktree when git metadata for it survives — otherwise there is nothing
+    /// to prune and the record deletion stands alone.
+    func cleanupSteps(for item: WorkspaceOrphanItem) -> [CleanupStep] {
+        switch item.kind {
+        case .gitWorktreeWithoutRecord:
+            return [.pruneGitWorktree]
+        case .workspaceRecordMissingDirectory:
+            return item.hasPrunableGitMetadata
+                ? [.pruneGitWorktree, .deleteWorkspaceRecord]
+                : [.deleteWorkspaceRecord]
+        case .lumeVMWithoutWorkspace:
+            return [.deleteLumeVM]
+        }
+    }
+
+    func deleteWorkspaceRecord(
+        for item: WorkspaceOrphanItem,
+        in repos: [Repo],
+        modelContext: ModelContext
+    ) throws {
+        guard let workspaceID = item.workspaceID,
+            let workspace = repos.flatMap(\.workspaces).first(where: { $0.id == workspaceID })
+        else {
+            throw WorkspaceOrphanReconciliationError.unsupportedCleanupItem
+        }
+
+        modelContext.delete(workspace)
+        do {
+            try modelContext.save()
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
+    }
+
+    func deleteLumeVM(
+        for item: WorkspaceOrphanItem,
+        registry: WorkspaceProviderRegistry
+    ) async throws {
+        guard let target = item.lumeCleanupTarget(),
+            let provider = registry.provider(for: LumeWorkspaceProvider.identifier)
+        else {
+            throw WorkspaceOrphanReconciliationError.unsupportedCleanupItem
+        }
+
+        do {
+            try await provider.deleteWorkspace(target)
+        } catch {
+            // The VM directory was just found on disk, so a Lume not-found here means the
+            // `workspaces` storage location isn't registered — surface that instead of "Not found".
+            guard let diagnostic = LumeErrorHeuristics.missingWorkspacesStorageDiagnostic(for: error) else {
+                throw error
+            }
+            throw WorkspaceProviderError.unavailable(diagnostic)
+        }
+    }
+
+    func confirmationTitle(for item: WorkspaceOrphanItem?) -> String {
+        guard let item else { return "Clean Workspace Leftover?" }
+        switch item.kind {
+        case .gitWorktreeWithoutRecord:
+            return "Remove Orphaned Worktree?"
+        case .workspaceRecordMissingDirectory:
+            return "Remove Missing Workspace Record?"
+        case .lumeVMWithoutWorkspace:
+            return "Delete Orphaned Lume VM?"
+        }
+    }
+
+    func confirmationMessage(for item: WorkspaceOrphanItem?) -> String {
+        guard let item else { return "" }
+        switch item.kind {
+        case .gitWorktreeWithoutRecord:
+            return
+                "This removes the git worktree '\(item.resourceName)' and its workspace branch when it is a workspace-owned branch."
+        case .workspaceRecordMissingDirectory:
+            return
+                "This removes the workspace record for '\(item.resourceName)'. No workspace directory exists at its saved path."
+        case .lumeVMWithoutWorkspace:
+            return "This deletes the Lume VM '\(item.resourceName)' from workspace VM storage."
+        }
+    }
+
+    func cleanupFailureMessage(for item: WorkspaceOrphanItem, error: Error) -> String {
+        "Could not clean '\(item.resourceName)': \(error.localizedDescription)"
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/WorkspaceOrphanReconciliationBannerRenderTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspaceOrphanReconciliationBannerRenderTests.swift
@@ -1,0 +1,101 @@
+//
+//  WorkspaceOrphanReconciliationBannerRenderTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Renders the leftover-cleanup banner from `WorkspaceOrphanReconciliationState` so the
+//  extracted state drives the same visible surface the main window shows. Writes PNGs for
+//  PR evidence when `WORKSPACES_EVIDENCE_DIR` is set; otherwise it is a layout smoke test.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@MainActor
+@Suite("WorkspaceOrphanReconciliationBanner render")
+struct WorkspaceOrphanReconciliationBannerRenderTests {
+    private func makeItem(
+        id: String,
+        kind: WorkspaceOrphanKind,
+        resourceName: String
+    ) -> WorkspaceOrphanItem {
+        WorkspaceOrphanItem(
+            id: id,
+            kind: kind,
+            repoID: UUID(),
+            repoName: "workspaces",
+            repoLocalPath: "/Users/dev/code/workspaces",
+            workspaceID: kind == .workspaceRecordMissingDirectory ? UUID() : nil,
+            workspaceName: resourceName,
+            resourceName: resourceName,
+            path: "/Users/dev/code/workspaces/.workspaces/\(resourceName)",
+            storagePath: kind == .lumeVMWithoutWorkspace ? "/Users/dev/.lume/workspaces" : nil,
+            gitBranch: "feature/\(resourceName)",
+            hasPrunableGitMetadata: kind == .workspaceRecordMissingDirectory
+        )
+    }
+
+    private func render(
+        _ state: WorkspaceOrphanReconciliationState,
+        to fileName: String
+    ) throws {
+        let banner = WorkspaceOrphanReconciliationBanner(
+            items: state.visibleItems,
+            cleaningItemIDs: state.cleaningItemIDs,
+            onClean: { _ in },
+            onDismiss: {}
+        )
+        .frame(width: 720)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .environment(\.colorScheme, .light)
+
+        let renderer = ImageRenderer(content: banner)
+        renderer.scale = 2
+        let image = try #require(renderer.nsImage)
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+
+        guard let dir = ProcessInfo.processInfo.environment["WORKSPACES_EVIDENCE_DIR"],
+            let tiff = image.tiffRepresentation,
+            let bitmap = NSBitmapImageRep(data: tiff),
+            let png = bitmap.representation(using: .png, properties: [:])
+        else {
+            return
+        }
+        try png.write(to: URL(fileURLWithPath: dir).appendingPathComponent(fileName))
+    }
+
+    @Test("Banner renders every scanned leftover kind")
+    func rendersAllScannedItems() throws {
+        var state = WorkspaceOrphanReconciliationState()
+        state.applyScanResult([
+            makeItem(id: "git", kind: .gitWorktreeWithoutRecord, resourceName: "stale-worktree"),
+            makeItem(
+                id: "record", kind: .workspaceRecordMissingDirectory, resourceName: "missing-dir"),
+            makeItem(id: "lume", kind: .lumeVMWithoutWorkspace, resourceName: "orphan-vm"),
+        ])
+
+        #expect(state.visibleItems.count == 3)
+        try render(state, to: "orphan-banner-all-items.png")
+    }
+
+    @Test("Banner shows only the leftover found after a dismissal")
+    func rendersOnlyNewItemAfterDismissal() throws {
+        var state = WorkspaceOrphanReconciliationState()
+        let existing = makeItem(
+            id: "git", kind: .gitWorktreeWithoutRecord, resourceName: "stale-worktree")
+        state.applyScanResult([existing])
+        state.dismissVisibleItems()
+
+        state.applyScanResult([
+            existing,
+            makeItem(id: "lume", kind: .lumeVMWithoutWorkspace, resourceName: "orphan-vm"),
+        ])
+
+        #expect(state.visibleItems.map(\.id) == ["lume"])
+        try render(state, to: "orphan-banner-after-dismissal.png")
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/WorkspaceOrphanReconciliationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspaceOrphanReconciliationControllerTests.swift
@@ -44,10 +44,10 @@ struct WorkspaceOrphanReconciliationControllerTests {
         )
     }
 
-    private func makeContext() throws -> ModelContext {
+    private func makeContainer() throws -> ModelContainer {
         let schema = Schema([Repo.self, Workspace.self, WebSource.self])
         let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
-        return ModelContext(try ModelContainer(for: schema, configurations: [configuration]))
+        return try ModelContainer(for: schema, configurations: [configuration])
     }
 
     // MARK: - Visibility and dismissal
@@ -88,23 +88,50 @@ struct WorkspaceOrphanReconciliationControllerTests {
 
     // MARK: - Cleanup in flight
 
-    @Test("A second confirmation while a cleanup is running is ignored")
-    func repeatCleanupIsRejectedWhileInFlight() {
+    @Test("An in-flight cleanup reports itself so a second confirmation is skipped")
+    func inFlightCleanupIsObservable() {
         var state = WorkspaceOrphanReconciliationState()
         let item = makeItem(id: "a")
         state.applyScanResult([item])
 
-        let startedFirst = state.beginCleaning(item)
-        let startedAgain = state.beginCleaning(item)
-        #expect(startedFirst)
-        #expect(startedAgain == false)
+        #expect(state.isCleaning(item) == false)
+        state.beginCleaning(item)
         #expect(state.isCleaning(item))
 
         state.endCleaning(item)
         #expect(state.isCleaning(item) == false)
+    }
 
-        let startedAfterFinishing = state.beginCleaning(item)
-        #expect(startedAfterFinishing)
+    @Test("Two cleanups in flight track independently")
+    func concurrentCleanupsAreTrackedSeparately() {
+        var state = WorkspaceOrphanReconciliationState()
+        let first = makeItem(id: "a")
+        let second = makeItem(id: "b")
+        state.applyScanResult([first, second])
+
+        state.beginCleaning(first)
+        state.beginCleaning(second)
+        #expect(state.cleaningItemIDs == ["a", "b"])
+
+        state.endCleaning(first)
+        #expect(state.isCleaning(first) == false)
+        #expect(state.isCleaning(second))
+    }
+
+    @Test("A rescan landing mid-confirmation leaves the pending item and in-flight set alone")
+    func scanDoesNotDisturbPendingOrInFlightState() {
+        var state = WorkspaceOrphanReconciliationState()
+        let pending = makeItem(id: "a")
+        let cleaning = makeItem(id: "b")
+        state.applyScanResult([pending, cleaning])
+        state.pendingCleanup = pending
+        state.beginCleaning(cleaning)
+
+        state.applyScanResult([pending, cleaning, makeItem(id: "c")])
+
+        #expect(state.pendingCleanup == pending)
+        #expect(state.isCleaning(cleaning))
+        #expect(state.visibleItems.map(\.id) == ["a", "b", "c"])
     }
 
     @Test("A cleaned item leaves the banner and forgets its dismissal")
@@ -156,9 +183,10 @@ struct WorkspaceOrphanReconciliationControllerTests {
 
     // MARK: - Record deletion
 
-    @Test("Deleting a record removes the workspace it names")
-    func deleteWorkspaceRecordRemovesWorkspace() throws {
-        let context = try makeContext()
+    @Test("Deleting a record persists — a fresh context no longer sees the workspace")
+    func deleteWorkspaceRecordPersistsTheDeletion() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
         let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
         let workspace = Workspace(
             name: "feature-a",
@@ -168,6 +196,7 @@ struct WorkspaceOrphanReconciliationControllerTests {
         repo.workspaces = [workspace]
         context.insert(repo)
         context.insert(workspace)
+        try context.save()
 
         let item = makeItem(
             id: "record",
@@ -176,13 +205,16 @@ struct WorkspaceOrphanReconciliationControllerTests {
         )
         try controller.deleteWorkspaceRecord(for: item, in: [repo], modelContext: context)
 
-        let remaining = try context.fetch(FetchDescriptor<Workspace>())
-        #expect(remaining.isEmpty)
+        // A second context over the same container only sees saved state, so this fails if
+        // the delete were left unsaved in the first context.
+        let verificationContext = ModelContext(container)
+        #expect(try verificationContext.fetch(FetchDescriptor<Workspace>()).isEmpty)
+        #expect(try verificationContext.fetch(FetchDescriptor<Repo>()).count == 1)
     }
 
     @Test("Deleting a record for an unknown workspace is rejected, not silently skipped")
     func deleteWorkspaceRecordRejectsUnknownWorkspace() throws {
-        let context = try makeContext()
+        let context = ModelContext(try makeContainer())
         let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
         context.insert(repo)
 
@@ -199,7 +231,7 @@ struct WorkspaceOrphanReconciliationControllerTests {
 
     @Test("A worktree orphan carries no workspace id, so record deletion is rejected")
     func deleteWorkspaceRecordRejectsItemWithoutWorkspaceID() throws {
-        let context = try makeContext()
+        let context = ModelContext(try makeContainer())
         let item = makeItem(id: "git", kind: .gitWorktreeWithoutRecord, workspaceID: nil)
 
         #expect(throws: WorkspaceOrphanReconciliationError.unsupportedCleanupItem) {
@@ -226,26 +258,38 @@ struct WorkspaceOrphanReconciliationControllerTests {
 
     // MARK: - Snapshots and copy
 
-    @Test("Repository snapshots carry the fields the reconciler matches on")
-    func repositorySnapshotsPreserveWorkspaceFields() {
+    /// Every field the reconciler matches on, so a mis-wired snapshot field fails here rather
+    /// than becoming a silently missed or falsely reported orphan.
+    @Test("Repository snapshots carry every field the reconciler matches on")
+    func repositorySnapshotsPreserveWorkspaceFields() throws {
         let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
         let workspace = Workspace(
             name: "feature-a",
             path: URL(fileURLWithPath: "/tmp/alpha/workspaces/feature-a"),
-            sourceRepo: repo
+            sourceRepo: repo,
+            gitBranch: "feature/a"
         )
+        workspace.remoteId = "remote-123"
+        workspace.backendMetadataRaw = "{\"vmName\":\"vm-a\"}"
         repo.workspaces = [workspace]
 
         let snapshots = controller.repositorySnapshots(repos: [repo])
+        let snapshot = try #require(snapshots.first)
+        let workspaceSnapshot = try #require(snapshot.workspaces.first)
 
         #expect(snapshots.count == 1)
-        #expect(snapshots[0].id == repo.id)
-        #expect(snapshots[0].name == "alpha")
-        #expect(snapshots[0].localPath == repo.localPath)
-        #expect(snapshots[0].workspaces.count == 1)
-        #expect(snapshots[0].workspaces[0].id == workspace.id)
-        #expect(snapshots[0].workspaces[0].path == workspace.path)
-        #expect(snapshots[0].workspaces[0].backendIdentifier == workspace.backendIdentifier)
+        #expect(snapshot.id == repo.id)
+        #expect(snapshot.name == repo.name)
+        #expect(snapshot.localPath == repo.localPath)
+        #expect(snapshot.workspaces.count == 1)
+        #expect(workspaceSnapshot.id == workspace.id)
+        #expect(workspaceSnapshot.name == workspace.name)
+        #expect(workspaceSnapshot.path == workspace.path)
+        #expect(workspaceSnapshot.gitBranch == workspace.gitBranch)
+        #expect(workspaceSnapshot.backendIdentifier == workspace.backendIdentifier)
+        #expect(workspaceSnapshot.remoteId == workspace.remoteId)
+        #expect(workspaceSnapshot.backendMetadataRaw == workspace.backendMetadataRaw)
+        #expect(workspaceSnapshot.usesHostWorkspaceFiles == workspace.usesHostWorkspaceFiles)
     }
 
     @Test("Confirmation copy names what the destructive action removes")

--- a/Tests/WorkspaceManagerAppTests/WorkspaceOrphanReconciliationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspaceOrphanReconciliationControllerTests.swift
@@ -1,0 +1,272 @@
+//
+//  WorkspaceOrphanReconciliationControllerTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Coverage for the main window's leftover-cleanup bookkeeping: which scanned orphans stay
+//  visible across rescans, and what a confirmed cleanup does for each orphan kind.
+//
+
+import Foundation
+import SwiftData
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@MainActor
+@Suite("WorkspaceOrphanReconciliation")
+struct WorkspaceOrphanReconciliationControllerTests {
+    private let controller = WorkspaceOrphanReconciliationController()
+
+    // MARK: - Fixtures
+
+    private func makeItem(
+        id: String,
+        kind: WorkspaceOrphanKind = .gitWorktreeWithoutRecord,
+        workspaceID: UUID? = nil,
+        resourceName: String = "leftover",
+        hasPrunableGitMetadata: Bool = false,
+        storagePath: String? = nil
+    ) -> WorkspaceOrphanItem {
+        WorkspaceOrphanItem(
+            id: id,
+            kind: kind,
+            repoID: nil,
+            repoName: nil,
+            repoLocalPath: nil,
+            workspaceID: workspaceID,
+            workspaceName: nil,
+            resourceName: resourceName,
+            path: "/tmp/workspaces/\(resourceName)",
+            storagePath: storagePath,
+            gitBranch: nil,
+            hasPrunableGitMetadata: hasPrunableGitMetadata
+        )
+    }
+
+    private func makeContext() throws -> ModelContext {
+        let schema = Schema([Repo.self, Workspace.self, WebSource.self])
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        return ModelContext(try ModelContainer(for: schema, configurations: [configuration]))
+    }
+
+    // MARK: - Visibility and dismissal
+
+    @Test("Dismissed items drop out of the banner while the rest stay")
+    func dismissalHidesOnlyVisibleItems() {
+        var state = WorkspaceOrphanReconciliationState()
+        state.applyScanResult([makeItem(id: "a"), makeItem(id: "b")])
+
+        state.dismissVisibleItems()
+
+        #expect(state.visibleItems.isEmpty)
+        #expect(state.items.count == 2)
+    }
+
+    @Test("A leftover found after a dismissal still surfaces the banner")
+    func newItemAfterDismissalIsVisible() {
+        var state = WorkspaceOrphanReconciliationState()
+        state.applyScanResult([makeItem(id: "a")])
+        state.dismissVisibleItems()
+
+        state.applyScanResult([makeItem(id: "a"), makeItem(id: "b")])
+
+        #expect(state.visibleItems.map(\.id) == ["b"])
+    }
+
+    @Test("A dismissed leftover that disappears and returns is offered again")
+    func dismissalDoesNotSurviveTheItemLeavingTheScan() {
+        var state = WorkspaceOrphanReconciliationState()
+        state.applyScanResult([makeItem(id: "a")])
+        state.dismissVisibleItems()
+
+        state.applyScanResult([])
+        state.applyScanResult([makeItem(id: "a")])
+
+        #expect(state.visibleItems.map(\.id) == ["a"])
+    }
+
+    // MARK: - Cleanup in flight
+
+    @Test("A second confirmation while a cleanup is running is ignored")
+    func repeatCleanupIsRejectedWhileInFlight() {
+        var state = WorkspaceOrphanReconciliationState()
+        let item = makeItem(id: "a")
+        state.applyScanResult([item])
+
+        let startedFirst = state.beginCleaning(item)
+        let startedAgain = state.beginCleaning(item)
+        #expect(startedFirst)
+        #expect(startedAgain == false)
+        #expect(state.isCleaning(item))
+
+        state.endCleaning(item)
+        #expect(state.isCleaning(item) == false)
+
+        let startedAfterFinishing = state.beginCleaning(item)
+        #expect(startedAfterFinishing)
+    }
+
+    @Test("A cleaned item leaves the banner and forgets its dismissal")
+    func cleanedItemIsRemovedWithItsDismissal() {
+        var state = WorkspaceOrphanReconciliationState()
+        let item = makeItem(id: "a")
+        state.applyScanResult([item, makeItem(id: "b")])
+        state.dismissVisibleItems()
+
+        state.removeCleanedItem(item)
+
+        #expect(state.items.map(\.id) == ["b"])
+        #expect(state.dismissedItemIDs == ["b"])
+    }
+
+    // MARK: - Per-kind cleanup steps
+
+    @Test("An orphaned worktree only prunes git")
+    func worktreeWithoutRecordPrunesOnly() {
+        let steps = controller.cleanupSteps(for: makeItem(id: "a", kind: .gitWorktreeWithoutRecord))
+        #expect(steps == [.pruneGitWorktree])
+    }
+
+    @Test("A record with surviving git metadata prunes before the record is deleted")
+    func recordWithPrunableMetadataPrunesFirst() {
+        let item = makeItem(
+            id: "a",
+            kind: .workspaceRecordMissingDirectory,
+            hasPrunableGitMetadata: true
+        )
+        #expect(controller.cleanupSteps(for: item) == [.pruneGitWorktree, .deleteWorkspaceRecord])
+    }
+
+    @Test("A record with nothing left to prune only deletes the record")
+    func recordWithoutPrunableMetadataSkipsPrune() {
+        let item = makeItem(
+            id: "a",
+            kind: .workspaceRecordMissingDirectory,
+            hasPrunableGitMetadata: false
+        )
+        #expect(controller.cleanupSteps(for: item) == [.deleteWorkspaceRecord])
+    }
+
+    @Test("An orphaned Lume VM only deletes the VM")
+    func lumeOrphanDeletesVM() {
+        let steps = controller.cleanupSteps(for: makeItem(id: "a", kind: .lumeVMWithoutWorkspace))
+        #expect(steps == [.deleteLumeVM])
+    }
+
+    // MARK: - Record deletion
+
+    @Test("Deleting a record removes the workspace it names")
+    func deleteWorkspaceRecordRemovesWorkspace() throws {
+        let context = try makeContext()
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let workspace = Workspace(
+            name: "feature-a",
+            path: URL(fileURLWithPath: "/tmp/alpha/workspaces/feature-a"),
+            sourceRepo: repo
+        )
+        repo.workspaces = [workspace]
+        context.insert(repo)
+        context.insert(workspace)
+
+        let item = makeItem(
+            id: "record",
+            kind: .workspaceRecordMissingDirectory,
+            workspaceID: workspace.id
+        )
+        try controller.deleteWorkspaceRecord(for: item, in: [repo], modelContext: context)
+
+        let remaining = try context.fetch(FetchDescriptor<Workspace>())
+        #expect(remaining.isEmpty)
+    }
+
+    @Test("Deleting a record for an unknown workspace is rejected, not silently skipped")
+    func deleteWorkspaceRecordRejectsUnknownWorkspace() throws {
+        let context = try makeContext()
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        context.insert(repo)
+
+        let item = makeItem(
+            id: "record",
+            kind: .workspaceRecordMissingDirectory,
+            workspaceID: UUID()
+        )
+
+        #expect(throws: WorkspaceOrphanReconciliationError.unsupportedCleanupItem) {
+            try controller.deleteWorkspaceRecord(for: item, in: [repo], modelContext: context)
+        }
+    }
+
+    @Test("A worktree orphan carries no workspace id, so record deletion is rejected")
+    func deleteWorkspaceRecordRejectsItemWithoutWorkspaceID() throws {
+        let context = try makeContext()
+        let item = makeItem(id: "git", kind: .gitWorktreeWithoutRecord, workspaceID: nil)
+
+        #expect(throws: WorkspaceOrphanReconciliationError.unsupportedCleanupItem) {
+            try controller.deleteWorkspaceRecord(for: item, in: [], modelContext: context)
+        }
+    }
+
+    @Test("A Lume orphan without storage has no cleanup target and is rejected")
+    func deleteLumeVMRejectsItemWithoutStorage() async throws {
+        let item = makeItem(id: "lume", kind: .lumeVMWithoutWorkspace, storagePath: nil)
+
+        do {
+            try await controller.deleteLumeVM(
+                for: item,
+                registry: WorkspaceProviderRegistry(providers: [])
+            )
+            Issue.record("Expected the cleanup to be rejected")
+        } catch {
+            #expect(
+                error as? WorkspaceOrphanReconciliationError == .unsupportedCleanupItem
+            )
+        }
+    }
+
+    // MARK: - Snapshots and copy
+
+    @Test("Repository snapshots carry the fields the reconciler matches on")
+    func repositorySnapshotsPreserveWorkspaceFields() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let workspace = Workspace(
+            name: "feature-a",
+            path: URL(fileURLWithPath: "/tmp/alpha/workspaces/feature-a"),
+            sourceRepo: repo
+        )
+        repo.workspaces = [workspace]
+
+        let snapshots = controller.repositorySnapshots(repos: [repo])
+
+        #expect(snapshots.count == 1)
+        #expect(snapshots[0].id == repo.id)
+        #expect(snapshots[0].name == "alpha")
+        #expect(snapshots[0].localPath == repo.localPath)
+        #expect(snapshots[0].workspaces.count == 1)
+        #expect(snapshots[0].workspaces[0].id == workspace.id)
+        #expect(snapshots[0].workspaces[0].path == workspace.path)
+        #expect(snapshots[0].workspaces[0].backendIdentifier == workspace.backendIdentifier)
+    }
+
+    @Test("Confirmation copy names what the destructive action removes")
+    func confirmationCopyIsKindSpecific() {
+        let worktree = makeItem(id: "a", kind: .gitWorktreeWithoutRecord, resourceName: "feature-a")
+        let record = makeItem(
+            id: "b", kind: .workspaceRecordMissingDirectory, resourceName: "feature-b")
+        let vm = makeItem(id: "c", kind: .lumeVMWithoutWorkspace, resourceName: "vm-c")
+
+        #expect(controller.confirmationTitle(for: worktree) == "Remove Orphaned Worktree?")
+        #expect(controller.confirmationTitle(for: record) == "Remove Missing Workspace Record?")
+        #expect(controller.confirmationTitle(for: vm) == "Delete Orphaned Lume VM?")
+
+        #expect(controller.confirmationMessage(for: worktree).contains("feature-a"))
+        #expect(controller.confirmationMessage(for: record).contains("feature-b"))
+        #expect(controller.confirmationMessage(for: vm).contains("vm-c"))
+    }
+
+    @Test("With no pending item the alert falls back to generic copy")
+    func confirmationCopyWithoutItem() {
+        #expect(controller.confirmationTitle(for: nil) == "Clean Workspace Leftover?")
+        #expect(controller.confirmationMessage(for: nil).isEmpty)
+    }
+}


### PR DESCRIPTION
Slice 1 of the `ContentView` decomposition. Refs #1160 — the issue stays open across slices, so no `Closes`.

The [slicing plan](https://github.com/fairchild/workspaces/issues/1160#issuecomment-5174510130) is posted on the issue: six ordered slices, each extracting one coherent cluster with its own tests, each leaving the app fully working. This is the first.

## What moves

The workspace-leftover cleanup cluster — four `@State` properties and eight functions — leaves the 3,787-line view struct for two new types:

- **`WorkspaceOrphanReconciliationState`** — a value struct holding the scanned items, per-item dismissals, in-flight cleanups, and the pending confirmation. Collapses `workspaceOrphanItems` / `dismissedWorkspaceOrphanItemIDs` / `cleaningWorkspaceOrphanItemIDs` / `pendingWorkspaceOrphanCleanup` into one `@State`, the `MainWindowViewState` pattern.
- **`WorkspaceOrphanReconciliationController`** — a `@MainActor` struct of projections and scoped effects: repo snapshots for the scan, the per-kind cleanup decision, record/VM deletion, and the confirmation copy. The `InspectorStateController` pattern, so the decision table is assertable without a window.

The interesting piece is `cleanupSteps(for:)`, which turns the inline `switch item.kind` (with its nested `hasPrunableGitMetadata` branch) into an ordered `[CleanupStep]`. That's what makes "a record whose directory is gone prunes the worktree first only when git metadata survives" a test rather than a comment.

`ContentView` drops 91 lines and goes from 35 `@State` to 32.

## Verification

- `swift build` clean; `swift test` — 1,346 tests in 200 suites, all passing on the final run. An earlier run flaked once on `WebNextServerService` "stop escalates to SIGKILL when the leader dies but a member ignores SIGTERM" (process-signal timing under parallel load); it passed 3/3 in isolation and doesn't touch this diff's files. Noting it because it's load-sensitive and may resurface in CI.
- `mise run lint` (`swift-format lint --strict`) clean.
- 20 new tests across two suites: the visibility/dismissal rules, the in-flight guard and two concurrent cleanups, a rescan landing mid-confirmation, the per-kind cleanup steps, record deletion against an in-memory `ModelContext` (including both rejection paths), snapshot field preservation, and confirmation copy.
- The record-deletion test was mutation-checked: removing `try modelContext.save()` from the controller makes it fail, so it proves persistence rather than in-context state.

## Evidence

The live debug app, launched through the fixture lane with no activation, showing the real banner driven by the extracted state — a real scan of this machine found 5 leftovers:

![phase-1-release](https://evidence.cloudcompute.com/workspaces/pr-1186/20260804-044514-phase-1-release.png)

`ImageRenderer` captures of the banner fed from `WorkspaceOrphanReconciliationState` directly, since the populated banner is a transient surface a fixture can't stage. Three scanned kinds, then the same state after a dismissal plus a rescan that finds one new leftover — the dismissal rule, rendered:

![orphan-banner-all-items](https://evidence.cloudcompute.com/workspaces/pr-1186/20260804-044513-orphan-banner-all-items.png)

![orphan-banner-after-dismissal](https://evidence.cloudcompute.com/workspaces/pr-1186/20260804-044514-orphan-banner-after-dismissal.png)

## Review loop

Reflected on the diff, then a directed codex review (`gpt-5.6-sol`, xhigh) aimed at six named failure modes plus a falsifiable completeness question: enumerate every symbol deleted from `ContentView` and say where its behavior now lives.

Verdict: **no blocking behavior change — functionally a pure extraction.** All ten deleted symbols mapped to an equivalent replacement; the cleanup ordering, dismissal rule, alert identity, SwiftData save/rollback, and the `workspace_orphan_scan` perf line all came back unchanged. It also checked the argument-evaluation order of the two `await`s now inside `makeWorkspaceOrphanReconciler()` against SE-0411, and read the sibling #1177 logger-category diff for interaction (none — it renames declarations this slice doesn't touch).

Three Low findings, all in `ac7abe89`:

1. **`@State` writeback topology not identical.** A rejected repeat confirmation used to only *read* the cleaning set; the returning-`Bool` `beginCleaning` wrote the whole struct back regardless. Fixed — `beginCleaning` no longer returns, and callers guard on the non-mutating `isCleaning` first.
2. **Render tests don't prove `ContentView`'s wiring.** They'd pass if the view passed `items` instead of `visibleItems`. Declined: proving that needs a hosted view. The live fixture screenshot above exercises the real path.
3. **Three assertions could pass against a wrong extraction.** Fixed — record deletion now verifies through a second `ModelContext` over the same container (mutation-checked), snapshot coverage extends to every field the reconciler matches on, and new cases cover two cleanups in flight and a rescan landing mid-confirmation.

## Mergeability

- Surface: desktop — main window leftover-cleanup banner and its confirmation alert
- User-facing behavior changed: No. Extraction only — the scan, the per-kind cleanup, the banner, and the alert copy are byte-identical in effect. The live screenshot above is the same banner from the same code path.
- Non-happy paths considered: cleanup failure surfaces through the same `presentWorkspaceOperationError` with the same message; a repeat confirmation while a cleanup is in flight is still ignored, and still without writing state back (`guard !isCleaning` before `beginCleaning`, matching the original's read-only reject); partial failure after a successful prune still aborts before record deletion; a cleanup item with no workspace id or no Lume storage still throws `unsupportedCleanupItem`; dismissals still expire when the item leaves the scan.
- Residual risk or follow-up: Four separate `@State` writes became mutating calls on one coalesced `@State` value, so SwiftUI now invalidates on the whole struct. Every mutation is `@MainActor`-serialized and each previously invalidated the view too, so this should be inert — it is the main thing worth a reviewer's eye. Slices 2–6 are queued on the issue and dispatched after this merges.
