### PR TITLE
refactor(app): extract session-switcher projections from ContentView (#1160 slice 5)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -139,6 +139,7 @@ struct ContentView: View {
     private let workspaceEnvironmentOptionsController = WorkspaceEnvironmentOptionsController()
     private let workspaceOrphanController = WorkspaceOrphanReconciliationController()
     private let maintenanceController = MainWindowMaintenanceController()
+    private let sessionSwitcherController = SessionSwitcherPresentationController()
     private let codePreviewController = CodePreviewNavigationController()
 
     private var launchRepositoryService: LaunchRepositoryService {
@@ -315,75 +316,23 @@ struct ContentView: View {
         )
     }
 
-    private var commandPaletteWorkspaceActivities: [UUID: SidebarSessionActivity] {
-        let presentation = SidebarWorkspacePresentationController()
-        let normalize: (URL) -> String = { url in normalizePath(url.path) }
-        return Dictionary(
-            uniqueKeysWithValues: repos.flatMap(\.workspaces).map { workspace in
-                let key = presentation.sessionKey(
-                    for: workspace,
-                    registry: workspaceProviderRegistry,
-                    normalizePath: normalize
-                )
-                let activity = presentation.sessionActivity(
-                    for: key,
-                    paneCountBySessionKey: paneCountBySessionKeyForSidebar,
-                    activeSessionKey: activeSessionKeyForSidebar,
-                    sessions: tileTreeStore.sessions,
-                    agentStatusBySessionID: agentSessionRegistry.statuses
-                )
-                return (workspace.id, activity)
-            }
-        )
-    }
-
-    private var commandPaletteRepoActivities: [UUID: SidebarSessionActivity] {
-        let presentation = SidebarWorkspacePresentationController()
-        return Dictionary(
-            uniqueKeysWithValues: repos.map { repo in
-                let key = HostTerminalSessionKey.repoPath(normalizePath(repo.localURL.path))
-                let baseline = presentation.sessionActivity(
-                    for: key,
-                    paneCountBySessionKey: paneCountBySessionKeyForSidebar,
-                    activeSessionKey: activeSessionKeyForSidebar,
-                    sessions: tileTreeStore.sessions,
-                    agentStatusBySessionID: agentSessionRegistry.statuses
-                )
-                let bubbled =
-                    workspaceStatusAggregator.repoStatuses[repo.id]
-                    .map { SidebarSessionActivity.from($0) } ?? .inactive
-                return (repo.id, baseline.mergedWithBubbled(bubbled))
-            }
-        )
-    }
-
-    private var sessionSwitcherWorkspaceSessionKeys: [UUID: HostTerminalSessionKey] {
-        let presentation = SidebarWorkspacePresentationController()
-        let normalize: (URL) -> String = { url in normalizePath(url.path) }
-        return Dictionary(
-            uniqueKeysWithValues: repos.flatMap(\.workspaces).map { workspace in
-                let key = presentation.sessionKey(
-                    for: workspace,
-                    registry: workspaceProviderRegistry,
-                    normalizePath: normalize
-                )
-                return (workspace.id, key)
-            }
-        )
-    }
-
-    private func makeSessionSwitcherSnapshot() -> SessionSwitcherSnapshot {
-        SessionSwitcherSnapshot.make(
+    private var sessionSwitcherProjectionContext: SessionSwitcherProjectionContext {
+        SessionSwitcherProjectionContext(
             repos: repos,
             webSources: webSources,
             sessions: tileTreeStore.sessions,
             activeSessionID: tileTreeStore.activeSessionID,
-            agentStatuses: agentSessionRegistry.statuses,
+            agentStatusBySessionID: agentSessionRegistry.statuses,
             paneCountBySessionKey: paneCountBySessionKeyForSidebar,
-            workspaceSessionKeys: sessionSwitcherWorkspaceSessionKeys,
-            workspaceActivities: commandPaletteWorkspaceActivities,
-            repoActivities: commandPaletteRepoActivities
+            activeSessionKey: activeSessionKeyForSidebar,
+            bubbledRepoStatuses: workspaceStatusAggregator.repoStatuses,
+            registry: workspaceProviderRegistry,
+            normalizePath: { url in normalizePath(url.path) }
         )
+    }
+
+    private func makeSessionSwitcherSnapshot() -> SessionSwitcherSnapshot {
+        sessionSwitcherController.snapshot(sessionSwitcherProjectionContext)
     }
 
     static func sidebarActiveSessionKey(

--- a/Sources/WorkspaceManager/Views/MainWindow/SessionSwitcherPresentationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SessionSwitcherPresentationController.swift
@@ -1,0 +1,115 @@
+//
+//  SessionSwitcherPresentationController.swift
+//  WorkspaceManager
+//
+//  The projections the main window feeds the session switcher and command palette: per-workspace
+//  session keys, per-workspace activity, and per-repo activity — the last of which merges a repo's
+//  own session activity with the status bubbled up from its workspaces. `SessionSwitcherSnapshot`
+//  ranks and assembles the rows; this decides what it is ranking, so those inputs are assertable
+//  without a window.
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+/// Everything the switcher's projections read, gathered once per pass so a rebuild takes one
+/// consistent view of sessions, statuses, and selection rather than re-reading them per row.
+struct SessionSwitcherProjectionContext {
+    let repos: [Repo]
+    let webSources: [WebSource]
+    let sessions: [HostTerminalSession]
+    let activeSessionID: UUID?
+    let agentStatusBySessionID: [UUID: AgentSessionStatus]
+    let paneCountBySessionKey: [HostTerminalSessionKey: Int]
+    let activeSessionKey: HostTerminalSessionKey?
+    /// Per-repo status rolled up from that repo's workspaces by `WorkspaceStatusAggregator`.
+    let bubbledRepoStatuses: [UUID: AgentSessionStatus]
+    let registry: WorkspaceProviderRegistry
+    let normalizePath: (URL) -> String
+}
+
+@MainActor
+struct SessionSwitcherPresentationController {
+    private let presentation = SidebarWorkspacePresentationController()
+
+    /// The host-session key each workspace's row routes to.
+    func workspaceSessionKeys(
+        _ context: SessionSwitcherProjectionContext
+    ) -> [UUID: HostTerminalSessionKey] {
+        Dictionary(
+            uniqueKeysWithValues: context.repos.flatMap(\.workspaces).map { workspace in
+                (workspace.id, sessionKey(for: workspace, in: context))
+            }
+        )
+    }
+
+    /// Activity for each workspace row, read from the same session and agent-status state the
+    /// sidebar uses so the two surfaces cannot disagree.
+    func workspaceActivities(
+        _ context: SessionSwitcherProjectionContext
+    ) -> [UUID: SessionActivity] {
+        Dictionary(
+            uniqueKeysWithValues: context.repos.flatMap(\.workspaces).map { workspace in
+                let activity = presentation.sessionActivity(
+                    for: sessionKey(for: workspace, in: context),
+                    paneCountBySessionKey: context.paneCountBySessionKey,
+                    activeSessionKey: context.activeSessionKey,
+                    sessions: context.sessions,
+                    agentStatusBySessionID: context.agentStatusBySessionID
+                )
+                return (workspace.id, activity)
+            }
+        )
+    }
+
+    /// Activity for each repo row. A repo has its own terminal session, but it also stands in for
+    /// its workspaces — so its row merges the baseline activity of its own session with the status
+    /// the aggregator bubbled up from below. A repo the aggregator has nothing for contributes
+    /// `.inactive`, leaving the baseline to speak for itself.
+    func repoActivities(
+        _ context: SessionSwitcherProjectionContext
+    ) -> [UUID: SessionActivity] {
+        Dictionary(
+            uniqueKeysWithValues: context.repos.map { repo in
+                let key = HostTerminalSessionKey.repoPath(context.normalizePath(repo.localURL))
+                let baseline = presentation.sessionActivity(
+                    for: key,
+                    paneCountBySessionKey: context.paneCountBySessionKey,
+                    activeSessionKey: context.activeSessionKey,
+                    sessions: context.sessions,
+                    agentStatusBySessionID: context.agentStatusBySessionID
+                )
+                let bubbled =
+                    context.bubbledRepoStatuses[repo.id]
+                    .map { SessionActivity.from($0) } ?? .inactive
+                return (repo.id, baseline.mergedWithBubbled(bubbled))
+            }
+        )
+    }
+
+    /// One switcher snapshot, built from the projections above.
+    func snapshot(_ context: SessionSwitcherProjectionContext) -> SessionSwitcherSnapshot {
+        SessionSwitcherSnapshot.make(
+            repos: context.repos,
+            webSources: context.webSources,
+            sessions: context.sessions,
+            activeSessionID: context.activeSessionID,
+            agentStatuses: context.agentStatusBySessionID,
+            paneCountBySessionKey: context.paneCountBySessionKey,
+            workspaceSessionKeys: workspaceSessionKeys(context),
+            workspaceActivities: workspaceActivities(context),
+            repoActivities: repoActivities(context)
+        )
+    }
+
+    private func sessionKey(
+        for workspace: Workspace,
+        in context: SessionSwitcherProjectionContext
+    ) -> HostTerminalSessionKey {
+        presentation.sessionKey(
+            for: workspace,
+            registry: context.registry,
+            normalizePath: context.normalizePath
+        )
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/SessionSwitcherPresentationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SessionSwitcherPresentationControllerTests.swift
@@ -189,6 +189,65 @@ struct SessionSwitcherPresentationControllerTests {
         #expect(activities[second.id] == .inactive)
     }
 
+    /// `mergedWithBubbled` prefers `self` on ties, so the baseline must be the receiver. Swapping
+    /// the operands is invisible at different severities and only shows up here: `.thinking` and
+    /// `.runningTool` rank equally, and the repo's own session is what should win.
+    @Test("On equal severity the repo's own activity wins over the bubbled one")
+    func equalSeverityPrefersTheBaseline() {
+        let repo = makeRepo(name: "alpha", workspaceNames: ["a1"])
+        let session = HostTerminalSession(key: .repoPath(repo.localURL.path), directory: repo.localURL)
+
+        let activities = controller.repoActivities(
+            context(
+                repos: [repo],
+                sessions: [session],
+                agentStatusBySessionID: [session.id: status(hostSessionID: session.id, run: .thinking)],
+                paneCountBySessionKey: [session.key: 1],
+                bubbledRepoStatuses: [
+                    repo.id: status(
+                        hostSessionID: UUID(),
+                        run: .runningTool(name: "bash", detail: nil)
+                    )
+                ]
+            )
+        )
+
+        #expect(SessionActivity.thinking.severity == SessionActivity.runningTool.severity)
+        #expect(activities[repo.id] == .thinking)
+    }
+
+    /// Binds that the repo projection actually routes through `context.normalizePath`: with a
+    /// normalizer that rewrites the path, a session on the *raw* path no longer matches.
+    @Test("Repo activity resolves its session key through the context normalizer")
+    func repoActivityUsesTheContextNormalizer() {
+        let repo = makeRepo(name: "alpha")
+        let session = HostTerminalSession(key: .repoPath(repo.localURL.path), directory: repo.localURL)
+        var rewritten = SessionSwitcherProjectionContext(
+            repos: [repo],
+            webSources: [],
+            sessions: [session],
+            activeSessionID: nil,
+            agentStatusBySessionID: [session.id: status(hostSessionID: session.id, run: .thinking)],
+            paneCountBySessionKey: [session.key: 1],
+            activeSessionKey: nil,
+            bubbledRepoStatuses: [:],
+            registry: WorkspaceProviderRegistry(providers: []),
+            normalizePath: { _ in "/somewhere/else" }
+        )
+
+        let rerouted = controller.repoActivities(rewritten)
+        rewritten = context(
+            repos: [repo],
+            sessions: [session],
+            agentStatusBySessionID: [session.id: status(hostSessionID: session.id, run: .thinking)],
+            paneCountBySessionKey: [session.key: 1]
+        )
+        let direct = controller.repoActivities(rewritten)
+
+        #expect(direct[repo.id] == .thinking)
+        #expect(rerouted[repo.id] == .inactive)
+    }
+
     @Test("Every repo appears in the projection, quiet or not")
     func everyRepoIsProjected() {
         let repos = [makeRepo(name: "alpha"), makeRepo(name: "beta"), makeRepo(name: "gamma")]
@@ -200,20 +259,75 @@ struct SessionSwitcherPresentationControllerTests {
 
     // MARK: - Snapshot assembly
 
-    @Test("The snapshot carries a row for every repo and workspace")
-    func snapshotCoversReposAndWorkspaces() {
-        let repo = makeRepo(name: "alpha", workspaceNames: ["a1", "a2"])
+    /// A shape-only assertion here would pass even if `snapshot` handed `make` empty
+    /// dictionaries, so this asserts a value that can only arrive through the projections.
+    /// Note `make` consults them for *live* rows only — a row backed by a session.
+    @Test("A live workspace row carries the activity the projection computed")
+    func snapshotLiveWorkspaceRowReflectsProjectedActivity() throws {
+        let repo = makeRepo(name: "alpha", workspaceNames: ["a1"])
+        let workspace = try #require(repo.workspaces.first)
+        let session = HostTerminalSession(
+            key: .hostPath(workspace.workspaceURL.path),
+            directory: workspace.workspaceURL
+        )
 
-        let snapshot = controller.snapshot(context(repos: [repo]))
+        let snapshot = controller.snapshot(
+            context(
+                repos: [repo],
+                sessions: [session],
+                agentStatusBySessionID: [session.id: status(hostSessionID: session.id, run: .thinking)],
+                paneCountBySessionKey: [session.key: 1]
+            )
+        )
 
-        // One row per repo and workspace, plus the standing theme command.
-        #expect(snapshot.rows.count >= 3)
+        let row = try #require(snapshot.rows.first { $0.target == .hostSession(session.id) })
+        #expect(row.kind == .workspace)
+        #expect(row.activity == .thinking)
     }
 
-    @Test("An empty model still produces a usable snapshot")
+    /// The bubbled merge reaching the switcher: a repo whose own session is idle but whose
+    /// workspaces are waiting shows the bubbled state on its live row.
+    @Test("A live repo row carries the merged bubbled activity")
+    func snapshotLiveRepoRowReflectsBubbledActivity() throws {
+        let repo = makeRepo(name: "alpha", workspaceNames: ["a1"])
+        let session = HostTerminalSession(key: .repoPath(repo.localURL.path), directory: repo.localURL)
+        let bubbled = status(hostSessionID: UUID(), run: .awaitingInput(reason: .permissionPrompt))
+
+        let snapshot = controller.snapshot(
+            context(
+                repos: [repo],
+                sessions: [session],
+                paneCountBySessionKey: [session.key: 1],
+                bubbledRepoStatuses: [repo.id: bubbled]
+            )
+        )
+
+        let row = try #require(snapshot.rows.first { $0.target == .hostSession(session.id) })
+        #expect(row.kind == .repo)
+        #expect(row.activity == .awaitingInput)
+    }
+
+    /// Documents the boundary the projections stop at: a repo with no live session renders a
+    /// dormant row, and `make` hardcodes those to `.inactive` regardless of what bubbled up.
+    @Test("A repo with no session renders dormant, ignoring bubbled status")
+    func snapshotDormantRepoRowIgnoresBubbledActivity() throws {
+        let repo = makeRepo(name: "alpha", workspaceNames: ["a1"])
+        let bubbled = status(hostSessionID: UUID(), run: .thinking)
+
+        let snapshot = controller.snapshot(
+            context(repos: [repo], bubbledRepoStatuses: [repo.id: bubbled])
+        )
+
+        let row = try #require(snapshot.rows.first { $0.target == .repo(repo.id) })
+        #expect(row.activity == .inactive)
+    }
+
+    @Test("An empty model produces only the standing command row")
     func snapshotWithNoModelIsStillUsable() {
         let snapshot = controller.snapshot(context(repos: []))
 
-        #expect(snapshot.rows.isEmpty == false)
+        #expect(snapshot.rows.contains { $0.kind == .command })
+        #expect(snapshot.rows.contains { $0.kind == .workspace } == false)
+        #expect(snapshot.rows.contains { $0.kind == .repo } == false)
     }
 }

--- a/Tests/WorkspaceManagerAppTests/SessionSwitcherPresentationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SessionSwitcherPresentationControllerTests.swift
@@ -1,0 +1,219 @@
+//
+//  SessionSwitcherPresentationControllerTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Coverage for the projections the main window feeds the session switcher: per-workspace session
+//  keys and activity, and the per-repo merge of a repo's own session activity with the status
+//  bubbled up from its workspaces. Snapshot ranking itself is covered in SessionSwitcherSnapshotTests.
+//
+
+import Foundation
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("SessionSwitcherPresentation")
+struct SessionSwitcherPresentationControllerTests {
+    private let controller = SessionSwitcherPresentationController()
+
+    // MARK: - Fixtures
+
+    private func makeRepo(
+        name: String = "alpha",
+        workspaceNames: [String] = []
+    ) -> Repo {
+        let repo = Repo(name: name, localPath: URL(fileURLWithPath: "/Users/dev/code/\(name)"))
+        repo.workspaces = workspaceNames.map { workspaceName in
+            Workspace(
+                name: workspaceName,
+                path: URL(fileURLWithPath: "/Users/dev/code/\(name)/.workspaces/\(workspaceName)"),
+                sourceRepo: repo
+            )
+        }
+        return repo
+    }
+
+    private func context(
+        repos: [Repo],
+        sessions: [HostTerminalSession] = [],
+        agentStatusBySessionID: [UUID: AgentSessionStatus] = [:],
+        paneCountBySessionKey: [HostTerminalSessionKey: Int] = [:],
+        activeSessionKey: HostTerminalSessionKey? = nil,
+        bubbledRepoStatuses: [UUID: AgentSessionStatus] = [:]
+    ) -> SessionSwitcherProjectionContext {
+        SessionSwitcherProjectionContext(
+            repos: repos,
+            webSources: [],
+            sessions: sessions,
+            activeSessionID: nil,
+            agentStatusBySessionID: agentStatusBySessionID,
+            paneCountBySessionKey: paneCountBySessionKey,
+            activeSessionKey: activeSessionKey,
+            bubbledRepoStatuses: bubbledRepoStatuses,
+            registry: WorkspaceProviderRegistry(providers: []),
+            normalizePath: { $0.path }
+        )
+    }
+
+    private func status(
+        hostSessionID: UUID,
+        run: AgentRunState,
+        cwd: String = "/Users/dev/code/alpha"
+    ) -> AgentSessionStatus {
+        AgentSessionStatus(
+            hostSessionID: hostSessionID,
+            cwd: cwd,
+            run: run,
+            lastEventAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
+    // MARK: - Workspace session keys
+
+    @Test("Every workspace across every repo gets a routing key")
+    func workspaceKeysCoverAllWorkspaces() {
+        let first = makeRepo(name: "alpha", workspaceNames: ["a1", "a2"])
+        let second = makeRepo(name: "beta", workspaceNames: ["b1"])
+        let allWorkspaces = [first, second].flatMap(\.workspaces)
+
+        let keys = controller.workspaceSessionKeys(context(repos: [first, second]))
+
+        #expect(keys.count == 3)
+        #expect(Set(keys.keys) == Set(allWorkspaces.map(\.id)))
+    }
+
+    /// With no provider registered, a workspace routes to its own directory on the host.
+    @Test("A local workspace routes to its host path")
+    func localWorkspaceRoutesToHostPath() throws {
+        let repo = makeRepo(name: "alpha", workspaceNames: ["a1"])
+        let workspace = try #require(repo.workspaces.first)
+
+        let keys = controller.workspaceSessionKeys(context(repos: [repo]))
+
+        #expect(keys[workspace.id] == .hostPath(workspace.workspaceURL.path))
+    }
+
+    @Test("No repos means no keys rather than a crash")
+    func noReposProducesNoKeys() {
+        #expect(controller.workspaceSessionKeys(context(repos: [])).isEmpty)
+    }
+
+    // MARK: - Workspace activity
+
+    @Test("A workspace with no session reports inactive")
+    func workspaceWithoutSessionIsInactive() throws {
+        let repo = makeRepo(name: "alpha", workspaceNames: ["a1"])
+        let workspace = try #require(repo.workspaces.first)
+
+        let activities = controller.workspaceActivities(context(repos: [repo]))
+
+        #expect(activities[workspace.id] == .inactive)
+    }
+
+    @Test("A workspace whose session is thinking reports thinking")
+    func workspaceActivityFollowsAgentStatus() throws {
+        let repo = makeRepo(name: "alpha", workspaceNames: ["a1"])
+        let workspace = try #require(repo.workspaces.first)
+        let session = HostTerminalSession(
+            key: .hostPath(workspace.workspaceURL.path),
+            directory: workspace.workspaceURL
+        )
+
+        let activities = controller.workspaceActivities(
+            context(
+                repos: [repo],
+                sessions: [session],
+                agentStatusBySessionID: [session.id: status(hostSessionID: session.id, run: .thinking)],
+                paneCountBySessionKey: [session.key: 1]
+            )
+        )
+
+        #expect(activities[workspace.id] == .thinking)
+    }
+
+    // MARK: - Repo activity and the bubbling merge
+
+    /// The rule this extraction locks in. A repo row speaks for its workspaces as well as its own
+    /// terminal, so it merges the two — and a repo the aggregator has nothing for must fall back to
+    /// `.inactive` rather than dropping the baseline.
+    @Test("A repo with no bubbled status keeps its own baseline")
+    func repoWithoutBubbledStatusKeepsBaseline() {
+        let repo = makeRepo(name: "alpha")
+        let session = HostTerminalSession(key: .repoPath(repo.localURL.path), directory: repo.localURL)
+
+        let activities = controller.repoActivities(
+            context(
+                repos: [repo],
+                sessions: [session],
+                agentStatusBySessionID: [session.id: status(hostSessionID: session.id, run: .thinking)],
+                paneCountBySessionKey: [session.key: 1]
+            )
+        )
+
+        #expect(activities[repo.id] == .thinking)
+    }
+
+    @Test("A quiet repo surfaces the status bubbled up from its workspaces")
+    func quietRepoSurfacesBubbledStatus() {
+        let repo = makeRepo(name: "alpha", workspaceNames: ["a1"])
+        let bubbled = status(hostSessionID: UUID(), run: .awaitingInput(reason: .permissionPrompt))
+
+        let activities = controller.repoActivities(
+            context(repos: [repo], bubbledRepoStatuses: [repo.id: bubbled])
+        )
+
+        #expect(activities[repo.id] == .awaitingInput)
+        #expect(activities[repo.id] != .inactive)
+    }
+
+    @Test("A repo with neither its own session nor anything bubbled is inactive")
+    func idleRepoIsInactive() {
+        let repo = makeRepo(name: "alpha")
+
+        #expect(controller.repoActivities(context(repos: [repo]))[repo.id] == .inactive)
+    }
+
+    @Test("Bubbled status is matched to its own repo, not shared across repos")
+    func bubbledStatusIsPerRepo() {
+        let first = makeRepo(name: "alpha")
+        let second = makeRepo(name: "beta")
+        let bubbled = status(hostSessionID: UUID(), run: .thinking)
+
+        let activities = controller.repoActivities(
+            context(repos: [first, second], bubbledRepoStatuses: [first.id: bubbled])
+        )
+
+        #expect(activities[first.id] != .inactive)
+        #expect(activities[second.id] == .inactive)
+    }
+
+    @Test("Every repo appears in the projection, quiet or not")
+    func everyRepoIsProjected() {
+        let repos = [makeRepo(name: "alpha"), makeRepo(name: "beta"), makeRepo(name: "gamma")]
+
+        let activities = controller.repoActivities(context(repos: repos))
+
+        #expect(Set(activities.keys) == Set(repos.map(\.id)))
+    }
+
+    // MARK: - Snapshot assembly
+
+    @Test("The snapshot carries a row for every repo and workspace")
+    func snapshotCoversReposAndWorkspaces() {
+        let repo = makeRepo(name: "alpha", workspaceNames: ["a1", "a2"])
+
+        let snapshot = controller.snapshot(context(repos: [repo]))
+
+        // One row per repo and workspace, plus the standing theme command.
+        #expect(snapshot.rows.count >= 3)
+    }
+
+    @Test("An empty model still produces a usable snapshot")
+    func snapshotWithNoModelIsStillUsable() {
+        let snapshot = controller.snapshot(context(repos: []))
+
+        #expect(snapshot.rows.isEmpty == false)
+    }
+}


### PR DESCRIPTION
Slice 5 of the `ContentView` decomposition. Refs #1160 — 6a/6b/6c remain per the [re-scope](https://github.com/fairchild/workspaces/issues/1160#issuecomment-5175860936), so no `Closes`.

Follows slices [1](https://github.com/fairchild/workspaces/pull/1186), [2](https://github.com/fairchild/workspaces/pull/1188), [3](https://github.com/fairchild/workspaces/pull/1190), and [4](https://github.com/fairchild/workspaces/pull/1191) (still in review — this branch is cut from `main` and will need the same one-line additive conflict resolution on the controller-declaration block once #1191 lands).

## What moves

The three projections the main window feeds the session switcher, into `SessionSwitcherPresentationController`:

- `commandPaletteWorkspaceActivities` → `workspaceActivities(_:)`
- `commandPaletteRepoActivities` → `repoActivities(_:)`
- `sessionSwitcherWorkspaceSessionKeys` → `workspaceSessionKeys(_:)`
- the body of `makeSessionSwitcherSnapshot` → `snapshot(_:)`

They previously re-read `tileTreeStore.sessions`, `agentSessionRegistry.statuses`, and `workspaceStatusAggregator.repoStatuses` independently; a new `SessionSwitcherProjectionContext` gathers them once per pass. The presentation lifecycle (`presentSessionSwitcher` / `dismissSessionSwitcher` / refresh-only-while-presented) stays in the view — it reads and writes `viewState`.

`ContentView` drops 51 lines (3,580 → 3,529).

### The rule this locks in

`SessionSwitcherSnapshot.make` was already tested in Core. What it was being *handed* was not — in particular the per-repo merge: a repo row speaks for its workspaces as well as its own terminal, so it merges its own session activity with the status the aggregator bubbles up, and a repo the aggregator has nothing for contributes `.inactive` rather than erasing the baseline.

## Verification

- `swift build` clean, no new StrictConcurrency warnings from the touched files; `swift test` — 1,395 tests in 203 suites, all passing.
- `mise run lint` clean under `NeverForceUnwrap` / `NeverUseForceTry`.
- 16 new tests across the three projections and snapshot assembly.

## Evidence

Four mutation checks, all confirmed to fail against the broken form:

| Mutation | Result |
|---|---|
| Drop the bubbled merge from repo activity | 3 tests fail |
| Let bubbled *replace* the baseline instead of merging | baseline test fails |
| Swap `mergedWithBubbled` operands (flips the tie-break) | tie test fails |
| Ignore `context.normalizePath` in the repo projection | normalizer test fails |

The last two exist because of the review — see below.

![s5-mutation-check](https://evidence.cloudcompute.com/workspaces/pr-1193/20260804-075125-s5-mutation-check.png)

![s5-projection-tests](https://evidence.cloudcompute.com/workspaces/pr-1193/20260804-075126-s5-projection-tests.png)

**blocked on evidence: host display locked, screenshot to follow.** One capture was attempted and returned the same blank 74714-byte frame as during slices 3 and 4.

## Review loop

Reflected on the diff, then a directed codex review (`gpt-5.6-sol`, xhigh) over eight named failure modes plus a falsifiable completeness question. Verdict: **a pure extraction, no source blocker.**

The interesting one was the timing question. Gathering the context once is the only semantic change in the diff, so I asked codex to construct a case where the old per-projection reads would have disagreed. Its answer: constructible in principle, unreachable in practice — snapshot construction is fully synchronous with no `await`, and every registered provider's `sessionKey` is a synchronous key constructor, so nothing can mutate the stores between reads. It flagged that a *deliberately side-effectful future provider* could make the difference observable, which is worth knowing but not a reason to hold this.

Three findings, all tests that didn't bind the code they named, all fixed in `12dd10bd`:

1. **Medium — the merge's argument order wasn't bound.** `mergedWithBubbled` prefers `self` on ties, so swapping operands is a real behavior change — but invisible at different severities, which is all my tests compared. `.thinking` and `.runningTool` rank equally; a tie test is what binds it.
2. **Medium — the snapshot test didn't exercise the projections.** `rows.count >= 3` passed even with empty dictionaries. **Fixing this turned up something I had wrong:** `make` consults the activity dictionaries for *live* rows only and hardcodes dormant rows to `.inactive`. My first corrected attempt asserted that a quiet repo surfaces its bubbled status through the snapshot — it does not. The tests now assert live rows via `.hostSession` targets, and one documents the dormant boundary explicitly.
3. **Low — several context inputs had no seam test.** Added one that fails if the repo projection ignores `context.normalizePath`.

Confirmed clean and checked explicitly: the `.inactive` fallback and baseline-first argument order match the original; `SidebarSessionActivity` is exactly a typealias for `SessionActivity` so the spelling change is inert; `context.normalizePath(repo.localURL)` beta-reduces to the old `normalizePath(repo.localURL.path)`; the shared `SidebarWorkspacePresentationController` is a stateless struct so hoisting it is inert; and the presentation lifecycle, guarded refresh, and sheet `onDismiss` clearing are unchanged.

## Mergeability

- Surface: desktop — session switcher and command palette row projections (activity badges and session routing)
- User-facing behavior changed: No. Extraction only; the same rows with the same activities, from the same inputs.
- Non-happy paths considered: a workspace with no session still reports `.inactive`; a repo with neither its own session nor anything bubbled is still `.inactive`; bubbled status is still matched per repo rather than shared; a repo with no live session still renders dormant and ignores bubbled status (pre-existing `make` behavior, now documented by a test); an empty model still yields only the standing theme command; and no repos still produces no keys rather than trapping.
- Residual risk or follow-up: gathering the context once is the only semantic change — unreachable today for the reason above, but a future provider whose `sessionKey` mutated MainActor state synchronously would make it observable. `Dictionary(uniqueKeysWithValues:)` still traps on duplicate repo/workspace UUIDs; that is pre-existing, present in `make` too, and unchanged here. Visual evidence blocked as noted. 6a/6b/6c remain.
