### PR TITLE
refactor(app): extract session-restore banner flow from ContentView (#1160 slice 4)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -103,8 +103,7 @@ struct ContentView: View {
     @State private var didScheduleInitialWorkspaceStatusSync = false
     @State private var didPrewarmPerfTerminalSurfaces = false
     @State private var workspaceOrphanState = WorkspaceOrphanReconciliationState()
-    @State private var pendingRestorePlan: RestorePlan?
-    @State private var restoreBannerDismissed = false
+    @State private var restoreState = MainWindowRestoreState()
     @AppStorage(TerminalRestoreBannerStorage.handledRunIDKey)
     private var restoreHandledRunID = ""
     @State private var isShowingFeedbackSheet = false
@@ -140,6 +139,7 @@ struct ContentView: View {
     private let workspaceOrphanController = WorkspaceOrphanReconciliationController()
     private let maintenanceController = MainWindowMaintenanceController()
     private let codePreviewController = CodePreviewNavigationController()
+    private let restoreController = MainWindowRestoreController()
 
     private var launchRepositoryService: LaunchRepositoryService {
         LaunchRepositoryService(modelContext: modelContext)
@@ -779,7 +779,7 @@ struct ContentView: View {
                     }
                 )
             }
-            if let plan = pendingRestorePlan, !plan.surfaces.isEmpty, !restoreBannerDismissed {
+            if let plan = restoreState.bannerPlan {
                 RestoreSessionsBanner(
                     sessionCount: plan.surfaces.count,
                     onRestore: {
@@ -3062,19 +3062,23 @@ struct ContentView: View {
             localStateStore: localStateStore,
             normalizePath: RestorePathNormalization.normalize
         ).makePlan(index: index)
-        if plan.surfaces.isEmpty {
+        switch restoreController.disposition(
+            for: plan,
+            handledRunID: restoreHandledRunID,
+            seedKey: .defaultHome,
+            seedDirectory: resolvedDefaultHostDirectory
+        ) {
+        case .noRestorableSurfaces:
             restoreLog.info("[Restore] no restorable surfaces from previous run")
-        } else if plan.wasHandled(handledRunID: restoreHandledRunID.isEmpty ? nil : restoreHandledRunID) {
+        case .alreadyHandled(let previousRunID):
             restoreLog.info(
-                "[Restore] suppressed banner: previous run \(plan.previousRunID ?? "?", privacy: .public) already handled"
+                "[Restore] suppressed banner: previous run \(previousRunID ?? "?", privacy: .public) already handled"
             )
-        } else if !plan.offersMoreThanLaunchSeed(
-            seedKey: .defaultHome, seedDirectory: resolvedDefaultHostDirectory)
-        {
+        case .onlyDuplicatesLaunchSeed:
             restoreLog.info("[Restore] suppressed banner: plan only duplicates the launch seed")
-        } else {
+        case .offer:
             restoreLog.info("[Restore] planned \(plan.surfaces.count, privacy: .public) restorable surface(s)")
-            pendingRestorePlan = plan
+            restoreState.offer(plan)
             autorunRestoreIfRequested(plan)
         }
     }
@@ -3084,7 +3088,8 @@ struct ContentView: View {
     /// if the user clicked Restore, so smoke scripts can exercise the real
     /// resume path without desktop input. No effect outside that environment.
     private func autorunRestoreIfRequested(_ plan: RestorePlan) {
-        guard ProcessInfo.processInfo.environment["WORKSPACES_RESTORE_AUTORUN"] == "1" else { return }
+        guard restoreController.isAutorunRequested(environment: ProcessInfo.processInfo.environment)
+        else { return }
         restoreLog.info("[Restore] autorun: executing planned restore after settle delay")
         Task { @MainActor in
             // Approximate a real banner click: let launch layout settle first.
@@ -3098,10 +3103,10 @@ struct ContentView: View {
     /// dismissed), then hide the banner for the rest of this launch. Later
     /// launches that select the same prior run won't re-offer it.
     private func markRestorePlanHandled(_ plan: RestorePlan) {
-        if let previousRunID = plan.previousRunID {
+        if let previousRunID = restoreController.handledRunID(for: plan) {
             restoreHandledRunID = previousRunID
         }
-        restoreBannerDismissed = true
+        restoreState.dismissBanner()
     }
 
     /// Launch each surface in a restore plan. Reattach/fresh surfaces are a plain
@@ -3116,7 +3121,7 @@ struct ContentView: View {
         // pre-restore seed (the default-home fallback) left on those keys, so a
         // resume/reattach surface is created fresh and the coordinator's key-reuse
         // path can't drop its initial command.
-        for key in Set(plan.surfaces.map(\.key)) {
+        for key in restoreController.ownedSessionKeys(in: plan) {
             _ = tileTreeStore.retireSessions(inScope: key)
         }
 
@@ -3126,26 +3131,16 @@ struct ContentView: View {
         // the resume surface starts a fresh session instead of `-A`-attaching to
         // the retired seed's leftover shell.
         let tmuxProbe = TmuxSessionProbe()
-        for surface in plan.surfaces {
-            if case .resumeClaude = surface.action {
-                await tmuxProbe.killSession(
-                    GhosttyTerminalConfig.tmuxSessionName(for: surface.directory))
-            }
+        for directory in restoreController.tmuxSessionDirectoriesToKill(in: plan) {
+            await tmuxProbe.killSession(GhosttyTerminalConfig.tmuxSessionName(for: directory))
         }
 
         var activatedByHostSessionID: [UUID: HostTerminalSession] = [:]
         for surface in plan.surfaces {
-            let initialCommand: String?
-            switch surface.action {
-            case .reattachTmux, .freshShell:
-                initialCommand = nil
-            case .resumeClaude(let agentSessionID):
-                initialCommand = RestoreLaunchCommand.claudeResume(sessionID: agentSessionID)
-            }
             let session = activateHostSession(
                 key: surface.key,
                 directory: surface.directory,
-                initialCommand: initialCommand
+                initialCommand: restoreController.initialCommand(for: surface.action)
             )
             activatedByHostSessionID[surface.hostSessionID] = session
         }

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -3102,6 +3102,8 @@ struct ContentView: View {
     /// Record that the user acted on this plan's prior run (restored or
     /// dismissed), then hide the banner for the rest of this launch. Later
     /// launches that select the same prior run won't re-offer it.
+    /// The dismissal is deliberately outside the `if`: a plan with no run identity persists
+    /// nothing but must still hide the banner. Pairing them would leave such a plan on screen.
     private func markRestorePlanHandled(_ plan: RestorePlan) {
         if let previousRunID = restoreController.handledRunID(for: plan) {
             restoreHandledRunID = previousRunID

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowRestoreController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowRestoreController.swift
@@ -1,0 +1,113 @@
+//
+//  MainWindowRestoreController.swift
+//  WorkspaceManager
+//
+//  The main window's restore-banner flow: whether a computed plan is worth offering, what
+//  acting on it persists, and what each restored surface launches with. Planning and the
+//  plan's own predicates live in `TerminalRestorePlanner`; this owns the order the window
+//  applies them in and the launch mapping, so both are assertable without a window.
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+/// Restore-banner state for the previous run's surfaces, held in one `@State`.
+///
+/// The handled-run id lives in `@AppStorage` rather than here: it must outlive the window so
+/// a later launch that selects the same prior run does not re-offer it.
+struct MainWindowRestoreState: Equatable {
+    private(set) var plan: RestorePlan?
+    private(set) var bannerDismissed = false
+
+    /// The plan the banner should show, or `nil` when there is nothing to offer — no plan, an
+    /// empty one, or one the user already acted on this launch.
+    var bannerPlan: RestorePlan? {
+        guard let plan, !plan.surfaces.isEmpty, !bannerDismissed else { return nil }
+        return plan
+    }
+
+    mutating func offer(_ plan: RestorePlan) {
+        self.plan = plan
+    }
+
+    mutating func dismissBanner() {
+        bannerDismissed = true
+    }
+}
+
+@MainActor
+struct MainWindowRestoreController {
+    /// Why a computed plan does or does not raise the restore banner.
+    ///
+    /// The cases are checked in this order and the first match wins, so an empty plan reports
+    /// as empty even when its run was also already handled. That ordering is what the log line
+    /// names, and it is the reason this is a decision rather than three independent predicates.
+    enum PlanDisposition: Equatable {
+        case noRestorableSurfaces
+        case alreadyHandled(previousRunID: String?)
+        case onlyDuplicatesLaunchSeed
+        case offer
+    }
+
+    func disposition(
+        for plan: RestorePlan,
+        handledRunID: String,
+        seedKey: HostTerminalSessionKey,
+        seedDirectory: URL
+    ) -> PlanDisposition {
+        if plan.surfaces.isEmpty {
+            return .noRestorableSurfaces
+        }
+        // An empty stored id means "nothing handled yet", not "handled by a run named empty".
+        if plan.wasHandled(handledRunID: handledRunID.isEmpty ? nil : handledRunID) {
+            return .alreadyHandled(previousRunID: plan.previousRunID)
+        }
+        if !plan.offersMoreThanLaunchSeed(seedKey: seedKey, seedDirectory: seedDirectory) {
+            return .onlyDuplicatesLaunchSeed
+        }
+        return .offer
+    }
+
+    /// The prior-run id that acting on this plan should persist, or `nil` when the plan has no
+    /// run identity to remember. The banner is dismissed either way.
+    func handledRunID(for plan: RestorePlan) -> String? {
+        plan.previousRunID
+    }
+
+    /// Dev-only drive hook for headless restore verification: with `WORKSPACES_RESTORE_AUTORUN=1`
+    /// a planned restore executes as if the user clicked Restore, so smoke scripts can exercise
+    /// the real resume path without desktop input.
+    func isAutorunRequested(environment: [String: String]) -> Bool {
+        environment["WORKSPACES_RESTORE_AUTORUN"] == "1"
+    }
+
+    /// Every key the plan owns. A pre-restore seed may hold one of these, and it is retired
+    /// first so the restored surface is created fresh rather than reusing the seed's session.
+    func ownedSessionKeys(in plan: RestorePlan) -> Set<HostTerminalSessionKey> {
+        Set(plan.surfaces.map(\.key))
+    }
+
+    /// Directories whose deterministic tmux session must be killed before restore. The planner
+    /// only chose resume because the prior tmux session is gone, so a live session on that name
+    /// can only be this launch's seed artifact — killing it stops the resume surface
+    /// `-A`-attaching to a leftover shell instead of starting fresh.
+    func tmuxSessionDirectoriesToKill(in plan: RestorePlan) -> [URL] {
+        plan.surfaces.compactMap { surface in
+            guard case .resumeClaude = surface.action else { return nil }
+            return surface.directory
+        }
+    }
+
+    /// What a restored surface launches with. Reattach and fresh surfaces are a plain
+    /// directory-backed launch — the deterministic tmux name reattaches a surviving session on
+    /// its own — while a resume surface gets `claude --resume` as initial input so it runs
+    /// through the login shell with the correct PATH and hook env.
+    func initialCommand(for action: RestoreSurfaceAction) -> String? {
+        switch action {
+        case .reattachTmux, .freshShell:
+            return nil
+        case .resumeClaude(let agentSessionID):
+            return RestoreLaunchCommand.claudeResume(sessionID: agentSessionID)
+        }
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/MainWindowRestoreControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowRestoreControllerTests.swift
@@ -1,0 +1,252 @@
+//
+//  MainWindowRestoreControllerTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Coverage for the main window's restore-banner flow: the order the three suppression
+//  reasons are checked in, what acting on a plan persists, and what each restored surface
+//  launches with. The plan's own predicates are covered in TerminalRestorePlannerTests.
+//
+
+import Foundation
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("MainWindowRestore")
+struct MainWindowRestoreControllerTests {
+    private let controller = MainWindowRestoreController()
+    private let seedDirectory = URL(fileURLWithPath: "/Users/dev")
+
+    // MARK: - Fixtures
+
+    private func surface(
+        action: RestoreSurfaceAction = .freshShell,
+        key: HostTerminalSessionKey = .hostPath("/Users/dev/code/alpha"),
+        directory: URL = URL(fileURLWithPath: "/Users/dev/code/alpha")
+    ) -> RestoreSurfacePlan {
+        RestoreSurfacePlan(
+            hostSessionID: UUID(),
+            key: key,
+            directory: directory,
+            action: action
+        )
+    }
+
+    private func plan(
+        _ surfaces: [RestoreSurfacePlan],
+        previousRunID: String? = "run-1"
+    ) -> RestorePlan {
+        RestorePlan(
+            surfaces: surfaces,
+            selectedHostSessionID: surfaces.first?.hostSessionID,
+            previousRunID: previousRunID
+        )
+    }
+
+    private func disposition(
+        for plan: RestorePlan,
+        handledRunID: String = ""
+    ) -> MainWindowRestoreController.PlanDisposition {
+        controller.disposition(
+            for: plan,
+            handledRunID: handledRunID,
+            seedKey: .defaultHome,
+            seedDirectory: seedDirectory
+        )
+    }
+
+    // MARK: - Which plans raise the banner
+
+    @Test("A plan with real surfaces from an unhandled run is offered")
+    func unhandledPlanIsOffered() {
+        #expect(disposition(for: plan([surface(action: .resumeClaude(agentSessionID: "a"))])) == .offer)
+    }
+
+    @Test("An empty plan raises nothing")
+    func emptyPlanIsNotOffered() {
+        #expect(disposition(for: plan([])) == .noRestorableSurfaces)
+    }
+
+    @Test("A plan whose run was already acted on is suppressed")
+    func handledPlanIsSuppressed() {
+        let result = disposition(
+            for: plan([surface(action: .resumeClaude(agentSessionID: "a"))], previousRunID: "run-1"),
+            handledRunID: "run-1"
+        )
+
+        #expect(result == .alreadyHandled(previousRunID: "run-1"))
+    }
+
+    @Test("A different prior run is still offered")
+    func differentRunIsStillOffered() {
+        let result = disposition(
+            for: plan([surface(action: .resumeClaude(agentSessionID: "a"))], previousRunID: "run-2"),
+            handledRunID: "run-1"
+        )
+
+        #expect(result == .offer)
+    }
+
+    /// An empty stored id means "nothing handled yet", so it must be normalized to `nil` before
+    /// the comparison. Passing it through verbatim would make it match a plan whose own run id
+    /// is empty and silently suppress the banner — this is the case that pins the normalization,
+    /// since a `nil` prior run is already rejected by `wasHandled` on its own.
+    @Test("An empty stored handled-run id never matches an empty prior-run id")
+    func emptyHandledRunIDIsNotARunName() {
+        let result = disposition(
+            for: plan([surface(action: .resumeClaude(agentSessionID: "a"))], previousRunID: ""),
+            handledRunID: ""
+        )
+
+        #expect(result == .offer)
+    }
+
+    @Test("A plan with no run identity is offered rather than assumed handled")
+    func planWithoutRunIdentityIsOffered() {
+        let result = disposition(
+            for: plan([surface(action: .resumeClaude(agentSessionID: "a"))], previousRunID: nil),
+            handledRunID: "run-1"
+        )
+
+        #expect(result == .offer)
+    }
+
+    @Test("A plan that only reproduces the launch seed is suppressed")
+    func launchSeedDuplicateIsSuppressed() {
+        let seedOnly = plan([
+            surface(action: .freshShell, key: .defaultHome, directory: seedDirectory)
+        ])
+
+        #expect(disposition(for: seedOnly) == .onlyDuplicatesLaunchSeed)
+    }
+
+    /// A fresh shell on the seed key at a *different* directory is a real restore — the default
+    /// host directory can change between runs.
+    @Test("A fresh shell on the seed key elsewhere is a real restore")
+    func seedKeyAtAnotherDirectoryIsOffered() {
+        let elsewhere = plan([
+            surface(
+                action: .freshShell,
+                key: .defaultHome,
+                directory: URL(fileURLWithPath: "/Users/dev/other")
+            )
+        ])
+
+        #expect(disposition(for: elsewhere) == .offer)
+    }
+
+    // MARK: - Ordering between the reasons
+
+    /// The rule this extraction locks in. Each predicate was individually testable before, but
+    /// nothing pinned which one reports when several apply — and the answer is what the log says.
+    @Test("An empty plan reports as empty even when its run was also handled")
+    func emptinessOutranksHandled() {
+        let result = disposition(for: plan([], previousRunID: "run-1"), handledRunID: "run-1")
+
+        #expect(result == .noRestorableSurfaces)
+    }
+
+    @Test("A handled run is suppressed as handled even when it only duplicates the seed")
+    func handledOutranksSeedDuplication() {
+        let seedOnly = plan(
+            [surface(action: .freshShell, key: .defaultHome, directory: seedDirectory)],
+            previousRunID: "run-1"
+        )
+
+        #expect(disposition(for: seedOnly, handledRunID: "run-1") == .alreadyHandled(previousRunID: "run-1"))
+    }
+
+    // MARK: - Acting on a plan
+
+    @Test("Acting on a plan persists its prior-run id")
+    func handledRunIDIsThePriorRun() {
+        #expect(controller.handledRunID(for: plan([surface()], previousRunID: "run-7")) == "run-7")
+    }
+
+    @Test("A plan with no run identity persists nothing")
+    func planWithoutRunIDPersistsNothing() {
+        #expect(controller.handledRunID(for: plan([surface()], previousRunID: nil)) == nil)
+    }
+
+    @Test("The banner hides once the user acts, and stays hidden")
+    func dismissHidesTheBanner() {
+        var state = MainWindowRestoreState()
+        state.offer(plan([surface()]))
+        #expect(state.bannerPlan != nil)
+
+        state.dismissBanner()
+
+        #expect(state.bannerPlan == nil)
+    }
+
+    @Test("An offered empty plan still shows no banner")
+    func emptyOfferedPlanShowsNoBanner() {
+        var state = MainWindowRestoreState()
+        state.offer(plan([]))
+
+        #expect(state.bannerPlan == nil)
+    }
+
+    @Test("With nothing offered there is no banner")
+    func initialStateShowsNoBanner() {
+        #expect(MainWindowRestoreState().bannerPlan == nil)
+    }
+
+    // MARK: - Autorun gate
+
+    @Test("Autorun fires only for the explicit dev opt-in")
+    func autorunRequiresTheExactFlag() {
+        #expect(controller.isAutorunRequested(environment: ["WORKSPACES_RESTORE_AUTORUN": "1"]))
+        #expect(controller.isAutorunRequested(environment: ["WORKSPACES_RESTORE_AUTORUN": "0"]) == false)
+        #expect(controller.isAutorunRequested(environment: ["WORKSPACES_RESTORE_AUTORUN": "true"]) == false)
+        #expect(controller.isAutorunRequested(environment: [:]) == false)
+    }
+
+    // MARK: - What each surface launches with
+
+    @Test("Only resume surfaces carry an initial command")
+    func initialCommandIsResumeOnly() {
+        #expect(controller.initialCommand(for: .freshShell) == nil)
+        #expect(controller.initialCommand(for: .reattachTmux(sessionName: "ws-alpha")) == nil)
+
+        let resume = controller.initialCommand(for: .resumeClaude(agentSessionID: "abc123"))
+        #expect(resume == RestoreLaunchCommand.claudeResume(sessionID: "abc123"))
+        #expect(resume?.contains("abc123") == true)
+    }
+
+    @Test("Only resume surfaces have their tmux session killed first")
+    func onlyResumeSurfacesAreKilled() {
+        let resumeDirectory = URL(fileURLWithPath: "/Users/dev/code/beta")
+        let target = plan([
+            surface(action: .freshShell, directory: URL(fileURLWithPath: "/Users/dev/code/alpha")),
+            surface(action: .resumeClaude(agentSessionID: "a"), directory: resumeDirectory),
+            surface(
+                action: .reattachTmux(sessionName: "ws-gamma"),
+                directory: URL(fileURLWithPath: "/Users/dev/code/gamma")),
+        ])
+
+        #expect(controller.tmuxSessionDirectoriesToKill(in: target) == [resumeDirectory])
+    }
+
+    @Test("A plan with no resume surfaces kills nothing")
+    func noResumeSurfacesKillNothing() {
+        let target = plan([surface(action: .freshShell), surface(action: .reattachTmux(sessionName: "x"))])
+
+        #expect(controller.tmuxSessionDirectoriesToKill(in: target).isEmpty)
+    }
+
+    @Test("Every key the plan restores is claimed, deduplicated")
+    func ownedKeysCoverThePlanWithoutDuplicates() {
+        let shared = HostTerminalSessionKey.hostPath("/Users/dev/code/alpha")
+        let other = HostTerminalSessionKey.hostPath("/Users/dev/code/beta")
+        let target = plan([
+            surface(key: shared),
+            surface(key: shared),
+            surface(key: other),
+        ])
+
+        #expect(controller.ownedSessionKeys(in: target) == [shared, other])
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/MainWindowRestoreControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowRestoreControllerTests.swift
@@ -170,11 +170,40 @@ struct MainWindowRestoreControllerTests {
         #expect(controller.handledRunID(for: plan([surface()], previousRunID: nil)) == nil)
     }
 
-    @Test("The banner hides once the user acts, and stays hidden")
+    @Test("The banner shows the plan it was offered, and hides once the user acts")
     func dismissHidesTheBanner() {
         var state = MainWindowRestoreState()
+        let offered = plan([surface()])
+        state.offer(offered)
+        #expect(state.bannerPlan == offered)
+
+        state.dismissBanner()
+
+        #expect(state.bannerPlan == nil)
+    }
+
+    /// Dismissal is for the rest of the launch. A later plan computation must not resurrect the
+    /// banner, which it would if `offer` reset the dismissal alongside the plan.
+    @Test("A plan offered after dismissal stays hidden")
+    func offerAfterDismissalStaysHidden() {
+        var state = MainWindowRestoreState()
         state.offer(plan([surface()]))
-        #expect(state.bannerPlan != nil)
+        state.dismissBanner()
+
+        state.offer(plan([surface()], previousRunID: "run-2"))
+
+        #expect(state.bannerPlan == nil)
+    }
+
+    /// Acting on a plan with no run identity persists nothing, but must still hide the banner —
+    /// the two halves are independent, and pairing them would leave such a plan on screen.
+    @Test("Dismissal does not depend on the plan having a run identity")
+    func dismissalIsIndependentOfRunIdentity() {
+        var state = MainWindowRestoreState()
+        let anonymous = plan([surface()], previousRunID: nil)
+        state.offer(anonymous)
+
+        #expect(controller.handledRunID(for: anonymous) == nil)
 
         state.dismissBanner()
 
@@ -214,6 +243,22 @@ struct MainWindowRestoreControllerTests {
         let resume = controller.initialCommand(for: .resumeClaude(agentSessionID: "abc123"))
         #expect(resume == RestoreLaunchCommand.claudeResume(sessionID: "abc123"))
         #expect(resume?.contains("abc123") == true)
+    }
+
+    /// Order and multiplicity both matter: the kill list is consumed in sequence, and two resume
+    /// surfaces on the same directory are two kills. A `Set`-based rewrite would collapse them.
+    @Test("The kill list keeps surface order and does not deduplicate")
+    func killListPreservesOrderAndDuplicates() {
+        let first = URL(fileURLWithPath: "/Users/dev/code/alpha")
+        let second = URL(fileURLWithPath: "/Users/dev/code/beta")
+        let target = plan([
+            surface(action: .resumeClaude(agentSessionID: "a"), directory: first),
+            surface(action: .freshShell, directory: URL(fileURLWithPath: "/Users/dev/code/skip")),
+            surface(action: .resumeClaude(agentSessionID: "b"), directory: first),
+            surface(action: .resumeClaude(agentSessionID: "c"), directory: second),
+        ])
+
+        #expect(controller.tmuxSessionDirectoriesToKill(in: target) == [first, first, second])
     }
 
     @Test("Only resume surfaces have their tmux session killed first")


### PR DESCRIPTION
Slice 4 of the `ContentView` decomposition. Refs #1160 — slices 5–6 remain, so no `Closes`.

Follows slices [1](https://github.com/fairchild/workspaces/pull/1186), [2](https://github.com/fairchild/workspaces/pull/1188), and [3](https://github.com/fairchild/workspaces/pull/1190).

## What moves

The session-restore banner flow, into `MainWindowRestoreController.swift`:

- **`MainWindowRestoreState`** — `pendingRestorePlan` + `restoreBannerDismissed` collapsed into one `@State`, with the three-part banner condition becoming a single `bannerPlan`.
- **`MainWindowRestoreController`** — `disposition(for:handledRunID:seedKey:seedDirectory:)` for the suppression chain, plus `handledRunID(for:)`, `isAutorunRequested(environment:)`, `ownedSessionKeys(in:)`, `tmuxSessionDirectoriesToKill(in:)`, and `initialCommand(for:)`.

`restoreHandledRunID` deliberately **stays** `@AppStorage`. It has to outlive the window — that is the whole mechanism by which a later launch selecting the same prior run doesn't re-offer it — so folding it into view state would have been a behavior change dressed as tidying.

### The rule this locks in

`RestorePlan.wasHandled` and `offersMoreThanLaunchSeed` were each already testable and tested in `TerminalRestorePlannerTests`. What had no test was **the order the window checks them in**, and that order is observable: it decides which reason the `[Restore]` log line reports. Two cases now pin it — an empty plan reports as empty even when its run was also already handled, and a handled run reports as handled even when it only duplicates the launch seed.

`ContentView` drops 25 lines (3,602 → 3,577 measured on the rebased tree, where slice 3 has landed). As with slice 3, the value here is coverage rather than line count; the effects (activating surfaces, killing tmux sessions, writing `@AppStorage`) correctly stay in the view.

## Verification

- `swift build` clean, no new StrictConcurrency warnings from the touched files; `swift test` — 1,402 tests in 203 suites, all passing after rebasing onto a `main` that now carries slice 3.
- `mise run lint` clean under the now-active `NeverForceUnwrap` / `NeverUseForceTry` rules.
- 23 new tests: which plans raise the banner, the ordering between suppression reasons, what acting on a plan persists, the autorun gate, and the per-surface launch mapping.

## Evidence

Two mutation checks. The second one is worth reading in full, because **it initially passed** — which exposed that my test claimed to cover the empty-id normalization while never exercising it (it used `previousRunID: nil`, so `wasHandled` rejected on its own guard and the normalization was never reached). Rewriting it to use `previousRunID: ""` made the mutation fail as it should. The artifact below shows that sequence rather than a cleaned-up version of it.

| Mutation | Result |
|---|---|
| Reorder the chain (handled checked before emptiness) | ordering test fails |
| Treat an empty stored handled-run id as a real run name | **passed at first** — test tightened, then fails |
| Deduplicate the tmux kill list via `Set` | order/multiplicity test fails (added in review) |

![s4-mutation-check](https://evidence.cloudcompute.com/workspaces/pr-1191/20260804-070520-s4-mutation-check.png)

![s4-restore-tests](https://evidence.cloudcompute.com/workspaces/pr-1191/20260804-070520-s4-restore-tests.png)

**![phase-1-release](https://evidence.cloudcompute.com/workspaces/pr-1191/20260804-081829-phase-1-release.png) (captured 2026-08-04 after host unlock; operator-scope snapshot of this branch, rendered content verified).** One capture was attempted and returned the same blank 74714-byte frame as during slice 3 (first seen ~23:04 local yesterday). Two things worth noting: the fixture lane runs `--clean-data`, so there is no prior-run continuity data and the restore banner could not be staged even with a working display — a screenshot would have shown the main window without this slice's surface on it; and the banner's own rendering is unchanged by this diff, which only changes what decides whether to show it.

## Review loop

Reflected on the diff, then a directed codex review (`gpt-5.6-sol`, xhigh) over seven named failure modes plus a falsifiable completeness question. Verdict: **a pure extraction, no behavior defect** — every finding was a test-coverage weakness, which is a useful signal on its own after slice 2 turned up a real one.

Confirmed clean and checked explicitly: the suppression chain preserves short-circuit order with all four log lines' text, values, and `.public` attributes intact, and no input makes the enum and the original chain disagree; the `@AppStorage` boundary still persists only for a non-`nil` prior run and dismisses either way; no formerly read-only path now writes `@State`; `compactMap` preserves tmux surface order *and* duplicates while `ownedSessionKeys` keeps the original `Set` contract; the autorun check still reads the environment at invocation and is still exactly `== "1"`.

Four coverage findings, all addressed in `ef44e7eb`:

1. **Medium — tmux order and multiplicity weren't pinned.** The kill-list test used a single resume surface, so a `Set`-based rewrite dropping order and duplicates would have passed. Now asserts `[A, A, B]` stays `[A, A, B]`; mutation-confirmed (the `Set` rewrite yields `[beta, alpha]` and fails).
2. **Medium — dismissal's independence from run identity wasn't pinned.** Moving `dismissBanner()` inside the `if let previousRunID` would leave an anonymous plan on screen with every test still green. Added the state-level half and stated the invariant at the `ContentView` call site; the full pairing needs a hosted view, same limitation as slice 3.
3. **Low — "stays hidden" was overclaimed.** It only checked the moment after dismissal, so an `offer()` that reset the dismissal would have passed. Now asserts a later plan stays hidden.
4. **Low — two assertions were weaker than their stated contract.** `bannerPlan != nil` accepted any non-`nil` plan; now asserts equality with the offered one.

## Mergeability

- Surface: desktop — main window session-restore banner (offer, dismiss, and the restore launch itself)
- User-facing behavior changed: No. Extraction only; the suppression order, all four `[Restore]` log lines, the persisted handled-run id, and the per-surface launch mapping are unchanged.
- Non-happy paths considered: an empty plan still logs "no restorable surfaces" and shows nothing; a plan whose run was already acted on stays suppressed across the rest of the launch; a plan that only reproduces the launch seed stays suppressed, while a fresh shell on the seed key at a *different* directory is still a real restore; a plan with no run identity is offered rather than assumed handled, and persists nothing when acted on; autorun still fires only for the exact `WORKSPACES_RESTORE_AUTORUN=1` opt-in; and a plan with no resume surfaces still kills no tmux sessions.
- Residual risk or follow-up: `ownedSessionKeys` returns a `Set`, so the retire loop's iteration order is unspecified — that matches the original, which also iterated `Set(plan.surfaces.map(\.key))`, and no ordering was relied on. Visual evidence is blocked as noted above. Slices 5–6 remain.

Made with [Orca](https://github.com/stablyai/orca) 🐋

