### PR TITLE
refactor(app): extract code-preview dirty-navigation guard from ContentView (#1160 slice 3)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/CodePreviewNavigationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/CodePreviewNavigationController.swift
@@ -1,0 +1,113 @@
+//
+//  CodePreviewNavigationController.swift
+//  WorkspaceManager
+//
+//  The editor's dirty-navigation flow (#704 Phase 4): whether opening another file or closing
+//  the preview proceeds now or pauses for Save / Discard / Cancel, and whether a Save that
+//  awaited across a newer navigation may still commit the target it captured.
+//  `DirtyNavigationGuard` owns the rules; this owns the state they read and the intents they
+//  produce, so the main window's use of the guard is testable without a window.
+//
+
+import Foundation
+
+/// A code-preview navigation intent deferred behind the dirty-editor prompt.
+enum PendingCodePreviewNavigation: Equatable {
+    case open(CodePreviewSelection)
+    case close
+}
+
+/// Deferred-navigation state for the code preview, held in one `@State`.
+struct CodePreviewNavigationState: Equatable {
+    /// The navigation held back by the unsaved-changes prompt. Non-nil presents the dialog.
+    private(set) var pending: PendingCodePreviewNavigation?
+
+    /// Monotonic token bumped each time a new pending navigation is raised, so a Save that
+    /// awaits across a newer navigation can detect it was superseded and decline to commit
+    /// its stale target.
+    private(set) var generation = 0
+
+    mutating func raise(_ navigation: PendingCodePreviewNavigation) {
+        generation &+= 1
+        pending = navigation
+    }
+
+    mutating func clearPending() {
+        pending = nil
+    }
+
+    /// Whether a Save-then-navigate that awaited an async save may still commit the target it
+    /// captured. Taking `currentGeneration` from `self` rather than an argument is the point:
+    /// the captured token comes from before the await, the current one from live state after
+    /// it, so a navigation raised in between wins by construction.
+    func canCommitDeferred(capturedGeneration: Int, hasUnsavedEdits: Bool) -> Bool {
+        DirtyNavigationGuard.shouldCommitDeferredNavigation(
+            capturedGeneration: capturedGeneration,
+            currentGeneration: generation,
+            hasUnsavedEdits: hasUnsavedEdits
+        )
+    }
+}
+
+@MainActor
+struct CodePreviewNavigationController {
+    /// What a navigation intent does right now.
+    enum NavigationAction: Equatable {
+        /// Nothing needed saving — navigate immediately.
+        case commit(PendingCodePreviewNavigation)
+        /// Hold the intent behind the unsaved-changes prompt.
+        case prompt(PendingCodePreviewNavigation)
+    }
+
+    /// What the user's answer to the prompt does.
+    enum PromptResolution: Equatable {
+        /// Cancel: drop the intent, leaving file and selection untouched.
+        case dismiss
+        /// Discard: navigate now.
+        case commit(PendingCodePreviewNavigation)
+        /// Save: write first, then navigate only if nothing superseded the intent.
+        case saveThenCommit(PendingCodePreviewNavigation)
+    }
+
+    /// Opening a file. Only a *different* file over a dirty editor prompts — re-selecting the
+    /// file already open is not navigation, so it never pauses.
+    func openAction(
+        for selection: CodePreviewSelection,
+        current: CodePreviewSelection?,
+        hasUnsavedEdits: Bool
+    ) -> NavigationAction {
+        if DirtyNavigationGuard.requiresPrompt(isDirty: hasUnsavedEdits),
+            let current,
+            current.id != selection.id
+        {
+            return .prompt(.open(selection))
+        }
+        return .commit(.open(selection))
+    }
+
+    /// Closing the preview from the editor's own Close button or the terminal toggle. Prompts
+    /// whenever a dirty file is open; with nothing open there is nothing to lose.
+    func closeAction(
+        current: CodePreviewSelection?,
+        hasUnsavedEdits: Bool
+    ) -> NavigationAction {
+        if DirtyNavigationGuard.requiresPrompt(isDirty: hasUnsavedEdits), current != nil {
+            return .prompt(.close)
+        }
+        return .commit(.close)
+    }
+
+    func resolution(
+        for choice: DirtyNavigationChoice,
+        pending: PendingCodePreviewNavigation
+    ) -> PromptResolution {
+        switch DirtyNavigationGuard.outcome(for: choice) {
+        case .veto:
+            return .dismiss
+        case .proceed:
+            return .commit(pending)
+        case .saveThenProceed:
+            return .saveThenCommit(pending)
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -32,12 +32,6 @@ private struct ModelSnapshot: Equatable {
     let webSourceIDs: [UUID]
 }
 
-/// A code-preview navigation intent deferred behind the dirty-editor prompt.
-enum PendingCodePreviewNavigation: Equatable {
-    case open(CodePreviewSelection)
-    case close
-}
-
 /// One activation of the embedded web-next surface. `redirect` is the relative
 /// path to land on after sign-in (`nil` = the app's default `/`); the unique
 /// `id` keys the detail view so a fresh activation always re-navigates.
@@ -116,12 +110,9 @@ struct ContentView: View {
     @State private var isShowingFeedbackSheet = false
     @State private var accessRecorder = MainWindowAccessRecorder()
     @State private var presentedSessionSwitcherSnapshot: SessionSwitcherSnapshot?
-    /// A code-preview navigation (open another file / close the preview) held back because the
-    /// open editor has unsaved edits, pending the Save / Discard / Cancel prompt (#704 Phase 4).
-    @State private var pendingCodePreviewNavigation: PendingCodePreviewNavigation?
-    /// Monotonic token bumped each time a new pending navigation is raised, so a Save that awaits
-    /// across a newer navigation can detect it was superseded and decline to commit its stale target.
-    @State private var codePreviewNavigationGeneration = 0
+    /// Code-preview navigation held back because the open editor has unsaved edits, pending the
+    /// Save / Discard / Cancel prompt (#704 Phase 4).
+    @State private var codePreviewNavigationState = CodePreviewNavigationState()
     @StateObject private var rightPaneStateStore = RightPaneStateStore()
     @StateObject private var automationWorkspaceCreateBridge = AutomationWorkspaceCreateGestureBridge()
     /// Seam store for the web main-content pane: a one-tile `SurfaceStore` domain. Source switches
@@ -148,6 +139,7 @@ struct ContentView: View {
     private let workspaceEnvironmentOptionsController = WorkspaceEnvironmentOptionsController()
     private let workspaceOrphanController = WorkspaceOrphanReconciliationController()
     private let maintenanceController = MainWindowMaintenanceController()
+    private let codePreviewController = CodePreviewNavigationController()
 
     private var launchRepositoryService: LaunchRepositoryService {
         LaunchRepositoryService(modelContext: modelContext)
@@ -1177,7 +1169,7 @@ struct ContentView: View {
                 "Unsaved changes",
                 isPresented: pendingCodePreviewNavigationBinding,
                 titleVisibility: .visible,
-                presenting: pendingCodePreviewNavigation
+                presenting: codePreviewNavigationState.pending
             ) { _ in
                 Button("Save") { resolvePendingCodePreviewNavigation(.save) }
                 Button("Discard", role: .destructive) { resolvePendingCodePreviewNavigation(.discard) }
@@ -1189,9 +1181,9 @@ struct ContentView: View {
 
     private var pendingCodePreviewNavigationBinding: Binding<Bool> {
         Binding(
-            get: { pendingCodePreviewNavigation != nil },
+            get: { codePreviewNavigationState.pending != nil },
             set: { isPresented in
-                if !isPresented { pendingCodePreviewNavigation = nil }
+                if !isPresented { codePreviewNavigationState.clearPending() }
             }
         )
     }
@@ -2660,26 +2652,33 @@ struct ContentView: View {
     }
 
     private func handleCodePreviewSelection(_ selection: CodePreviewSelection) {
-        // Opening a different file while the current one is dirty pauses for Save / Discard / Cancel.
-        if DirtyNavigationGuard.requiresPrompt(isDirty: appCommandState.hasUnsavedDocumentEdits),
-            let current = viewState.selectedCodePreview,
-            current.id != selection.id
-        {
-            raisePendingCodePreviewNavigation(.open(selection))
-            return
+        applyCodePreviewNavigation(
+            codePreviewController.openAction(
+                for: selection,
+                current: viewState.selectedCodePreview,
+                hasUnsavedEdits: appCommandState.hasUnsavedDocumentEdits
+            )
+        )
+    }
+
+    private func applyCodePreviewNavigation(
+        _ action: CodePreviewNavigationController.NavigationAction
+    ) {
+        switch action {
+        case .commit(let navigation):
+            commitCodePreviewNavigation(navigation)
+        case .prompt(let navigation):
+            codePreviewNavigationState.raise(navigation)
         }
-        commitCodePreviewSelection(selection)
     }
 
-    /// Set a new pending navigation and bump the generation token so an in-flight Save resolving an
-    /// older intent can see it was superseded.
-    private func raisePendingCodePreviewNavigation(_ pending: PendingCodePreviewNavigation) {
-        codePreviewNavigationGeneration &+= 1
-        pendingCodePreviewNavigation = pending
-    }
-
-    private func commitCodePreviewSelection(_ selection: CodePreviewSelection) {
-        viewState.selectedCodePreview = selection
+    private func commitCodePreviewNavigation(_ navigation: PendingCodePreviewNavigation) {
+        switch navigation {
+        case .open(let selection):
+            viewState.selectedCodePreview = selection
+        case .close:
+            viewState.selectedCodePreview = nil
+        }
         viewState.isTerminalPanelVisible = true
     }
 
@@ -2716,60 +2715,44 @@ struct ContentView: View {
     /// here — a full repo/workspace-switch prompt is deferred (#704 Phase 4 follow-up); this path
     /// only tears the preview down alongside its context.
     private func clearCodePreview() {
-        commitClearCodePreview()
+        commitCodePreviewNavigation(.close)
     }
 
     /// Guarded close for the editor's own Close button / terminal toggle: when the open file is
     /// dirty this pauses for Save / Discard / Cancel instead of dropping edits.
     private func requestCloseCodePreview() {
-        if DirtyNavigationGuard.requiresPrompt(isDirty: appCommandState.hasUnsavedDocumentEdits),
-            viewState.selectedCodePreview != nil
-        {
-            raisePendingCodePreviewNavigation(.close)
-            return
-        }
-        commitClearCodePreview()
-    }
-
-    private func commitClearCodePreview() {
-        viewState.selectedCodePreview = nil
-        viewState.isTerminalPanelVisible = true
+        applyCodePreviewNavigation(
+            codePreviewController.closeAction(
+                current: viewState.selectedCodePreview,
+                hasUnsavedEdits: appCommandState.hasUnsavedDocumentEdits
+            )
+        )
     }
 
     /// Resolve a deferred code-preview navigation once the user answers the unsaved-changes prompt.
     private func resolvePendingCodePreviewNavigation(_ choice: DirtyNavigationChoice) {
-        guard let pending = pendingCodePreviewNavigation else { return }
-        switch DirtyNavigationGuard.outcome(for: choice) {
-        case .veto:
-            pendingCodePreviewNavigation = nil
-        case .proceed:
-            pendingCodePreviewNavigation = nil
-            commitPendingCodePreviewNavigation(pending)
-        case .saveThenProceed:
+        guard let pending = codePreviewNavigationState.pending else { return }
+        switch codePreviewController.resolution(for: choice, pending: pending) {
+        case .dismiss:
+            codePreviewNavigationState.clearPending()
+        case .commit(let navigation):
+            codePreviewNavigationState.clearPending()
+            commitCodePreviewNavigation(navigation)
+        case .saveThenCommit(let navigation):
             // Capture the generation now; a newer navigation raised during the await bumps it and
             // must win. After the save, only commit this (captured) target if nothing superseded it
             // and the document is genuinely clean — the user may have typed more while the write was
             // in flight, which would leave it dirty again.
-            let capturedGeneration = codePreviewNavigationGeneration
+            let capturedGeneration = codePreviewNavigationState.generation
             Task { @MainActor in
                 await appCommandState.saveDirtyDocument()
-                if DirtyNavigationGuard.shouldCommitDeferredNavigation(
+                if codePreviewNavigationState.canCommitDeferred(
                     capturedGeneration: capturedGeneration,
-                    currentGeneration: codePreviewNavigationGeneration,
                     hasUnsavedEdits: appCommandState.hasUnsavedDocumentEdits
                 ) {
-                    commitPendingCodePreviewNavigation(pending)
+                    commitCodePreviewNavigation(navigation)
                 }
             }
-        }
-    }
-
-    private func commitPendingCodePreviewNavigation(_ pending: PendingCodePreviewNavigation) {
-        switch pending {
-        case .open(let selection):
-            commitCodePreviewSelection(selection)
-        case .close:
-            commitClearCodePreview()
         }
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2714,6 +2714,9 @@ struct ContentView: View {
     /// surrounding selection has already changed. The dirty-edit veto deliberately does not fire
     /// here — a full repo/workspace-switch prompt is deferred (#704 Phase 4 follow-up); this path
     /// only tears the preview down alongside its context.
+    /// Commits `.close` directly and must keep doing so: routing this through
+    /// `codePreviewController.closeAction` would make repo/workspace removal prompt for unsaved
+    /// edits instead of tearing the preview down, and every controller test would stay green.
     private func clearCodePreview() {
         commitCodePreviewNavigation(.close)
     }

--- a/Tests/WorkspaceManagerAppTests/CodePreviewNavigationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/CodePreviewNavigationControllerTests.swift
@@ -187,6 +187,26 @@ struct CodePreviewNavigationControllerTests {
         #expect(state.canCommitDeferred(capturedGeneration: captured, hasUnsavedEdits: false))
     }
 
+    /// The same rule with a real suspension between capture and check, mirroring the production
+    /// shape: capture the generation, await, then read. This pins the ordering; it does not reach
+    /// the `@State` wrapper itself, so it would not catch production snapshotting the struct into
+    /// a local before the Task instead of reading through the wrapper after it. That property was
+    /// verified out-of-band by a hosted-SwiftUI probe during review — see the PR's Review loop.
+    @Test("A navigation raised across a suspension still supersedes the captured target")
+    func deferredCommitIsVetoedAcrossASuspension() async {
+        var state = CodePreviewNavigationState()
+        state.raise(.open(selection("b.swift")))
+        let captured = state.generation
+
+        await Task.yield()
+        state.raise(.open(selection("c.swift")))
+        await Task.yield()
+
+        #expect(
+            state.canCommitDeferred(capturedGeneration: captured, hasUnsavedEdits: false) == false
+        )
+    }
+
     /// End-to-end ordering over the real sequence: open A dirty → prompt → Save → user opens C
     /// mid-save → the save resolves. C must win.
     @Test("Across a full save-then-supersede sequence the newer navigation wins")

--- a/Tests/WorkspaceManagerAppTests/CodePreviewNavigationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/CodePreviewNavigationControllerTests.swift
@@ -1,0 +1,226 @@
+//
+//  CodePreviewNavigationControllerTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Coverage for the editor's dirty-navigation flow: when opening or closing pauses for the
+//  unsaved-changes prompt, what each answer does, and the generation-token rule that decides
+//  whether a Save which awaited across a newer navigation may still commit its captured target.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("CodePreviewNavigation")
+struct CodePreviewNavigationControllerTests {
+    private let controller = CodePreviewNavigationController()
+
+    private func selection(_ path: String) -> CodePreviewSelection {
+        CodePreviewSelection(rootURL: URL(fileURLWithPath: "/tmp/repo"), relativePath: path)
+    }
+
+    // MARK: - Opening a file
+
+    @Test("With a clean editor, opening a file navigates immediately")
+    func openWithCleanEditorCommits() {
+        let target = selection("b.swift")
+
+        let action = controller.openAction(
+            for: target,
+            current: selection("a.swift"),
+            hasUnsavedEdits: false
+        )
+
+        #expect(action == .commit(.open(target)))
+    }
+
+    @Test("Opening a different file over unsaved edits pauses for the prompt")
+    func openDifferentFileOverDirtyEditorPrompts() {
+        let target = selection("b.swift")
+
+        let action = controller.openAction(
+            for: target,
+            current: selection("a.swift"),
+            hasUnsavedEdits: true
+        )
+
+        #expect(action == .prompt(.open(target)))
+    }
+
+    @Test("Re-selecting the file already open never prompts, dirty or not")
+    func reopeningTheCurrentFileCommits() {
+        let target = selection("a.swift")
+
+        let action = controller.openAction(for: target, current: target, hasUnsavedEdits: true)
+
+        #expect(action == .commit(.open(target)))
+    }
+
+    @Test("With no file open there is nothing to lose, so opening commits")
+    func openWithNothingOpenCommits() {
+        let target = selection("a.swift")
+
+        let action = controller.openAction(for: target, current: nil, hasUnsavedEdits: true)
+
+        #expect(action == .commit(.open(target)))
+    }
+
+    // MARK: - Closing the preview
+
+    @Test("Closing a dirty editor pauses for the prompt")
+    func closeWithDirtyEditorPrompts() {
+        let action = controller.closeAction(current: selection("a.swift"), hasUnsavedEdits: true)
+
+        #expect(action == .prompt(.close))
+    }
+
+    @Test("Closing a clean editor closes immediately")
+    func closeWithCleanEditorCommits() {
+        let action = controller.closeAction(current: selection("a.swift"), hasUnsavedEdits: false)
+
+        #expect(action == .commit(.close))
+    }
+
+    @Test("Closing with nothing open commits even while another document is dirty")
+    func closeWithNothingOpenCommits() {
+        let action = controller.closeAction(current: nil, hasUnsavedEdits: true)
+
+        #expect(action == .commit(.close))
+    }
+
+    // MARK: - Answering the prompt
+
+    @Test("Cancel drops the intent, Discard navigates, Save writes first")
+    func promptAnswersMapToResolutions() {
+        let pending = PendingCodePreviewNavigation.open(selection("b.swift"))
+
+        #expect(controller.resolution(for: .cancel, pending: pending) == .dismiss)
+        #expect(controller.resolution(for: .discard, pending: pending) == .commit(pending))
+        #expect(controller.resolution(for: .save, pending: pending) == .saveThenCommit(pending))
+    }
+
+    @Test("A close intent survives the prompt as a close, not as an open")
+    func closeIntentRoundTripsThroughThePrompt() {
+        #expect(
+            controller.resolution(for: .discard, pending: .close) == .commit(.close)
+        )
+    }
+
+    // MARK: - Deferred-navigation state
+
+    @Test("Raising a navigation records it and bumps the generation")
+    func raiseRecordsPendingAndBumpsGeneration() {
+        var state = CodePreviewNavigationState()
+        let target = selection("b.swift")
+
+        #expect(state.pending == nil)
+        let before = state.generation
+
+        state.raise(.open(target))
+
+        #expect(state.pending == .open(target))
+        #expect(state.generation == before &+ 1)
+    }
+
+    @Test("Dismissing the prompt clears the intent without bumping the generation")
+    func clearPendingLeavesGenerationAlone() {
+        var state = CodePreviewNavigationState()
+        state.raise(.close)
+        let generation = state.generation
+
+        state.clearPending()
+
+        #expect(state.pending == nil)
+        #expect(state.generation == generation)
+    }
+
+    /// The happy path: Save completes, nothing else happened, the document is clean.
+    @Test("An uncontested save commits the target it captured")
+    func deferredCommitProceedsWhenNothingSuperseded() {
+        var state = CodePreviewNavigationState()
+        state.raise(.open(selection("b.swift")))
+        let captured = state.generation
+
+        #expect(state.canCommitDeferred(capturedGeneration: captured, hasUnsavedEdits: false))
+    }
+
+    /// The rule this slice exists to pin: a navigation raised while the save was in flight
+    /// bumps the generation, so the older intent must not land the user on a stale file.
+    @Test("A navigation raised during the save supersedes the captured target")
+    func deferredCommitIsVetoedBySupersedingNavigation() {
+        var state = CodePreviewNavigationState()
+        state.raise(.open(selection("b.swift")))
+        let captured = state.generation
+
+        // User picks a third file while the write is still in flight.
+        state.raise(.open(selection("c.swift")))
+
+        #expect(
+            state.canCommitDeferred(capturedGeneration: captured, hasUnsavedEdits: false) == false
+        )
+    }
+
+    /// Typing during the save leaves the document dirty again; committing would drop those edits.
+    @Test("Edits typed during the save veto the deferred commit")
+    func deferredCommitIsVetoedByFreshEdits() {
+        var state = CodePreviewNavigationState()
+        state.raise(.open(selection("b.swift")))
+        let captured = state.generation
+
+        #expect(
+            state.canCommitDeferred(capturedGeneration: captured, hasUnsavedEdits: true) == false
+        )
+    }
+
+    /// Dismissing the dialog must not silently re-enable a superseded save: clearing the intent
+    /// leaves the generation alone, so an in-flight capture stays valid on its own terms.
+    @Test("Clearing the pending intent does not by itself veto an in-flight save")
+    func clearPendingDoesNotVetoDeferredCommit() {
+        var state = CodePreviewNavigationState()
+        state.raise(.open(selection("b.swift")))
+        let captured = state.generation
+
+        state.clearPending()
+
+        #expect(state.canCommitDeferred(capturedGeneration: captured, hasUnsavedEdits: false))
+    }
+
+    /// End-to-end ordering over the real sequence: open A dirty → prompt → Save → user opens C
+    /// mid-save → the save resolves. C must win.
+    @Test("Across a full save-then-supersede sequence the newer navigation wins")
+    func fullSupersessionSequence() {
+        var state = CodePreviewNavigationState()
+
+        let first = controller.openAction(
+            for: selection("b.swift"),
+            current: selection("a.swift"),
+            hasUnsavedEdits: true
+        )
+        guard case .prompt(let firstIntent) = first else {
+            Issue.record("Expected the first open to prompt")
+            return
+        }
+        state.raise(firstIntent)
+
+        #expect(controller.resolution(for: .save, pending: firstIntent) == .saveThenCommit(firstIntent))
+        let captured = state.generation
+
+        let second = controller.openAction(
+            for: selection("c.swift"),
+            current: selection("a.swift"),
+            hasUnsavedEdits: true
+        )
+        guard case .prompt(let secondIntent) = second else {
+            Issue.record("Expected the second open to prompt")
+            return
+        }
+        state.raise(secondIntent)
+
+        #expect(
+            state.canCommitDeferred(capturedGeneration: captured, hasUnsavedEdits: false) == false
+        )
+        #expect(state.pending == secondIntent)
+    }
+}


### PR DESCRIPTION
Slice 3 of the `ContentView` decomposition. Refs #1160 — slices 4–6 remain, so no `Closes`.

Follows [slice 1](https://github.com/fairchild/workspaces/pull/1186) and [slice 2](https://github.com/fairchild/workspaces/pull/1188), rebased onto a `main` that already carries #1189's StrictConcurrency warnings and the new `NeverForceUnwrap` / `NeverUseForceTry` rules.

## What moves

The editor's dirty-navigation flow (#704 Phase 4), into `CodePreviewNavigationController.swift`:

- **`CodePreviewNavigationState`** — the two `@State` (`pendingCodePreviewNavigation` + `codePreviewNavigationGeneration`) collapsed into one value struct, plus `PendingCodePreviewNavigation` which now lives with the state it describes.
- **`CodePreviewNavigationController`** — `openAction`, `closeAction`, and `resolution(for:pending:)`: whether a navigation proceeds or pauses for Save / Discard / Cancel, and what each answer does.

**This slice is about coverage, not line count.** `ContentView` drops only 17 lines (3,594 → 3,577) — the plan's ~105 estimate counted the commit plumbing, which mutates `viewState` and correctly stays in the view. What it buys is that the generation-token supersession rule — *a navigation raised while a Save is in flight must beat the one that Save captured* — had **no test at all**. `DirtyNavigationGuard` was tested; the main window's use of it was not, and that use is the subtle part.

One deliberate shape change: `canCommitDeferred(capturedGeneration:hasUnsavedEdits:)` takes `currentGeneration` from `self` rather than as an argument. The captured token comes from before the `await`, the current one from live state after it — making that relationship structural instead of a convention a future edit could quietly break.

## Verification

- `swift build` clean; `swift test` — 1,379 tests in 202 suites, all passing, **after** the rebase onto #1189.
- `mise run lint` clean under the new `NeverForceUnwrap` / `NeverUseForceTry` rules, re-run post-rebase. No new StrictConcurrency warnings from the touched files (the remaining `StatusLinePayload` ones are pre-existing in Core).
- 17 new tests: the prompt predicates for open and close (including the asymmetry — re-opening the *same* file never prompts, closing always does when a dirty file is open), the Cancel/Discard/Save resolution table, and six on the generation rule.

## Evidence

Two mutation checks, both re-run and confirmed to fail against the broken form — this is the substance of the "behavior preserved" claim:

| Mutation | Result |
|---|---|
| Remove the generation bump from `raise` | 4 tests fail, including both supersession cases |
| Drop the same-file `id` guard in `openAction` | re-select test fails (would prompt on re-opening the current file) |

![s3-mutation-check](https://evidence.cloudcompute.com/workspaces/pr-1190/20260804-064642-s3-mutation-check.png)

![s3-dirty-navigation-tests](https://evidence.cloudcompute.com/workspaces/pr-1190/20260804-064608-s3-dirty-navigation-tests.png)

**No fixture-lane screenshot, and the reason matters.** This slice's visible surface is the "Unsaved changes" confirmation dialog, which needs a dirty editor *plus* a navigation attempt — the fixture lane cannot stage it, and the `WORKSPACES_UI_FIXTURE_OPEN_PREVIEW` bootstrap writes `selectedCodePreview` directly via `MainWindowLaunchActionHandler`, bypassing the extracted path entirely. A main-window screenshot would have shown the surface without exercising any of this diff, so it would have been decoration, not evidence.

Separately, window capture on this host started returning blank frames at ~23:04 local (`could not create image from window`; the same lane succeeded at 21:25 and 22:22 for slices 1–2). Worth a look independently of this PR — it will block the next slice that does have a stageable surface.

## Review loop

Reflected on the diff, then a directed codex review (`gpt-5.6-sol`, xhigh) over eight named failure modes plus a falsifiable completeness question. Verdict: **a pure behavioral extraction, no correctness blocker.**

The one I most wanted checked came back clean with better evidence than my own reasoning: the post-`await` read still observes writes made during the save, because the escaped closure captures the `@State` *location*, not a snapshot of the struct. Codex verified that with a direct hosted-SwiftUI probe rather than by argument. Also confirmed: the Save branch still does not clear the pending intent (dismissal owns that, as before); no formerly read-only path now writes state; both commit arms preserve their exact `viewState` assignments; `clearCodePreview()` still bypasses the guard; and the prompt predicates are exact.

Two coverage findings, both addressed in `7054bf06`:

1. **Medium — the generation tests didn't exercise the `@State`/Task boundary.** They mutated a local struct synchronously, so they'd stay green if production snapshotted the state into a local before the `Task`. Added a case with a real suspension between capture and check. That pins the ordering but not the wrapper; the wrapper property is what codex's probe verified, and the test says so in a comment rather than implying more than it proves.
2. **Low — a future edit could route the unguarded `clearCodePreview()` through the guarded close**, making repo/workspace removal prompt for unsaved edits with every controller test still green. Not testable without hosting the view, so the invariant is now stated at the call site.

## Mergeability

- Surface: desktop — editor dirty-navigation guard (unsaved-changes prompt when opening another file or closing the code preview)
- User-facing behavior changed: No. Extraction only; the prompt predicates, the Save/Discard/Cancel table, and the supersession rule are unchanged, and the mutation checks above are what backs that rather than a narrative claim.
- Non-happy paths considered: re-selecting the file already open still never prompts; closing with nothing open still commits even while another document is dirty; Cancel still leaves file and selection untouched; a navigation raised during an in-flight Save still wins over the captured one; edits typed during the Save still veto the deferred commit; and the unguarded teardown used by repo/workspace removal still bypasses the prompt entirely.
- Residual risk or follow-up: the `@State`-wrapper read after the `await` is the load-bearing detail and is verified by codex's hosted probe rather than by a test in this repo — a hosted-view test is the honest follow-up if this area changes again. No fixture screenshot for the reason above; window capture on this host is currently broken and worth separate attention. Slices 4–6 remain.

Made with [Orca](https://github.com/stablyai/orca) 🐋
