### PR TITLE
ci: markdown link-check gate + repair broken internal refs

### DIFF
--- a/.agents/workspaces/README.md
+++ b/.agents/workspaces/README.md
@@ -25,4 +25,4 @@ Open `index.html` in a browser — the JS detects the missing webkit handler and
 
 ## Bridge
 
-The app pushes live workspace data to `window.RepoLanding.onData(data)` and listens for actions via `window.webkit.messageHandlers.repoLanding.postMessage({ action, ... })`. See [docs/development/repo-landing-overrides.md](../../docs/development/repo-landing-overrides.md) for the full contract.
+The app pushes live workspace data to `window.RepoLanding.onData(data)` and listens for actions via `window.webkit.messageHandlers.repoLanding.postMessage({ action, ... })`. See `RepoLandingView.swift` for the full contract.

--- a/.agents/workspaces/README.md
+++ b/.agents/workspaces/README.md
@@ -1,5 +1,10 @@
 # .agents/workspaces — Repo Landing Override
 
+> **Not currently wired up.** Commit `a7569b39` ("refine main window navigation and
+> simplify sidebar chrome") replaced this WKWebView-based override with a native SwiftUI
+> `RepoLandingView`; there is no WebKit bridge or `.agents/workspaces/index.html`
+> override-loading path in the app anymore. This directory describes the prior design.
+
 This directory replaces the native SwiftUI landing page with a custom HTML dashboard when you click this repo in the sidebar.
 
 ## How it works
@@ -25,4 +30,4 @@ Open `index.html` in a browser — the JS detects the missing webkit handler and
 
 ## Bridge
 
-The app pushes live workspace data to `window.RepoLanding.onData(data)` and listens for actions via `window.webkit.messageHandlers.repoLanding.postMessage({ action, ... })`. See `RepoLandingView.swift` for the full contract.
+The app pushed live workspace data to `window.RepoLanding.onData(data)` and listened for actions via `window.webkit.messageHandlers.repoLanding.postMessage({ action, ... })`, per the design this directory describes. Current `RepoLandingView.swift` is native SwiftUI and has no such bridge.

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,23 +1,18 @@
 # Catches the "git mv a plan into backlog/done/ and nothing re-points
 # referrers" breakage class before merge — see issue #1155. Deliberately its
 # own workflow (not a job in ci.yml): ci.yml's path filter keeps the
-# expensive macOS build scoped to product/build/release inputs, and this
-# check is a fast, docs-scoped, ubuntu-latest job that shouldn't ride along
-# with every doc change on that filter.
+# expensive macOS build scoped to product/build/release inputs, and this is
+# a fast, docs-scoped, ubuntu-latest job that shouldn't ride along with that
+# filter. Unfiltered trigger (no `paths:`): the file that goes stale is
+# often not the .md that references it — a git mv of the *target* (a
+# script, an image, a renamed non-.md file) leaves no .md diff to filter on,
+# so this has to run on every push/PR to actually catch that case.
 name: Docs Link Check
 
 on:
   push:
     branches: [main]
-    paths:
-      - "**/*.md"
-      - "scripts/check-markdown-links.py"
-      - ".github/workflows/docs-link-check.yml"
   pull_request:
-    paths:
-      - "**/*.md"
-      - "scripts/check-markdown-links.py"
-      - ".github/workflows/docs-link-check.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,0 +1,38 @@
+# Catches the "git mv a plan into backlog/done/ and nothing re-points
+# referrers" breakage class before merge — see issue #1155. Deliberately its
+# own workflow (not a job in ci.yml): ci.yml's path filter keeps the
+# expensive macOS build scoped to product/build/release inputs, and this
+# check is a fast, docs-scoped, ubuntu-latest job that shouldn't ride along
+# with every doc change on that filter.
+name: Docs Link Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - "scripts/check-markdown-links.py"
+      - ".github/workflows/docs-link-check.yml"
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "scripts/check-markdown-links.py"
+      - ".github/workflows/docs-link-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-link-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+      - name: Check Markdown links
+        run: uv run scripts/check-markdown-links.py

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -540,7 +540,7 @@ security find-identity -v -p codesigning
 | `scripts/prepare-prerelease.sh` | Prepare tester-prerelease version/build metadata and changelog notes for a PR |
 | `scripts/notarize.sh` | Create DMG and notarize |
 | `scripts/setup-release-secrets.sh` | Configure GitHub Actions release secrets/variables from a verified `.p12` and provisioning profile |
-| `scripts/signing-config.sh` | Your signing credentials (not in git) |
+| `scripts/signing-config.sh.template` | Copy to `scripts/signing-config.sh` and fill in your signing credentials (gitignored, not in git) |
 
 ---
 

--- a/docs/daytona-vm.md
+++ b/docs/daytona-vm.md
@@ -126,4 +126,4 @@ Only one remote connection can be in-flight at a time. Clicking a second cloud w
 
 ## Future Work
 
-See `backlog/daytona-native-swift-api-plan.md` — replace the Python CLI bridge with direct URLSession calls to the Daytona REST API, eliminating the `uv`/Python dependency and enabling streaming progress updates.
+See `backlog/done/daytona-native-swift-api-plan.md` — replace the Python CLI bridge with direct URLSession calls to the Daytona REST API, eliminating the `uv`/Python dependency and enabling streaming progress updates.

--- a/docs/decisions/terminal-multiplexing.md
+++ b/docs/decisions/terminal-multiplexing.md
@@ -6,10 +6,10 @@ superseded-by: docs/decisions/tile-tree-surface-abstraction.md
 supersedes:
   - backlog/done/pane-tree-tiling_plan.md
   - backlog/done/terminal-multiplexing-decision_plan.md
-implements: backlog/tmux-support_plan.md
+implements: backlog/done/tmux-support_plan.md
 related:
-  - backlog/desktop-continuity_plan.md
-  - backlog/terminal-architecture-followups.md
+  - backlog/done/desktop-continuity_plan.md
+  - backlog/done/terminal-architecture-followups.md
 ---
 
 # Terminal Multiplexing Model
@@ -27,7 +27,7 @@ related:
 Scope:
 
 - Applies to the macOS app's main terminal panel.
-- The current two-pane Ghostty-managed split stays the default until `backlog/tmux-support_plan.md` ships its first phase. There is no immediate user-visible change.
+- The current two-pane Ghostty-managed split stays the default until `backlog/done/tmux-support_plan.md` ships its first phase. There is no immediate user-visible change.
 - Web/sandbox terminal is out of scope; it already uses tmux-in-sandbox for reattach (#311 → #324).
 
 ## The question that drove the decision
@@ -45,7 +45,7 @@ Continuity is what users actually want from a long-lived terminal-first agent wo
 
 ## Why pane-tree did not win
 
-Pane-tree is a coherent, well-specified plan. It loses on cost-vs-value, not on craft. The cohesive `Cmd+*` muscle-memory story (often cited as a reason to own the layout) is real, but `Ctrl+B`'s prefix model avoids direct collision with current app-owned shortcuts (confirmed in `backlog/tmux-support_plan.md`), and users who already live in tmux carry the prefix model with them.
+Pane-tree is a coherent, well-specified plan. It loses on cost-vs-value, not on craft. The cohesive `Cmd+*` muscle-memory story (often cited as a reason to own the layout) is real, but `Ctrl+B`'s prefix model avoids direct collision with current app-owned shortcuts (confirmed in `backlog/done/tmux-support_plan.md`), and users who already live in tmux carry the prefix model with them.
 
 ## Why hybrid did not win
 
@@ -57,14 +57,14 @@ Freeze was tempting given the desktop P0 set is already crowded. The reason not 
 
 ## What changes
 
-- `backlog/tmux-support_plan.md` is promoted from awaiting-decision to active P1.
-- `backlog/pane-tree-tiling_plan.md` is archived to `backlog/done/` with a pointer to this record.
-- `backlog/terminal-multiplexing-decision_plan.md` is archived to `backlog/done/`; its purpose is fulfilled by this record.
-- `backlog/desktop-continuity_plan.md` is added — a separate plan for the continuity gap. Tmux delivers reattach within a session; it does not deliver across-session restore on desktop. That is its own problem, and acknowledging it is what makes the decision honest.
+- `backlog/done/tmux-support_plan.md` is promoted from awaiting-decision to active P1.
+- `backlog/done/pane-tree-tiling_plan.md` is archived to `backlog/done/` with a pointer to this record.
+- `backlog/done/terminal-multiplexing-decision_plan.md` is archived to `backlog/done/`; its purpose is fulfilled by this record.
+- `backlog/done/desktop-continuity_plan.md` is added — a separate plan for the continuity gap. Tmux delivers reattach within a session; it does not deliver across-session restore on desktop. That is its own problem, and acknowledging it is what makes the decision honest.
 
 ## What does not change
 
-- The current two-pane split UX. Until `backlog/tmux-support_plan.md` ships its mode-transition phase, users see exactly today's behavior.
+- The current two-pane split UX. Until `backlog/done/tmux-support_plan.md` ships its mode-transition phase, users see exactly today's behavior.
 - Web/sandbox tmux behavior (already shipped via #311 → #324).
 - The `Cmd+D` / `Cmd+Shift+D` shortcuts. They continue to drive Ghostty splits in the default mode; tmux's `Ctrl+B` prefix layers on top in tmux mode.
 
@@ -76,13 +76,13 @@ Reopen this decision if any of the following hold:
 - A continuity story emerges that the desktop continuity plan cannot solve, and that story turns out to be layout-shape-dependent (i.e., the user really did want a pane-tree to restore).
 - An external constraint (App Store policy, a Ghostty upstream change, a tmux dep regression) makes the tmux path materially more expensive than the current estimate.
 
-The next checkpoint is the first phase of `backlog/tmux-support_plan.md`. If that phase lands cleanly and continuity work is in motion, this decision stays.
+The next checkpoint is the first phase of `backlog/done/tmux-support_plan.md`. If that phase lands cleanly and continuity work is in motion, this decision stays.
 
 ## Related
 
-- `backlog/tmux-support_plan.md` — implementation
-- `backlog/desktop-continuity_plan.md` — the separate continuity problem this decision exposes
+- `backlog/done/tmux-support_plan.md` — implementation
+- `backlog/done/desktop-continuity_plan.md` — the separate continuity problem this decision exposes
 - `backlog/done/pane-tree-tiling_plan.md` — archived alternative
 - `backlog/done/terminal-multiplexing-decision_plan.md` — the decision-session brief that produced this record
-- `backlog/terminal-architecture-followups.md` — items the implementation will touch
+- `backlog/done/terminal-architecture-followups.md` — items the implementation will touch
 - PRs: #311 / #312 / #315 / #324 — tmux-in-sandbox capability + clarification

--- a/docs/development/claude-code-integration.md
+++ b/docs/development/claude-code-integration.md
@@ -6,7 +6,7 @@ native UI: sidebar status, live status fields, macOS notifications, tab titles
 from terminal state, and transcript viewing.
 
 This document describes the shipped architecture. Deferred programmatic/headless
-Claude work is tracked separately in `backlog/headless-claude-programmatic-runner.md`.
+Claude work is tracked separately in `backlog/done/headless-claude-programmatic-runner.md`.
 
 ## Agent Update Intake
 
@@ -298,7 +298,7 @@ Supported consumption shapes:
 Known transcript record types get richer rendering. Unknown records decode to an
 opaque JSON case and render collapsed. Transcript data is not used to reconstruct
 registry state on app launch. If crash recovery becomes necessary, prefer a
-host-owned durable `AgentEvent` log; see `backlog/agent-event-log-recovery.md`.
+host-owned durable `AgentEvent` log; see `backlog/done/agent-event-log-recovery.md`.
 
 ## Settings Installer
 
@@ -418,9 +418,9 @@ Perf suites remain opt-in with `WORKSPACES_PERF_RUN=1`.
 ## Deferred Ideas
 
 - Programmatic/headless Claude execution:
-  `backlog/headless-claude-programmatic-runner.md`
+  `backlog/done/headless-claude-programmatic-runner.md`
 - Host-owned durable event-log recovery:
-  `backlog/agent-event-log-recovery.md`
+  `backlog/done/agent-event-log-recovery.md`
 
 ## Historical PR Sequence
 

--- a/docs/development/terminal-arc-retro-2026-04.md
+++ b/docs/development/terminal-arc-retro-2026-04.md
@@ -178,8 +178,8 @@ time someone touches the area.
 - `web/src/app/dashboard/components/use-terminal-sessions.ts` — created in #302, fixed in #303 (INP) and #305 (reset effect).
 - `web/src/app/dashboard/components/terminal-panel.tsx` — refactored in #302, simplified in #305.
 - `web/src/lib/agent-sessions.ts` — migration for `terminal → shell` rename (#302).
-- `backlog/terminal-polish-followup.md` — rewritten in #306.
-- `backlog/terminal-architecture-followups.md` — renamed + rewritten in #306.
+- `backlog/done/terminal-polish-followup.md` — rewritten in #306.
+- `backlog/done/terminal-architecture-followups.md` — renamed + rewritten in #306.
 - `backlog/terminal-tmux-and-followups-plan.md` — deleted in #306.
 - `docs/development/agent-chat-sandbox.md` — auth section added (this retrospective's PR).
 

--- a/docs/performance/2026-04-08-global-slowness-learnings.md
+++ b/docs/performance/2026-04-08-global-slowness-learnings.md
@@ -8,8 +8,8 @@ This file is the short reference for the current Workspaces performance investig
 
 Use it together with:
 
-- [investigation-2026-04-07-global-slowness-and-input-latency.md](/Users/fairchild/.worktrees/workspaces/codex/workspaces-perf-optimization/docs/performance/investigation-2026-04-07-global-slowness-and-input-latency.md)
-- [investigation-2026-04-07-global-slowness-and-input-latency-log.md](/Users/fairchild/.worktrees/workspaces/codex/workspaces-perf-optimization/docs/performance/investigation-2026-04-07-global-slowness-and-input-latency-log.md)
+- [investigation-2026-04-07-global-slowness-and-input-latency.md](investigation-2026-04-07-global-slowness-and-input-latency.md)
+- [investigation-2026-04-07-global-slowness-and-input-latency-log.md](investigation-2026-04-07-global-slowness-and-input-latency-log.md)
 
 ## Current Best Read
 

--- a/docs/performance/webview-memory-impact-2026-02-28.md
+++ b/docs/performance/webview-memory-impact-2026-02-28.md
@@ -39,7 +39,7 @@ Interpretation: no measurable idle-memory regression from linking WebKit when th
 Date/time artifact:
 
 - benchmark JSON: `output/tart-webview-benchmark/live/20260228-204558/benchmark.json`
-- script: `scripts/tart-webview-memory-benchmark.sh`
+- script: `scripts/tart-webview-memory-benchmark.sh` (removed as dead in #1168; this benchmark was a one-off)
 - VM: `sequoia-base`
 - binary: `release`
 - runs: `5`

--- a/fixtures/ops-report/README.md
+++ b/fixtures/ops-report/README.md
@@ -1,6 +1,6 @@
 # Ops Report Fixtures
 
-These fixture packs drive [`scripts/ops-report.py`](/Users/fairchild/.codex/worktrees/3272/workspaces/scripts/ops-report.py) in replay mode:
+These fixture packs drive [`scripts/ops-report.py`](../../scripts/ops-report.py) in replay mode:
 
 ```bash
 uv run --script scripts/ops-report.py \
@@ -26,7 +26,7 @@ File shapes should mirror the live GitHub/perf inputs that `ops-report.py` alrea
 - `issues.json`: `gh issue list --json ...` style entries
 - `prs.json`: `gh pr list --json ...` style entries
 - `runs.json`: `gh run list --json ...` style entries
-- perf files: same shape as [`docs/performance/latest-summary.json`](/Users/fairchild/.codex/worktrees/3272/workspaces/docs/performance/latest-summary.json) and [`docs/performance/metrics-history.csv`](/Users/fairchild/.codex/worktrees/3272/workspaces/docs/performance/metrics-history.csv)
+- perf files: same shape as [`docs/performance/latest-summary.json`](../../docs/performance/latest-summary.json) and [`docs/performance/metrics-history.csv`](../../docs/performance/metrics-history.csv)
 
 Scenarios:
 

--- a/prototypes/spaces-dashboard/README.md
+++ b/prototypes/spaces-dashboard/README.md
@@ -76,4 +76,4 @@ Full exploration: `EXPLORATION-llm-driven-dashboard.md`.
 
 ## Next step
 
-`backlog/spaces-agent-discovery-dashboard-plan.md` — Phase 1: build repo scanning + dashboard into the Next.js app.
+`backlog/done/spaces-agent-discovery-dashboard-plan.md` — Phase 1: build repo scanning + dashboard into the Next.js app.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -160,7 +160,7 @@ Use these scripts for day-to-day UI verification:
 - In shared-desktop mode, pair the launch with `./scripts/capture-window.sh` and pause your own input during capture.
 - On startup failure, writes a diagnostics bundle under `.dev-data/logs/launch-diagnostics-<timestamp>/`.
 - Use `./scripts/launch-dev.sh --watch` to keep tailing the launch log until interrupted.
-- See `backlog/isolation-strategies.md` for long-form architecture context.
+- See `backlog/done/isolation-strategies.md` for long-form architecture context.
 
 2. `./scripts/dev-smoke.sh`
 - Fast debug-app startup smoke for local development.

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -8,8 +8,9 @@
 Archiving or renaming a file (e.g. `git mv backlog/foo.md backlog/done/foo.md`)
 does not re-point anything that linked to it — this catches that class of
 breakage before merge. Only real Markdown link syntax `[text](target)` /
-`![alt](target)` is checked; backtick code spans and fenced code blocks are
-stripped first, since those commonly hold illustrative (non-link) paths.
+`![alt](target)` is checked; fenced code blocks and inline code spans are
+stripped first (both commonly hold illustrative, non-link paths), matched by
+delimiter run length like CommonMark, not by naive backtick pairing.
 
 Usage: check-markdown-links.py [PATH ...]  (defaults to repo root)
 Exit 0 if every link resolves, 1 with a per-line report otherwise.
@@ -30,82 +31,119 @@ EXCLUDE_DIRS = {
     ".venv",
     "dist",
     ".next",
-    "backlog",  # fast-churn task ledger with its own archive lifecycle, not reference docs
-    "docs/archive",  # frozen historical snapshot, not maintained
 }
 
-FENCE_RE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
-INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+# Root-scoped: excluded only when rooted at the repo top, not wherever the
+# name happens to appear (docs/backlog/x.md is not backlog/**).
+EXCLUDE_ROOT_PREFIXES = (
+    "backlog/",  # fast-churn task ledger with its own archive lifecycle, not reference docs
+    "docs/archive/",  # frozen historical snapshot, not maintained
+)
+
+FENCE_LINE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+INLINE_CODE_RE = re.compile(r"(`+)(?:(?!\1).)*?\1")
 LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+
+# Known non-path prose fillers ("[Web CI passed](url)", "cp X Y") found by
+# manual audit — exact match only, after stripping any <...> wrapping.
+KNOWN_PLACEHOLDERS = {"url", "link", "run url"}
+
+
+def strip_fenced_code(text: str) -> str:
+    """Blank fenced code-block lines, preserving line count and fence semantics:
+    a closing fence must reuse the opening's character and be >= its length."""
+    out_lines = []
+    fence_char: str | None = None
+    fence_len = 0
+    for line in text.split("\n"):
+        if fence_char is None:
+            m = FENCE_LINE_RE.match(line)
+            if m:
+                fence_char = m.group(1)[0]
+                fence_len = len(m.group(1))
+                out_lines.append("")
+                continue
+            out_lines.append(line)
+        else:
+            stripped = line.strip()
+            if stripped and set(stripped) == {fence_char} and len(stripped) >= fence_len:
+                fence_char = None
+                fence_len = 0
+            out_lines.append("")
+    return "\n".join(out_lines)
 
 
 def strip_non_prose(text: str) -> str:
-    text = FENCE_RE.sub(lambda m: "\n" * m.group(0).count("\n"), text)
+    text = strip_fenced_code(text)
     text = INLINE_CODE_RE.sub("", text)
     return text
 
 
-def is_checkable_target(target: str) -> bool:
-    if target.startswith(("http://", "https://", "mailto:", "tel:", "#")):
-        return False
-    path_part = target.split("#", 1)[0].strip().strip("<>")
-    if not path_part:
-        return False
-    if "." in path_part or "/" in path_part:
+def resolve_target(md_file: Path, repo_root: Path, path_part: str) -> Path | None:
+    """Resolve a link's path component. Returns None for targets that should
+    be reported as broken outright (absolute-path leaks, escapes repo root)."""
+    if path_part.startswith("/"):
+        # Markdown renderers (GitHub included) treat a leading "/" as
+        # relative to the site/domain root, not the repo checkout — never a
+        # valid same-repo relative link, and exactly the class of absolute
+        # local-worktree-path leak this checker exists to catch.
+        return None
+    resolved = (md_file.parent / path_part).resolve()
+    if not resolved.is_relative_to(repo_root):
+        return None
+    return resolved
+
+
+def is_checkable_target(path_part: str) -> bool:
+    return path_part not in KNOWN_PLACEHOLDERS
+
+
+def is_excluded(path: Path, repo_root: Path) -> bool:
+    if any(part in EXCLUDE_DIRS for part in path.parts):
         return True
-    # A bare, all-lowercase word with no path shape ("url", "link", "run
-    # url") is prose-example filler, not a target. A real extensionless
-    # filename (LICENSE, Makefile) always has an uppercase char, so it
-    # still gets checked.
-    if " " in path_part or path_part.islower():
+    try:
+        rel_posix = path.relative_to(repo_root).as_posix()
+    except ValueError:
         return False
-    return True
+    return any(rel_posix.startswith(prefix) for prefix in EXCLUDE_ROOT_PREFIXES)
 
 
-def is_excluded(path: Path) -> bool:
-    posix = f"/{path.as_posix()}/"
-    return any(f"/{excl}/" in posix for excl in EXCLUDE_DIRS)
-
-
-def iter_markdown_files(roots: list[Path]) -> list[Path]:
+def iter_markdown_files(roots: list[Path], repo_root: Path) -> list[Path]:
     files: list[Path] = []
     for root in roots:
         if root.is_file():
             files.append(root)
             continue
-        files.extend(p for p in root.rglob("*.md") if not is_excluded(p))
+        files.extend(p for p in root.rglob("*.md") if not is_excluded(p, repo_root))
     return sorted(set(files))
 
 
-def check_file(md_file: Path, repo_root: Path) -> list[tuple[int, str, str]]:
+def check_file(md_file: Path, repo_root: Path) -> list[tuple[int, str]]:
     problems = []
     raw = md_file.read_text(encoding="utf-8", errors="replace")
     prose = strip_non_prose(raw)
     for lineno, line in enumerate(prose.splitlines(), start=1):
         for m in LINK_RE.finditer(line):
             target = m.group(1).strip()
-            if not is_checkable_target(target):
+            if target.startswith(("http://", "https://", "mailto:", "tel:", "#")):
                 continue
-            path_part = target.split("#", 1)[0].strip()
-            if not path_part:
+            path_part = target.split("#", 1)[0].strip().strip("<>").strip()
+            if not path_part or not is_checkable_target(path_part):
                 continue
-            if path_part.startswith("/"):
-                resolved = (repo_root / path_part.lstrip("/")).resolve()
-            else:
-                resolved = (md_file.parent / path_part).resolve()
-            if not resolved.exists():
-                problems.append((lineno, target, str(resolved)))
+            resolved = resolve_target(md_file, repo_root, path_part)
+            if resolved is None or not resolved.exists():
+                problems.append((lineno, target))
     return problems
 
 
 def main(argv: list[str]) -> int:
     repo_root = Path(__file__).resolve().parent.parent
     roots = [Path(a).resolve() for a in argv] if argv else [repo_root]
-    files = iter_markdown_files(roots)
+    files = iter_markdown_files(roots, repo_root)
 
     total_problems = 0
     for md_file in files:
-        for lineno, target, resolved in check_file(md_file, repo_root):
+        for lineno, target in check_file(md_file, repo_root):
             rel = md_file.relative_to(repo_root) if md_file.is_relative_to(repo_root) else md_file
             print(f"{rel}:{lineno}: broken link -> {target}")
             total_problems += 1

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Check that relative links in Markdown files resolve to real files.
+
+Archiving or renaming a file (e.g. `git mv backlog/foo.md backlog/done/foo.md`)
+does not re-point anything that linked to it — this catches that class of
+breakage before merge. Only real Markdown link syntax `[text](target)` /
+`![alt](target)` is checked; backtick code spans and fenced code blocks are
+stripped first, since those commonly hold illustrative (non-link) paths.
+
+Usage: check-markdown-links.py [PATH ...]  (defaults to repo root)
+Exit 0 if every link resolves, 1 with a per-line report otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+EXCLUDE_DIRS = {
+    ".git",
+    "node_modules",
+    ".build",
+    "DerivedData",
+    ".swiftpm",
+    ".venv",
+    "dist",
+    ".next",
+    "backlog",  # fast-churn task ledger with its own archive lifecycle, not reference docs
+    "docs/archive",  # frozen historical snapshot, not maintained
+}
+
+FENCE_RE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
+INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+
+
+def strip_non_prose(text: str) -> str:
+    text = FENCE_RE.sub(lambda m: "\n" * m.group(0).count("\n"), text)
+    text = INLINE_CODE_RE.sub("", text)
+    return text
+
+
+def is_checkable_target(target: str) -> bool:
+    if target.startswith(("http://", "https://", "mailto:", "tel:", "#")):
+        return False
+    # Placeholder-y example targets ("url", "link", "<run url>") carry no
+    # path shape (no '.' and no '/') and aren't meant to resolve.
+    path_part = target.split("#", 1)[0].strip().strip("<>")
+    return "." in path_part or "/" in path_part
+
+
+def is_excluded(path: Path) -> bool:
+    posix = f"/{path.as_posix()}/"
+    return any(f"/{excl}/" in posix for excl in EXCLUDE_DIRS)
+
+
+def iter_markdown_files(roots: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for root in roots:
+        if root.is_file():
+            files.append(root)
+            continue
+        files.extend(p for p in root.rglob("*.md") if not is_excluded(p))
+    return sorted(set(files))
+
+
+def check_file(md_file: Path, repo_root: Path) -> list[tuple[int, str, str]]:
+    problems = []
+    raw = md_file.read_text(encoding="utf-8", errors="replace")
+    prose = strip_non_prose(raw)
+    for lineno, line in enumerate(prose.splitlines(), start=1):
+        for m in LINK_RE.finditer(line):
+            target = m.group(1).strip()
+            if not is_checkable_target(target):
+                continue
+            path_part = target.split("#", 1)[0].strip()
+            if not path_part:
+                continue
+            if path_part.startswith("/"):
+                resolved = (repo_root / path_part.lstrip("/")).resolve()
+            else:
+                resolved = (md_file.parent / path_part).resolve()
+            if not resolved.exists():
+                problems.append((lineno, target, str(resolved)))
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    roots = [Path(a).resolve() for a in argv] if argv else [repo_root]
+    files = iter_markdown_files(roots)
+
+    total_problems = 0
+    for md_file in files:
+        for lineno, target, resolved in check_file(md_file, repo_root):
+            rel = md_file.relative_to(repo_root) if md_file.is_relative_to(repo_root) else md_file
+            print(f"{rel}:{lineno}: broken link -> {target}")
+            total_problems += 1
+
+    if total_problems:
+        print(f"\n{total_problems} broken link(s) in {len(files)} file(s) checked.")
+        return 1
+
+    print(f"OK: {len(files)} Markdown file(s) checked, no broken relative links.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -48,10 +48,18 @@ def strip_non_prose(text: str) -> str:
 def is_checkable_target(target: str) -> bool:
     if target.startswith(("http://", "https://", "mailto:", "tel:", "#")):
         return False
-    # Placeholder-y example targets ("url", "link", "<run url>") carry no
-    # path shape (no '.' and no '/') and aren't meant to resolve.
     path_part = target.split("#", 1)[0].strip().strip("<>")
-    return "." in path_part or "/" in path_part
+    if not path_part:
+        return False
+    if "." in path_part or "/" in path_part:
+        return True
+    # A bare, all-lowercase word with no path shape ("url", "link", "run
+    # url") is prose-example filler, not a target. A real extensionless
+    # filename (LICENSE, Makefile) always has an uppercase char, so it
+    # still gets checked.
+    if " " in path_part or path_part.islower():
+        return False
+    return True
 
 
 def is_excluded(path: Path) -> bool:

--- a/web/docs/architecture.md
+++ b/web/docs/architecture.md
@@ -89,7 +89,7 @@ The agent runtime executes Claude Code through the `ComputeProviderRegistry` at 
 | `github-actions` | Runner stub | No | Transcript stub |
 | `mock` | In-process test provider | Yes | PTY stub |
 
-> Historical note: `cloudflare-sandbox` was scaffolded alongside the Vercel provider as a multi-provider proof-of-concept. The Worker and provider class were deleted in PR #321 because the scaffold had never been wired to a real Cloudflare account and was sitting in the runtime as ~500 lines of dead code. Design notes preserved in `backlog/cloudflare-sandbox-live-plan.md`.
+> Historical note: `cloudflare-sandbox` was scaffolded alongside the Vercel provider as a multi-provider proof-of-concept. The Worker and provider class were deleted in PR #321 because the scaffold had never been wired to a real Cloudflare account and was sitting in the runtime as ~500 lines of dead code. Design notes preserved in `backlog/done/cloudflare-sandbox-live-plan.md`.
 
 ### Session Lifecycle
 


### PR DESCRIPTION
## Summary

Archiving a plan via `git mv` doesn't re-point anything that linked to it. This PR
re-audits the month-old findings from #1155 against the live tree (several had already
been superseded by other PRs, and one new instance had appeared since) and repairs what's
currently broken:

- Two absolute local-worktree-path leaks (`docs/performance/2026-04-08-global-slowness-learnings.md`,
  `fixtures/ops-report/README.md`) — real markdown links pointing at another machine's
  `/Users/fairchild/.worktrees/...` / `/Users/fairchild/.codex/worktrees/...` path.
- One dangling forward-reference (`.agents/workspaces/README.md` linked to a
  `docs/development/repo-landing-overrides.md` that was never created). Turned out to be a
  bigger find than a link fix: the whole WKWebView bridge that file describes was replaced
  by native SwiftUI in `a7569b39` (2026-03-10) — `RepoLandingView.swift` has no bridge code
  anymore. Corrected the file to say the design is no longer wired up, rather than pointing
  the link at a source that doesn't implement it (caught in codex review, see below).
- ~20 stale `backlog/<name>.md` prose references (backtick mentions, not hyperlinks) to
  plans since archived to `backlog/done/` — worst offenders
  `docs/decisions/terminal-multiplexing.md` and `docs/development/claude-code-integration.md`.
  Only the path pointers were touched; `terminal-multiplexing.md` is marked "retained
  unchanged as historical record" and its reasoning/prose is untouched.
- `RELEASING.md`'s Scripts Reference table pointed at `scripts/signing-config.sh`, which
  only exists locally after copying `scripts/signing-config.sh.template` — repointed at
  the template that actually ships in the repo.
- One genuinely dead script reference (`scripts/tart-webview-memory-benchmark.sh`, deleted
  in #1168) in a dated performance report — annotated rather than silently left dangling.

Several items from the original audit (`docs/agents/triage-labels.md`'s
`scripts/migrate-agent-labels.py` note, the `scripts/setup`/`stop`/`archive` lifecycle-hook
mentions in `README.md`/`docs/product_overview.md`/`docs/user-stories.md`) turned out to be
accurate on re-verification — those describe a convention for repos *managed by*
WorkspaceManager, not files this repo itself needs, or already correctly narrate history in
past tense. Left as-is; re-verifying against the live tree is what the issue asked for.

`backlog/**` and `docs/archive/**` are deliberately out of scope — see Mergeability.

## What's new

- `scripts/check-markdown-links.py` — a small, dependency-free `uv` single-file script
  that checks every `[text](target)` / `![alt](target)` in `*.md` resolves. Fenced code
  blocks and inline code spans are stripped with CommonMark-style delimiter-run matching
  (not naive backtick pairing), external URLs/anchors are skipped, and a leading `/` is
  always flagged as an absolute-path leak rather than silently treated as repo-relative.
- `.github/workflows/docs-link-check.yml` — new, focused workflow (not a job added to
  `ci.yml`), `ubuntu-latest`, ~10s runtime, unconditional trigger (see Mergeability for why
  it isn't path-filtered).

## Evidence

- Pass, full repaired tree: `OK: 213 Markdown file(s) checked, no broken relative links.` (exit 0)
- Fail, deliberately broken link injected into an isolated fixture dir: reports
  `fail-fixture/docs/broken.md:3: broken link -> ./does-not-exist.md`, `1 broken link(s)`
  (exit 1)
- `actionlint .github/workflows/docs-link-check.yml` — clean
- Evidence URLs: [link-check pass/fail transcript](https://evidence.cloudcompute.com/workspaces/pr-1187/20260804-052528-link-check-pass-fail.txt), [codex review findings](https://evidence.cloudcompute.com/workspaces/pr-1187/20260804-052533-codex-review-findings.txt)

## Review loop

Directed codex (gpt-5.6-sol, xhigh) review before opening, per `codex-review-loop`. Found
5 blockers + 1 nit, all fixed in a follow-up commit:

1. **Blocker** — `docs-link-check.yml`'s `paths:` filter would miss the case where the
   *target* of a broken link (not the referencing `.md`) is the file that moved — exactly
   the class this gate exists to catch. Fixed: dropped the filter, runs unconditionally.
2. **Blocker** — `.agents/workspaces/README.md`'s fix cited `RepoLandingView.swift` as
   having "the full contract," but that file has no WebKit bridge at all (removed in
   `a7569b39`). Fixed: corrected the doc to say the feature isn't wired up, instead of
   inventing a false current source.
3. **Blocker** — Fence/inline-code stripping used naive backtick pairing: an unmatched
   fence could swallow a real link up to an unrelated later fence, and a double-backtick
   span containing single backticks could leak its contents (including a link) as a false
   positive. Fixed: line-anchored fence detection + CommonMark-style delimiter-run-length
   matching for inline code, verified against both adversarial cases.
4. **Blocker** — The placeholder heuristic (skip bare lowercase/no-dot/no-slash targets)
   both skipped real broken links like `[file](missing)` and mis-flagged `[x](URL)`-style
   uppercase placeholders. Fixed: dropped the heuristic for an explicit 3-item allowlist of
   the actual prose fillers found in this repo (`url`, `link`, `run url`); everything else
   is checked for real.
5. **Blocker** — A leading `/` was resolved against repo root instead of flagged, but
   Markdown renderers (GitHub included) treat a leading `/` as domain-root-relative, not
   repo-relative — silently "fixing" it was semantically wrong. Fixed: any leading `/` is
   now always reported broken; also reject paths that escape repo root via `../` traversal.
6. **Nit** — `backlog`/`docs/archive` exclusion matched the substring anywhere in the path
   (`docs/backlog/x.md` would've been wrongly excluded). Fixed: scoped to repo-root
   prefixes only, verified with a real in-tree probe.

All 6 verified independently post-fix (adversarial probes + a real in-repo root-scoping
test), not just re-run against the existing 213-file corpus, since none of the bugs were
visible in the current tree — they're forward-looking robustness gaps against future PRs.

## Mergeability

**Surface:** CI configuration (new workflow) + documentation content (14 files) + one new
dependency-free `scripts/` utility. No app/product code touched.

**Behavior changed:** New CI gate, unconditional trigger — every PR now runs a ~10s
`ubuntu-latest` check that fails on any broken relative Markdown link (real `[text](path)`
syntax, not backtick text) in a tracked file outside `backlog/**` / `docs/archive/**`.
~29 stale path references repaired across 12 files; no prose/reasoning changed except
where a path pointer itself was the content, or where a doc's own factual claim was wrong
(`.agents/workspaces/README.md`, found via codex review — see Review loop #2).

**Non-happy paths considered:** Checker excludes `backlog/**` (fast-moving task ledger;
~29 further stale internal cross-references exist between already-archived
`backlog/done/*.md` plans and were left alone as historical-archive noise, not "docs") and
`docs/archive/**` (frozen snapshot of an unrelated "superpowers" tool whose `scripts/`
mentions refer to that tool's own layout, not this repo's `scripts/`). New workflow file
rather than a job in `ci.yml`, since `ci.yml`'s `paths:` filter deliberately keeps the
expensive macOS Swift build off doc-only PRs (see its top-of-file comment) — a job sharing
that trigger would defeat it; this follows the repo's existing
one-focused-workflow-per-concern pattern (`web-ci.yml`, `mise-security.yml`,
`milestone-legibility.yml`). Unlike those, this workflow's trigger is intentionally
*unfiltered* (see Review loop #1) — the breakage class here is triggered by the *target*
moving, which is often not a `.md` file.

**Residual risk:** Low. The checker is read-only, runs in ~10s, and only reports link
syntax it can prove doesn't resolve — false positives were adversarially tested against
(prose placeholders, code-fence/inline-code edge cases, skill files with their own local
`scripts/` subdirectories, bare-uppercase filenames, absolute-path leaks, root-scoping) and
a directed codex pass found and fixed 5 real gaps before merge. #1154's sibling PR (#1182,
already merged into main — this branch is rebased on top of it) touched
`AGENTS.md`/`ARCHITECTURE.md`; this PR makes no edits to either file, confirmed via
file-overlap check before rebasing.

Closes #1155
