### PR TITLE
refactor(app): extract background maintenance passes from ContentView (#1160 slice 2)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -147,6 +147,7 @@ struct ContentView: View {
     private let tabRoutingController = TabRoutingController()
     private let workspaceEnvironmentOptionsController = WorkspaceEnvironmentOptionsController()
     private let workspaceOrphanController = WorkspaceOrphanReconciliationController()
+    private let maintenanceController = MainWindowMaintenanceController()
 
     private var launchRepositoryService: LaunchRepositoryService {
         LaunchRepositoryService(modelContext: modelContext)
@@ -2356,27 +2357,10 @@ struct ContentView: View {
         await purgeExpiredArchivedWorkspaces(trigger: "launch_deferred")
     }
 
-    /// Local archived workspaces whose `.archived/` directory has aged past the
-    /// configured retention. Pure so the selection rule is unit-testable; workspaces
-    /// without an `archivedAt` (archived before this was tracked) are never auto-purged.
-    static func expiredArchivedWorkspaces(
-        _ workspaces: [Workspace],
-        now: Date,
-        delayDays: Int
-    ) -> [Workspace] {
-        guard delayDays > 0 else { return [] }
-        let cutoff = now.addingTimeInterval(-Double(delayDays) * 86_400)
-        return workspaces.filter { workspace in
-            workspace.backend == .local
-                && workspace.status == .archived
-                && (workspace.archivedAt.map { $0 <= cutoff } ?? false)
-        }
-    }
-
     @MainActor
     private func purgeExpiredArchivedWorkspaces(trigger: String) async {
         let delayDays = ArchivedWorkspaceSettings.purgeDays()
-        let candidates = Self.expiredArchivedWorkspaces(
+        let candidates = maintenanceController.expiredArchivedWorkspaces(
             repos.flatMap(\.workspaces),
             now: Date(),
             delayDays: delayDays
@@ -2416,64 +2400,11 @@ struct ContentView: View {
 
     @MainActor
     private func syncWorkspaceStatuses(trigger: String) async {
-        let syncStartedAt = Date()
-        let nonLocalWorkspaces = repos.flatMap(\.workspaces).filter {
-            $0.backend != .local && $0.remoteId != nil
-        }
-        guard !nonLocalWorkspaces.isEmpty else { return }
-
-        var changed = false
-        var changedCount = 0
-        var hadFailure = false
-        let groupedWorkspaces = Dictionary(grouping: nonLocalWorkspaces, by: \.backendIdentifier)
-
-        for (providerID, providerWorkspaces) in groupedWorkspaces {
-            guard let provider = workspaceProviderRegistry.provider(for: providerID) else { continue }
-
-            let providerSyncStartedAt = Date()
-            var providerChangedCount = 0
-            var outcome = "success"
-
-            do {
-                let snapshots = try await provider.syncStatuses(
-                    for: providerWorkspaces.map(WorkspaceProviderTarget.init)
-                )
-                let statusesByRemoteID = Dictionary(
-                    uniqueKeysWithValues: snapshots.map { ($0.remoteId, $0.status) }
-                )
-
-                for workspace in providerWorkspaces {
-                    guard let remoteID = workspace.remoteId else { continue }
-                    let newStatus = statusesByRemoteID[remoteID] ?? .archived
-                    if workspace.status != newStatus {
-                        workspaceProviderLog.info(
-                            "[WorkspaceProvider] Syncing workspace '\(workspace.name, privacy: .public)' (\(providerID, privacy: .public)): \(workspace.status.rawValue, privacy: .public) -> \(newStatus.rawValue, privacy: .public)"
-                        )
-                        workspace.status = newStatus
-                        changed = true
-                        changedCount += 1
-                        providerChangedCount += 1
-                    }
-                }
-            } catch {
-                outcome = "failure"
-                hadFailure = true
-                workspaceProviderLog.error(
-                    "[WorkspaceProvider] Failed to sync \(providerID, privacy: .public) workspace statuses: \(error.localizedDescription, privacy: .public)"
-                )
-            }
-
-            perfLog.info(
-                "[Perf] metric=workspace_status_sync_provider duration_ms=\(String(format: "%.2f", Date().timeIntervalSince(providerSyncStartedAt) * 1000), privacy: .public) trigger=\(trigger, privacy: .public) provider=\(providerID, privacy: .public) workspace_count=\(providerWorkspaces.count, privacy: .public) changed_count=\(providerChangedCount, privacy: .public) outcome=\(outcome, privacy: .public)"
-            )
-        }
-
-        if changed {
-            try? modelContext.save()
-        }
-
-        perfLog.info(
-            "[Perf] metric=workspace_status_sync duration_ms=\(String(format: "%.2f", Date().timeIntervalSince(syncStartedAt) * 1000), privacy: .public) trigger=\(trigger, privacy: .public) providers=\(groupedWorkspaces.count, privacy: .public) workspace_count=\(nonLocalWorkspaces.count, privacy: .public) changed_count=\(changedCount, privacy: .public) outcome=\(hadFailure ? "partial_failure" : "success", privacy: .public)"
+        await maintenanceController.syncWorkspaceStatuses(
+            repos: repos,
+            registry: workspaceProviderRegistry,
+            modelContext: modelContext,
+            trigger: trigger
         )
     }
 
@@ -3248,48 +3179,14 @@ struct ContentView: View {
     }
 
     private func refreshWorkspaceStatusAggregator() {
-        let presentation = SidebarWorkspacePresentationController()
-        let statuses = agentSessionRegistry.statuses
-        let sessions = tileTreeStore.sessions
-        let normalize: (URL) -> String = { url in normalizePath(url.path) }
-
-        let workspaceInputs: [WorkspaceStatusAggregator.WorkspaceInput] =
-            repos
-            .flatMap(\.workspaces)
-            .map { workspace in
-                let key = presentation.sessionKey(
-                    for: workspace,
-                    registry: workspaceProviderRegistry,
-                    normalizePath: normalize
-                )
-                let status = presentation.freshestAgentStatus(
-                    for: key,
-                    sessions: sessions,
-                    agentStatusBySessionID: statuses
-                )
-                return WorkspaceStatusAggregator.WorkspaceInput(
-                    workspaceID: workspace.id,
-                    repoID: workspace.sourceRepo?.id,
-                    lastAccessedAt: workspace.lastAccessedAt,
-                    status: status
-                )
-            }
-
-        let repoInputs: [WorkspaceStatusAggregator.RepoInput] = repos.map { repo in
-            let key = HostTerminalSessionKey.repoPath(normalize(repo.localURL))
-            let status = presentation.freshestAgentStatus(
-                for: key,
-                sessions: sessions,
-                agentStatusBySessionID: statuses
-            )
-            return WorkspaceStatusAggregator.RepoInput(
-                repoID: repo.id,
-                lastAccessedAt: repo.lastAccessedAt,
-                status: status
-            )
-        }
-
-        workspaceStatusAggregator.update(workspaces: workspaceInputs, repos: repoInputs)
+        let inputs = maintenanceController.aggregatorInputs(
+            repos: repos,
+            sessions: tileTreeStore.sessions,
+            agentStatusBySessionID: agentSessionRegistry.statuses,
+            registry: workspaceProviderRegistry,
+            normalizePath: { url in normalizePath(url.path) }
+        )
+        workspaceStatusAggregator.update(workspaces: inputs.workspaces, repos: inputs.repos)
     }
 
     @MainActor

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowMaintenanceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowMaintenanceController.swift
@@ -1,0 +1,228 @@
+//
+//  MainWindowMaintenanceController.swift
+//  WorkspaceManager
+//
+//  The main window's background maintenance work: the remote status-sync pass, the rule
+//  picking archived workspaces that have aged out, and the sidebar-aggregator projection.
+//  The archived purge itself stays in the view because it clears the current selection on
+//  the way through; everything here is reachable without a window, so the decisions and the
+//  save they drive are testable.
+//
+
+import Foundation
+import SwiftData
+import WorkspaceManagerCore
+import os.log
+
+private let perfLog = Logger(subsystem: "com.cloudcompute.workspaces", category: "PerformanceSignposts")
+private let workspaceProviderLog = Logger(
+    subsystem: "com.cloudcompute.workspaces",
+    category: "WorkspaceProvider"
+)
+
+@MainActor
+struct MainWindowMaintenanceController {
+    /// A workspace whose persisted status disagrees with what its provider reports.
+    /// `previousStatus` is captured before the caller writes, so the log line reads the
+    /// same transition the decision was made on.
+    struct StatusChange {
+        let workspace: Workspace
+        let previousStatus: WorkspaceStatus
+        let newStatus: WorkspaceStatus
+    }
+
+    /// One sidebar-aggregation pass, projected from the current model and session state.
+    struct AggregatorInputs: Equatable {
+        let workspaces: [WorkspaceStatusAggregator.WorkspaceInput]
+        let repos: [WorkspaceStatusAggregator.RepoInput]
+    }
+
+    /// What one status-sync pass did. The pass also emits the `workspace_status_sync` perf
+    /// line; this is the same tally as a return value, so callers and tests can assert the
+    /// outcome without reading the log stream.
+    struct StatusSyncOutcome: Equatable {
+        let providerCount: Int
+        let workspaceCount: Int
+        let changedCount: Int
+        let hadFailure: Bool
+
+        static let noWork = StatusSyncOutcome(
+            providerCount: 0, workspaceCount: 0, changedCount: 0, hadFailure: false
+        )
+    }
+
+    // MARK: - Archived purge
+
+    /// Local archived workspaces whose `.archived/` directory has aged past the configured
+    /// retention. Workspaces without an `archivedAt` (archived before this was tracked) are
+    /// never auto-purged, and a non-positive delay disables the sweep entirely.
+    func expiredArchivedWorkspaces(
+        _ workspaces: [Workspace],
+        now: Date,
+        delayDays: Int
+    ) -> [Workspace] {
+        guard delayDays > 0 else { return [] }
+        let cutoff = now.addingTimeInterval(-Double(delayDays) * 86_400)
+        return workspaces.filter { workspace in
+            workspace.backend == .local
+                && workspace.status == .archived
+                && (workspace.archivedAt.map { $0 <= cutoff } ?? false)
+        }
+    }
+
+    // MARK: - Remote status sync
+
+    /// Remote-backed workspaces that can be synced, grouped by the provider that owns them.
+    /// Local workspaces and remote ones with no remote id have nothing to ask a provider about.
+    func statusSyncGroups(repos: [Repo]) -> [String: [Workspace]] {
+        let syncable = repos.flatMap(\.workspaces).filter {
+            $0.backend != .local && $0.remoteId != nil
+        }
+        return Dictionary(grouping: syncable, by: \.backendIdentifier)
+    }
+
+    /// What a provider's snapshots imply for the workspaces it was asked about. A workspace
+    /// the provider no longer reports is treated as archived; one whose status already matches
+    /// is omitted, so the caller only writes and saves when something actually moved.
+    func statusChanges(
+        for workspaces: [Workspace],
+        snapshots: [WorkspaceProviderStatusSnapshot]
+    ) -> [StatusChange] {
+        let statusesByRemoteID = Dictionary(
+            uniqueKeysWithValues: snapshots.map { ($0.remoteId, $0.status) }
+        )
+        return workspaces.compactMap { workspace in
+            guard let remoteID = workspace.remoteId else { return nil }
+            let newStatus = statusesByRemoteID[remoteID] ?? .archived
+            guard workspace.status != newStatus else { return nil }
+            return StatusChange(
+                workspace: workspace,
+                previousStatus: workspace.status,
+                newStatus: newStatus
+            )
+        }
+    }
+
+    /// Asks each provider for the current status of its remote workspaces and writes back
+    /// what moved. Provider failures are isolated: one provider throwing is logged and marks
+    /// the pass a partial failure without stopping the others, and the context is saved once
+    /// at the end only if something actually changed.
+    @discardableResult
+    func syncWorkspaceStatuses(
+        repos: [Repo],
+        registry: WorkspaceProviderRegistry,
+        modelContext: ModelContext,
+        trigger: String
+    ) async -> StatusSyncOutcome {
+        let syncStartedAt = Date()
+        let groupedWorkspaces = statusSyncGroups(repos: repos)
+        let syncableCount = groupedWorkspaces.values.reduce(0) { $0 + $1.count }
+        guard syncableCount > 0 else { return .noWork }
+
+        var changed = false
+        var changedCount = 0
+        var hadFailure = false
+
+        for (providerID, providerWorkspaces) in groupedWorkspaces {
+            guard let provider = registry.provider(for: providerID) else { continue }
+
+            let providerSyncStartedAt = Date()
+            var providerChangedCount = 0
+            var outcome = "success"
+
+            do {
+                let snapshots = try await provider.syncStatuses(
+                    for: providerWorkspaces.map(WorkspaceProviderTarget.init)
+                )
+
+                for change in statusChanges(for: providerWorkspaces, snapshots: snapshots) {
+                    workspaceProviderLog.info(
+                        "[WorkspaceProvider] Syncing workspace '\(change.workspace.name, privacy: .public)' (\(providerID, privacy: .public)): \(change.previousStatus.rawValue, privacy: .public) -> \(change.newStatus.rawValue, privacy: .public)"
+                    )
+                    change.workspace.status = change.newStatus
+                    changed = true
+                    changedCount += 1
+                    providerChangedCount += 1
+                }
+            } catch {
+                outcome = "failure"
+                hadFailure = true
+                workspaceProviderLog.error(
+                    "[WorkspaceProvider] Failed to sync \(providerID, privacy: .public) workspace statuses: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+
+            perfLog.info(
+                "[Perf] metric=workspace_status_sync_provider duration_ms=\(String(format: "%.2f", Date().timeIntervalSince(providerSyncStartedAt) * 1000), privacy: .public) trigger=\(trigger, privacy: .public) provider=\(providerID, privacy: .public) workspace_count=\(providerWorkspaces.count, privacy: .public) changed_count=\(providerChangedCount, privacy: .public) outcome=\(outcome, privacy: .public)"
+            )
+        }
+
+        if changed {
+            try? modelContext.save()
+        }
+
+        perfLog.info(
+            "[Perf] metric=workspace_status_sync duration_ms=\(String(format: "%.2f", Date().timeIntervalSince(syncStartedAt) * 1000), privacy: .public) trigger=\(trigger, privacy: .public) providers=\(groupedWorkspaces.count, privacy: .public) workspace_count=\(syncableCount, privacy: .public) changed_count=\(changedCount, privacy: .public) outcome=\(hadFailure ? "partial_failure" : "success", privacy: .public)"
+        )
+
+        return StatusSyncOutcome(
+            providerCount: groupedWorkspaces.count,
+            workspaceCount: syncableCount,
+            changedCount: changedCount,
+            hadFailure: hadFailure
+        )
+    }
+
+    // MARK: - Sidebar aggregation
+
+    /// Projects repos, workspaces, live sessions, and agent status into the aggregator's
+    /// inputs. Pure over its arguments, so the sidebar's status roll-up is assertable
+    /// without a window or a live registry.
+    func aggregatorInputs(
+        repos: [Repo],
+        sessions: [HostTerminalSession],
+        agentStatusBySessionID: [UUID: AgentSessionStatus],
+        registry: WorkspaceProviderRegistry,
+        normalizePath: (URL) -> String
+    ) -> AggregatorInputs {
+        let presentation = SidebarWorkspacePresentationController()
+
+        let workspaceInputs: [WorkspaceStatusAggregator.WorkspaceInput] =
+            repos
+            .flatMap(\.workspaces)
+            .map { workspace in
+                let key = presentation.sessionKey(
+                    for: workspace,
+                    registry: registry,
+                    normalizePath: normalizePath
+                )
+                let status = presentation.freshestAgentStatus(
+                    for: key,
+                    sessions: sessions,
+                    agentStatusBySessionID: agentStatusBySessionID
+                )
+                return WorkspaceStatusAggregator.WorkspaceInput(
+                    workspaceID: workspace.id,
+                    repoID: workspace.sourceRepo?.id,
+                    lastAccessedAt: workspace.lastAccessedAt,
+                    status: status
+                )
+            }
+
+        let repoInputs: [WorkspaceStatusAggregator.RepoInput] = repos.map { repo in
+            let key = HostTerminalSessionKey.repoPath(normalizePath(repo.localURL))
+            let status = presentation.freshestAgentStatus(
+                for: key,
+                sessions: sessions,
+                agentStatusBySessionID: agentStatusBySessionID
+            )
+            return WorkspaceStatusAggregator.RepoInput(
+                repoID: repo.id,
+                lastAccessedAt: repo.lastAccessedAt,
+                status: status
+            )
+        }
+
+        return AggregatorInputs(workspaces: workspaceInputs, repos: repoInputs)
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowMaintenanceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowMaintenanceController.swift
@@ -81,26 +81,32 @@ struct MainWindowMaintenanceController {
         return Dictionary(grouping: syncable, by: \.backendIdentifier)
     }
 
-    /// What a provider's snapshots imply for the workspaces it was asked about. A workspace
-    /// the provider no longer reports is treated as archived; one whose status already matches
-    /// is omitted, so the caller only writes and saves when something actually moved.
-    func statusChanges(
-        for workspaces: [Workspace],
-        snapshots: [WorkspaceProviderStatusSnapshot]
-    ) -> [StatusChange] {
-        let statusesByRemoteID = Dictionary(
-            uniqueKeysWithValues: snapshots.map { ($0.remoteId, $0.status) }
+    /// The status a provider reports, keyed by remote id. Traps on duplicate remote ids,
+    /// which is the long-standing contract with providers.
+    func statusesByRemoteID(
+        from snapshots: [WorkspaceProviderStatusSnapshot]
+    ) -> [String: WorkspaceStatus] {
+        Dictionary(uniqueKeysWithValues: snapshots.map { ($0.remoteId, $0.status) })
+    }
+
+    /// What a provider's answer implies for one workspace, or `nil` when its status already
+    /// matches. A workspace the provider no longer reports is treated as archived.
+    ///
+    /// Deciding one workspace at a time — rather than batching a group's decisions ahead of
+    /// its writes — is what keeps a status read after any earlier write in the same pass, so
+    /// a workspace reached twice in one group settles instead of transitioning twice.
+    func statusChange(
+        for workspace: Workspace,
+        statusesByRemoteID: [String: WorkspaceStatus]
+    ) -> StatusChange? {
+        guard let remoteID = workspace.remoteId else { return nil }
+        let newStatus = statusesByRemoteID[remoteID] ?? .archived
+        guard workspace.status != newStatus else { return nil }
+        return StatusChange(
+            workspace: workspace,
+            previousStatus: workspace.status,
+            newStatus: newStatus
         )
-        return workspaces.compactMap { workspace in
-            guard let remoteID = workspace.remoteId else { return nil }
-            let newStatus = statusesByRemoteID[remoteID] ?? .archived
-            guard workspace.status != newStatus else { return nil }
-            return StatusChange(
-                workspace: workspace,
-                previousStatus: workspace.status,
-                newStatus: newStatus
-            )
-        }
     }
 
     /// Asks each provider for the current status of its remote workspaces and writes back
@@ -134,8 +140,16 @@ struct MainWindowMaintenanceController {
                 let snapshots = try await provider.syncStatuses(
                     for: providerWorkspaces.map(WorkspaceProviderTarget.init)
                 )
+                let reportedStatuses = statusesByRemoteID(from: snapshots)
 
-                for change in statusChanges(for: providerWorkspaces, snapshots: snapshots) {
+                for workspace in providerWorkspaces {
+                    guard
+                        let change = statusChange(
+                            for: workspace,
+                            statusesByRemoteID: reportedStatuses
+                        )
+                    else { continue }
+
                     workspaceProviderLog.info(
                         "[WorkspaceProvider] Syncing workspace '\(change.workspace.name, privacy: .public)' (\(providerID, privacy: .public)): \(change.previousStatus.rawValue, privacy: .public) -> \(change.newStatus.rawValue, privacy: .public)"
                     )

--- a/Tests/WorkspaceManagerAppTests/ArchivedWorkspacePurgeTests.swift
+++ b/Tests/WorkspaceManagerAppTests/ArchivedWorkspacePurgeTests.swift
@@ -15,6 +15,7 @@ import WorkspaceManagerCore
 @MainActor
 @Suite("ArchivedWorkspacePurge")
 struct ArchivedWorkspacePurgeTests {
+    private let controller = MainWindowMaintenanceController()
     private let now = Date(timeIntervalSince1970: 1_700_000_000)
     private let day = 86_400.0
 
@@ -81,7 +82,7 @@ struct ArchivedWorkspacePurgeTests {
             archivedAt: now.addingTimeInterval(-40 * day)
         )
 
-        let result = ContentView.expiredArchivedWorkspaces(
+        let result = controller.expiredArchivedWorkspaces(
             [expired, boundary],
             now: now,
             delayDays: 30
@@ -89,7 +90,7 @@ struct ArchivedWorkspacePurgeTests {
 
         // Re-run over the full set to confirm filtering excludes the others.
         let all = repo.workspaces
-        let resultAll = ContentView.expiredArchivedWorkspaces(all, now: now, delayDays: 30)
+        let resultAll = controller.expiredArchivedWorkspaces(all, now: now, delayDays: 30)
         #expect(Set(resultAll.map(\.name)) == ["expired", "boundary"])
         #expect(Set(result.map(\.name)) == ["expired", "boundary"])
     }
@@ -105,7 +106,7 @@ struct ArchivedWorkspacePurgeTests {
             archivedAt: now.addingTimeInterval(-400 * day)
         )
 
-        #expect(ContentView.expiredArchivedWorkspaces([expired], now: now, delayDays: 0).isEmpty)
-        #expect(ContentView.expiredArchivedWorkspaces([expired], now: now, delayDays: -5).isEmpty)
+        #expect(controller.expiredArchivedWorkspaces([expired], now: now, delayDays: 0).isEmpty)
+        #expect(controller.expiredArchivedWorkspaces([expired], now: now, delayDays: -5).isEmpty)
     }
 }

--- a/Tests/WorkspaceManagerAppTests/MainWindowMaintenanceControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowMaintenanceControllerTests.swift
@@ -1,0 +1,376 @@
+//
+//  MainWindowMaintenanceControllerTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Coverage for the main window's background maintenance passes: which remote workspaces
+//  get synced, what a provider's answer writes back and persists, and the sidebar-aggregator
+//  projection. The archived-purge selection rule is covered in ArchivedWorkspacePurgeTests.
+//
+
+import Foundation
+import SwiftData
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("MainWindowMaintenanceController")
+struct MainWindowMaintenanceControllerTests {
+    private let controller = MainWindowMaintenanceController()
+
+    // MARK: - Fixtures
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([Repo.self, Workspace.self, WebSource.self])
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [configuration])
+    }
+
+    @discardableResult
+    private func makeWorkspace(
+        repo: Repo,
+        name: String,
+        backendIdentifier: String,
+        remoteId: String?,
+        status: WorkspaceStatus = .active,
+        context: ModelContext? = nil
+    ) -> Workspace {
+        let workspace = Workspace(
+            name: name,
+            path: URL(fileURLWithPath: "/tmp/workspaces/\(name)"),
+            sourceRepo: repo,
+            status: status,
+            backendIdentifier: backendIdentifier,
+            remoteId: remoteId
+        )
+        repo.workspaces.append(workspace)
+        context?.insert(workspace)
+        return workspace
+    }
+
+    private func makeRegistry(_ providers: [StatusSyncStubProvider]) -> WorkspaceProviderRegistry {
+        WorkspaceProviderRegistry(providers: providers)
+    }
+
+    // MARK: - Sync work list
+
+    @Test("Only remote workspaces with a remote id are synced, grouped by provider")
+    func syncGroupsSkipLocalAndUnidentifiedWorkspaces() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        makeWorkspace(repo: repo, name: "local", backendIdentifier: "local", remoteId: nil)
+        makeWorkspace(repo: repo, name: "no-remote-id", backendIdentifier: "daytona", remoteId: nil)
+        makeWorkspace(repo: repo, name: "d1", backendIdentifier: "daytona", remoteId: "d-1")
+        makeWorkspace(repo: repo, name: "d2", backendIdentifier: "daytona", remoteId: "d-2")
+        makeWorkspace(repo: repo, name: "l1", backendIdentifier: "lume", remoteId: "l-1")
+
+        let groups = controller.statusSyncGroups(repos: [repo])
+
+        #expect(Set(groups.keys) == ["daytona", "lume"])
+        #expect(Set(groups["daytona", default: []].map(\.name)) == ["d1", "d2"])
+        #expect(groups["lume", default: []].map(\.name) == ["l1"])
+    }
+
+    @Test("A repo with nothing remote produces no sync work")
+    func syncGroupsEmptyWhenAllLocal() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        makeWorkspace(repo: repo, name: "local", backendIdentifier: "local", remoteId: nil)
+
+        #expect(controller.statusSyncGroups(repos: [repo]).isEmpty)
+    }
+
+    // MARK: - Status decision
+
+    @Test("Only workspaces whose status actually moved are reported, with the prior status")
+    func statusChangesReportOnlyRealTransitions() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let moving = makeWorkspace(
+            repo: repo, name: "moving", backendIdentifier: "daytona", remoteId: "d-1",
+            status: .active)
+        let steady = makeWorkspace(
+            repo: repo, name: "steady", backendIdentifier: "daytona", remoteId: "d-2",
+            status: .active)
+
+        let changes = controller.statusChanges(
+            for: [moving, steady],
+            snapshots: [
+                WorkspaceProviderStatusSnapshot(remoteId: "d-1", status: .stopped),
+                WorkspaceProviderStatusSnapshot(remoteId: "d-2", status: .active),
+            ]
+        )
+
+        #expect(changes.count == 1)
+        #expect(changes.first?.workspace.name == "moving")
+        #expect(changes.first?.previousStatus == .active)
+        #expect(changes.first?.newStatus == .stopped)
+    }
+
+    @Test("A workspace the provider no longer reports is treated as archived")
+    func statusChangesTreatMissingRemoteAsArchived() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let vanished = makeWorkspace(
+            repo: repo, name: "vanished", backendIdentifier: "daytona", remoteId: "gone",
+            status: .active)
+
+        let changes = controller.statusChanges(for: [vanished], snapshots: [])
+
+        #expect(changes.map(\.newStatus) == [.archived])
+    }
+
+    @Test("A workspace already archived and still unreported produces no change")
+    func statusChangesSkipAlreadyArchivedMissingWorkspace() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let archived = makeWorkspace(
+            repo: repo, name: "archived", backendIdentifier: "daytona", remoteId: "gone",
+            status: .archived)
+
+        #expect(controller.statusChanges(for: [archived], snapshots: []).isEmpty)
+    }
+
+    // MARK: - Sync pass
+
+    @Test("A sync pass writes the provider's statuses and persists them")
+    func syncPassPersistsStatusChanges() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        context.insert(repo)
+        let workspace = makeWorkspace(
+            repo: repo, name: "remote", backendIdentifier: "daytona", remoteId: "d-1",
+            status: .active, context: context)
+        try context.save()
+
+        let provider = StatusSyncStubProvider(
+            id: "daytona",
+            snapshots: [WorkspaceProviderStatusSnapshot(remoteId: "d-1", status: .stopped)]
+        )
+
+        let outcome = await controller.syncWorkspaceStatuses(
+            repos: [repo],
+            registry: makeRegistry([provider]),
+            modelContext: context,
+            trigger: "test"
+        )
+
+        #expect(outcome == .init(providerCount: 1, workspaceCount: 1, changedCount: 1, hadFailure: false))
+        #expect(workspace.status == .stopped)
+
+        // A second context over the same container only sees saved state, so this fails if
+        // the pass wrote the status without saving.
+        let verification = ModelContext(container)
+        let persisted = try verification.fetch(FetchDescriptor<Workspace>())
+        #expect(persisted.map(\.status) == [.stopped])
+    }
+
+    @Test("A pass that changes nothing reports no changes")
+    func syncPassWithNoTransitionsReportsZeroChanged() async throws {
+        let context = ModelContext(try makeContainer())
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        context.insert(repo)
+        makeWorkspace(
+            repo: repo, name: "remote", backendIdentifier: "daytona", remoteId: "d-1",
+            status: .active, context: context)
+
+        let provider = StatusSyncStubProvider(
+            id: "daytona",
+            snapshots: [WorkspaceProviderStatusSnapshot(remoteId: "d-1", status: .active)]
+        )
+
+        let outcome = await controller.syncWorkspaceStatuses(
+            repos: [repo],
+            registry: makeRegistry([provider]),
+            modelContext: context,
+            trigger: "test"
+        )
+
+        #expect(outcome.changedCount == 0)
+        #expect(outcome.hadFailure == false)
+    }
+
+    @Test("One provider failing does not stop the others, and marks the pass a partial failure")
+    func syncPassIsolatesProviderFailure() async throws {
+        let context = ModelContext(try makeContainer())
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        context.insert(repo)
+        makeWorkspace(
+            repo: repo, name: "broken", backendIdentifier: "daytona", remoteId: "d-1",
+            status: .active, context: context)
+        let healthy = makeWorkspace(
+            repo: repo, name: "healthy", backendIdentifier: "lume", remoteId: "l-1",
+            status: .active, context: context)
+
+        let failing = StatusSyncStubProvider(id: "daytona", error: StubSyncError.unreachable)
+        let working = StatusSyncStubProvider(
+            id: "lume",
+            snapshots: [WorkspaceProviderStatusSnapshot(remoteId: "l-1", status: .stopped)]
+        )
+
+        let outcome = await controller.syncWorkspaceStatuses(
+            repos: [repo],
+            registry: makeRegistry([failing, working]),
+            modelContext: context,
+            trigger: "test"
+        )
+
+        #expect(outcome.hadFailure)
+        #expect(outcome.providerCount == 2)
+        #expect(outcome.changedCount == 1)
+        #expect(healthy.status == .stopped)
+    }
+
+    @Test("A workspace whose provider is not registered is left untouched")
+    func syncPassSkipsUnregisteredProvider() async throws {
+        let context = ModelContext(try makeContainer())
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        context.insert(repo)
+        let orphaned = makeWorkspace(
+            repo: repo, name: "orphaned", backendIdentifier: "unregistered", remoteId: "x-1",
+            status: .active, context: context)
+
+        let outcome = await controller.syncWorkspaceStatuses(
+            repos: [repo],
+            registry: makeRegistry([]),
+            modelContext: context,
+            trigger: "test"
+        )
+
+        #expect(outcome.changedCount == 0)
+        #expect(orphaned.status == .active)
+    }
+
+    @Test("Nothing syncable short-circuits the pass")
+    func syncPassWithNoRemoteWorkspacesShortCircuits() async throws {
+        let context = ModelContext(try makeContainer())
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        context.insert(repo)
+        makeWorkspace(
+            repo: repo, name: "local", backendIdentifier: "local", remoteId: nil, context: context)
+
+        let outcome = await controller.syncWorkspaceStatuses(
+            repos: [repo],
+            registry: makeRegistry([]),
+            modelContext: context,
+            trigger: "test"
+        )
+
+        #expect(outcome == .noWork)
+    }
+
+    // MARK: - Sidebar aggregation
+
+    @Test("Aggregator inputs carry every repo and workspace with its access time")
+    func aggregatorInputsProjectReposAndWorkspaces() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let workspace = makeWorkspace(
+            repo: repo, name: "feature-a", backendIdentifier: "local", remoteId: nil)
+
+        let inputs = controller.aggregatorInputs(
+            repos: [repo],
+            sessions: [],
+            agentStatusBySessionID: [:],
+            registry: makeRegistry([]),
+            normalizePath: { $0.path }
+        )
+
+        #expect(inputs.repos.map(\.repoID) == [repo.id])
+        #expect(inputs.repos.map(\.lastAccessedAt) == [repo.lastAccessedAt])
+        #expect(inputs.workspaces.map(\.workspaceID) == [workspace.id])
+        #expect(inputs.workspaces.map(\.repoID) == [repo.id])
+        #expect(inputs.workspaces.map(\.lastAccessedAt) == [workspace.lastAccessedAt])
+    }
+
+    @Test("With no registered agent status every input reports nil rather than a stale status")
+    func aggregatorInputsReportNilStatusWithoutSessions() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        makeWorkspace(repo: repo, name: "feature-a", backendIdentifier: "local", remoteId: nil)
+
+        let inputs = controller.aggregatorInputs(
+            repos: [repo],
+            sessions: [],
+            agentStatusBySessionID: [:],
+            registry: makeRegistry([]),
+            normalizePath: { $0.path }
+        )
+
+        #expect(inputs.workspaces.allSatisfy { $0.status == nil })
+        #expect(inputs.repos.allSatisfy { $0.status == nil })
+    }
+
+    @Test("An empty model produces empty aggregator inputs")
+    func aggregatorInputsEmptyForNoRepos() {
+        let inputs = controller.aggregatorInputs(
+            repos: [],
+            sessions: [],
+            agentStatusBySessionID: [:],
+            registry: makeRegistry([]),
+            normalizePath: { $0.path }
+        )
+
+        #expect(inputs == .init(workspaces: [], repos: []))
+    }
+}
+
+private enum StubSyncError: Error {
+    case unreachable
+}
+
+/// Minimal provider that only answers `syncStatuses`; every other requirement falls through
+/// to the protocol's default implementations.
+private actor StatusSyncStubProvider: WorkspaceProviderProtocol {
+    nonisolated let descriptor: WorkspaceProviderDescriptor
+
+    private let snapshots: [WorkspaceProviderStatusSnapshot]
+    private let error: (any Error)?
+
+    init(
+        id: String,
+        snapshots: [WorkspaceProviderStatusSnapshot] = [],
+        error: (any Error)? = nil
+    ) {
+        self.descriptor = WorkspaceProviderDescriptor(
+            id: id,
+            displayName: id,
+            description: "stub provider for status-sync tests"
+        )
+        self.snapshots = snapshots
+        self.error = error
+    }
+
+    func availability() async -> WorkspaceProviderAvailability {
+        WorkspaceProviderAvailability(isAvailable: true)
+    }
+
+    nonisolated func sessionKey(for workspace: WorkspaceProviderTarget) -> HostTerminalSessionKey {
+        .backendSession(providerID: descriptor.id, instanceID: workspace.terminalSessionIdentifier)
+    }
+
+    func createWorkspace(
+        request: WorkspaceProviderCreationRequest,
+        workspaceService: any WorkspaceServiceProtocol,
+        progress: WorkspaceProviderProgressHandler?,
+        persist: WorkspaceProviderPersistenceHandler?
+    ) async throws -> WorkspaceProviderCreationResult {
+        throw StubSyncError.unreachable
+    }
+
+    func terminalLaunchSpec(for workspace: WorkspaceProviderTarget) async throws -> TerminalLaunchSpec {
+        TerminalLaunchSpec(
+            sessionKey: sessionKey(for: workspace),
+            workingDirectory: workspace.workspaceURL
+        )
+    }
+
+    func startWorkspace(_ workspace: WorkspaceProviderTarget) async throws {}
+    func stopWorkspace(_ workspace: WorkspaceProviderTarget) async throws {}
+    func archiveWorkspace(_ workspace: WorkspaceProviderTarget) async throws {}
+    func deleteWorkspace(_ workspace: WorkspaceProviderTarget) async throws {}
+
+    func syncStatuses(
+        for workspaces: [WorkspaceProviderTarget]
+    ) async throws -> [WorkspaceProviderStatusSnapshot] {
+        if let error {
+            throw error
+        }
+        return snapshots
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/MainWindowMaintenanceControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowMaintenanceControllerTests.swift
@@ -67,7 +67,9 @@ struct MainWindowMaintenanceControllerTests {
         let groups = controller.statusSyncGroups(repos: [repo])
 
         #expect(Set(groups.keys) == ["daytona", "lume"])
-        #expect(Set(groups["daytona", default: []].map(\.name)) == ["d1", "d2"])
+        // Ordered: a group keeps the order its workspaces appear in, which is the order
+        // the sync pass asks the provider about them.
+        #expect(groups["daytona", default: []].map(\.name) == ["d1", "d2"])
         #expect(groups["lume", default: []].map(\.name) == ["l1"])
     }
 
@@ -81,6 +83,14 @@ struct MainWindowMaintenanceControllerTests {
 
     // MARK: - Status decision
 
+    private func changes(
+        for workspaces: [Workspace],
+        snapshots: [WorkspaceProviderStatusSnapshot]
+    ) -> [MainWindowMaintenanceController.StatusChange] {
+        let reported = controller.statusesByRemoteID(from: snapshots)
+        return workspaces.compactMap { controller.statusChange(for: $0, statusesByRemoteID: reported) }
+    }
+
     @Test("Only workspaces whose status actually moved are reported, with the prior status")
     func statusChangesReportOnlyRealTransitions() {
         let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
@@ -91,7 +101,7 @@ struct MainWindowMaintenanceControllerTests {
             repo: repo, name: "steady", backendIdentifier: "daytona", remoteId: "d-2",
             status: .active)
 
-        let changes = controller.statusChanges(
+        let result = changes(
             for: [moving, steady],
             snapshots: [
                 WorkspaceProviderStatusSnapshot(remoteId: "d-1", status: .stopped),
@@ -99,10 +109,10 @@ struct MainWindowMaintenanceControllerTests {
             ]
         )
 
-        #expect(changes.count == 1)
-        #expect(changes.first?.workspace.name == "moving")
-        #expect(changes.first?.previousStatus == .active)
-        #expect(changes.first?.newStatus == .stopped)
+        #expect(result.count == 1)
+        #expect(result.first?.workspace.name == "moving")
+        #expect(result.first?.previousStatus == .active)
+        #expect(result.first?.newStatus == .stopped)
     }
 
     @Test("A workspace the provider no longer reports is treated as archived")
@@ -112,9 +122,7 @@ struct MainWindowMaintenanceControllerTests {
             repo: repo, name: "vanished", backendIdentifier: "daytona", remoteId: "gone",
             status: .active)
 
-        let changes = controller.statusChanges(for: [vanished], snapshots: [])
-
-        #expect(changes.map(\.newStatus) == [.archived])
+        #expect(changes(for: [vanished], snapshots: []).map(\.newStatus) == [.archived])
     }
 
     @Test("A workspace already archived and still unreported produces no change")
@@ -124,7 +132,53 @@ struct MainWindowMaintenanceControllerTests {
             repo: repo, name: "archived", backendIdentifier: "daytona", remoteId: "gone",
             status: .archived)
 
-        #expect(controller.statusChanges(for: [archived], snapshots: []).isEmpty)
+        #expect(changes(for: [archived], snapshots: []).isEmpty)
+    }
+
+    @Test("A workspace whose status was already applied this pass settles instead of moving again")
+    func statusChangeSettlesAfterAnEarlierWriteInTheSamePass() throws {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let workspace = makeWorkspace(
+            repo: repo, name: "remote", backendIdentifier: "daytona", remoteId: "d-1",
+            status: .active)
+        let reported = controller.statusesByRemoteID(
+            from: [WorkspaceProviderStatusSnapshot(remoteId: "d-1", status: .stopped)]
+        )
+
+        let first = try #require(controller.statusChange(for: workspace, statusesByRemoteID: reported))
+        workspace.status = first.newStatus
+        let second = controller.statusChange(for: workspace, statusesByRemoteID: reported)
+
+        #expect(first.newStatus == .stopped)
+        #expect(second == nil)
+    }
+
+    /// A workspace reached twice in one pass must transition once. Batching a group's
+    /// decisions ahead of its writes would report and log it twice.
+    @Test("A workspace reached twice in one pass transitions once")
+    func syncPassAppliesRepeatedIdentityOnce() async throws {
+        let context = ModelContext(try makeContainer())
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        context.insert(repo)
+        let workspace = makeWorkspace(
+            repo: repo, name: "remote", backendIdentifier: "daytona", remoteId: "d-1",
+            status: .active, context: context)
+
+        let provider = StatusSyncStubProvider(
+            id: "daytona",
+            snapshots: [WorkspaceProviderStatusSnapshot(remoteId: "d-1", status: .stopped)]
+        )
+
+        // The same repo twice surfaces the same Workspace identity twice in one group.
+        let outcome = await controller.syncWorkspaceStatuses(
+            repos: [repo, repo],
+            registry: makeRegistry([provider]),
+            modelContext: context,
+            trigger: "test"
+        )
+
+        #expect(outcome.changedCount == 1)
+        #expect(workspace.status == .stopped)
     }
 
     // MARK: - Sync pass
@@ -277,6 +331,45 @@ struct MainWindowMaintenanceControllerTests {
         #expect(inputs.workspaces.map(\.workspaceID) == [workspace.id])
         #expect(inputs.workspaces.map(\.repoID) == [repo.id])
         #expect(inputs.workspaces.map(\.lastAccessedAt) == [workspace.lastAccessedAt])
+    }
+
+    /// The projection is only useful if session state actually reaches it, so this asserts a
+    /// live agent status lands on the matching workspace and bubbles to its repo — and that a
+    /// session on an unrelated key does not.
+    @Test("A live agent status reaches the workspace whose session key matches")
+    func aggregatorInputsCarryLiveAgentStatus() throws {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let workspace = makeWorkspace(
+            repo: repo, name: "feature-a", backendIdentifier: "local", remoteId: nil)
+
+        let matching = HostTerminalSession(
+            key: .hostPath(workspace.workspaceURL.path),
+            directory: workspace.workspaceURL
+        )
+        let unrelated = HostTerminalSession(
+            key: .hostPath("/tmp/somewhere-else"),
+            directory: URL(fileURLWithPath: "/tmp/somewhere-else")
+        )
+        let status = AgentSessionStatus(
+            hostSessionID: matching.id,
+            cwd: workspace.workspaceURL.path,
+            run: .thinking,
+            lastEventAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        let inputs = controller.aggregatorInputs(
+            repos: [repo],
+            sessions: [matching, unrelated],
+            agentStatusBySessionID: [matching.id: status],
+            registry: makeRegistry([]),
+            normalizePath: { $0.path }
+        )
+
+        #expect(inputs.workspaces.compactMap(\.status) == [status])
+        #expect(inputs.workspaces.count == 1)
+        // The repo's own key has no session, so its status stays nil; roll-up to the repo row
+        // is the aggregator's job, not the projection's.
+        #expect(inputs.repos.allSatisfy { $0.status == nil })
     }
 
     @Test("With no registered agent status every input reports nil rather than a stale status")


### PR DESCRIPTION
Slice 2 of the `ContentView` decomposition. Refs #1160 — slices 3–6 remain, so no `Closes`.

Follows [slice 1](https://github.com/fairchild/workspaces/pull/1186), rebased onto a `main` that already carries both it and the #1184 logger-category pass.

## What moves

The periodic maintenance work the main window drives, into `MainWindowMaintenanceController`:

- **The remote status-sync pass** — moved wholesale. Its dependencies are only `repos`, the provider registry, and the model context, so it goes over the boundary intact rather than being split into decide-here/act-there. That puts the `modelContext.save()` this slice was flagged for under test.
- **`statusSyncGroups` / `statusChange`** — the two decisions inside that pass, now named: which workspaces are worth asking a provider about, and what a provider's answer implies for one of them. The "provider no longer reports it → treat as archived" rule was previously a `?? .archived` buried mid-loop.
- **`expiredArchivedWorkspaces`** — was a `static func` on `ContentView` with its own tests; body unchanged, tests repointed.
- **The sidebar-aggregator projection** — ~40 lines of inline input-building, now a pure function over repos, sessions, agent status, and the registry.

The archived purge itself **stays in the view**. It clears the current selection on the way through (`setSelectedWorkspace(nil)` when the purged workspace was selected), and selection state belongs with the view. Pushing it across would have meant handing the controller a selection callback — more coupling than the extraction buys.

`ContentView` drops 103 lines (3,697 → 3,594).

### Logger categories

The moved code emits four log lines. #1184 renamed `Perf` → `PerformanceSignposts` just before this branch, so the new file declares `PerformanceSignposts` and `WorkspaceProvider` to match what that pass left in `ContentView`. The emitted strings are unchanged; only their file moved.

## Verification

- `swift build` clean; `swift test` — 1,362 tests in 201 suites, all passing.
- `mise run lint` (`swift-format lint --strict`) clean.
- 15 new tests plus the 3 repointed purge tests: the sync work-list filters and their ordering, the status decision (treat-missing-as-archived, its already-archived no-op, and settling after an earlier write), the full sync pass against a stub provider — persistence, no-op, provider-failure isolation, unregistered provider, repeated identity, and the early return — and the aggregator projection with and without live agent status.
- Two mutation checks, both confirmed to fail against the broken form: deleting `modelContext.save()` fails `syncPassPersistsStatusChanges`, and reinstating the batched decision loop fails `syncPassAppliesRepeatedIdentityOnce` with `changed_count` 2 vs 1.

## Evidence

The live debug app through the fixture lane, no activation. This is the slice's own surface, not a generic screenshot: every status dot in the sidebar is the extracted `aggregatorInputs` projection's output, arriving through the real `refreshWorkspaceStatusAggregator` path on appear. The per-workspace dots (`refactor-runtime` red, `feature-auth` blue, `bugfix-422` yellow), the repo-level roll-up bubbling to `bread-builder` red and `bertram-chat` yellow, and the "2 need you" toolbar pill are all downstream of the moved code.

![phase-1-release](https://evidence.cloudcompute.com/workspaces/pr-1188/20260804-054237-phase-1-release.png)

## Review loop

Reflected on the diff, then a directed codex review (`gpt-5.6-sol`, xhigh) aimed at seven named failure modes plus a falsifiable completeness question. **It found a real defect**, and its first verdict was "not a pure extraction yet."

1. **High — batched decisions changed alias semantics.** `f9746b93` computed a provider group's status changes up front, then applied them. The original decided and wrote one workspace at a time. Codex constructed the case: pass `[repo, repo]`, so the same `Workspace` identity appears twice in one group. The original wrote `active → stopped` on the first occurrence and the second read `.stopped` and settled; the batched form read `.active` twice, logged the transition twice, and reported `changed_count=2`. Same final persisted status, different log sequence and tally. Low production likelihood — `@Query` supplies distinct models — but it is a behavior difference under the function's accepted inputs, which is exactly what an extraction-only contract forbids. Fixed in `b0a3671e` by splitting into `statusesByRemoteID(from:)` and a per-workspace `statusChange(for:statusesByRemoteID:)` and looping workspaces again, with a regression test that fails against the batched form.
2. **Low — three assertions couldn't distinguish a wrong extraction.** Within-group ordering was asserted as a `Set`, and the aggregator test's all-`nil` assertion would pass if sessions and statuses were ignored entirely. Both fixed in `b0a3671e`.

Everything else came back clean and checked explicitly: `syncableCount` always equals the old flat-array count; both perf templates, the provider-failure line, and the purge error line are unchanged in fields and ordering; the logger categories match what #1184 left (`PerformanceSignposts`, `WorkspaceProvider`); the early return, unregistered-provider skip, failure isolation, and save-once-if-changed all behave identically; the purge selector body is line-for-line identical with all four call sites repointed; aggregator ordering and the normalizer are unchanged; no isolation or reentrancy change.

Not fixed, and worth stating rather than implying: exact log emission counts and "saved exactly once" still have no assertion, because neither is observable without a logger or model-context spy.

## Mergeability

- Surface: desktop — main window background maintenance (remote status sync, archived purge, sidebar status roll-up)
- User-facing behavior changed: No. Extraction only. The sidebar roll-up above renders from the moved projection; log lines, perf-metric fields, and the save condition are unchanged.
- Non-happy paths considered: one provider throwing is still isolated — it logs, marks the pass a partial failure, and the other providers still apply (covered by a test); a workspace whose provider is not registered is still skipped without a per-provider perf line; the context is still saved once at the end and only when something changed; nothing syncable still short-circuits before any logging; a workspace the provider stops reporting is still treated as archived, and one already archived produces no write.
- Residual risk or follow-up: the decision/write interleaving that the review caught is restored and pinned by a mutation-checked regression test, so the remaining delta is structural only. Pre-existing and deliberately unchanged: `Dictionary(uniqueKeysWithValues:)` over provider snapshots still traps if a provider returns duplicate remote ids. Log emission counts and save-exactly-once are unasserted (no spy). Slices 3–6 remain.
