### PR TITLE
refactor(app): extract main-window lifecycle sequences from ContentView (#1160 slice 6a)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -140,6 +140,7 @@ struct ContentView: View {
     private let workspaceOrphanController = WorkspaceOrphanReconciliationController()
     private let maintenanceController = MainWindowMaintenanceController()
     private let sessionSwitcherController = SessionSwitcherPresentationController()
+    private let lifecycleController = MainWindowLifecycleController()
     private let codePreviewController = CodePreviewNavigationController()
 
     private var launchRepositoryService: LaunchRepositoryService {
@@ -749,6 +750,59 @@ struct ContentView: View {
         )
     }
 
+    private var launchActions: MainWindowLifecycleController.LaunchActions {
+        MainWindowLifecycleController.LaunchActions(
+            configureAutomationIntegration: configureAutomationIntegration,
+            ensureInitialHostSession: ensureInitialHostSession,
+            computeRestorePlanIfEnabled: computeRestorePlanIfEnabled,
+            prewarmPerfTerminalSurfacesIfNeeded: prewarmPerfTerminalSurfacesIfNeeded,
+            resolveSurfaceLifecycle: resolveSurfaceLifecycle,
+            applyDiagnosticsFixtureIfNeeded: applyDiagnosticsFixtureIfNeeded,
+            applySessionSwitcherFixtureIfNeeded: applySessionSwitcherFixtureIfNeeded,
+            pruneRightPaneState: pruneRightPaneState,
+            syncOpenInEditorShortcutRouting: syncOpenInEditorShortcutRouting,
+            refreshWorkspaceStatusAggregator: refreshWorkspaceStatusAggregator,
+            noteHostLumeSmokeLaunchReady: hostLumeSmokeAutomation.noteLaunchReady,
+            noteDesktopUISmokeLaunchReady: desktopUISmokeAutomation.noteLaunchReady
+        )
+    }
+
+    private func modelChangeActions(
+        old: ModelSnapshot,
+        new: ModelSnapshot
+    ) -> MainWindowLifecycleController.ModelChangeActions {
+        MainWindowLifecycleController.ModelChangeActions(
+            rebuildSelectionCaches: {
+                mainSelectionCoordinator.rebuildCachesIfNeeded(
+                    repos: repos, webSources: webSources, normalizePath: normalizePath
+                )
+            },
+            releaseRemovedWebSources: { releaseRemovedWebSources(old: old, new: new) },
+            reconcileSelectionAfterModelChange: reconcileSelectionAfterModelChange,
+            resolveSurfaceLifecycle: resolveSurfaceLifecycle,
+            applyDiagnosticsFixtureIfNeeded: applyDiagnosticsFixtureIfNeeded,
+            applySessionSwitcherFixtureIfNeeded: applySessionSwitcherFixtureIfNeeded,
+            pruneRepoSessions: {
+                tileTreeStore.pruneRepoSessions(validRepoPaths: normalizedRepoPathSnapshot)
+            },
+            refreshWorkspaceStatusAggregator: refreshWorkspaceStatusAggregator,
+            refreshSessionSwitcherSnapshotIfPresented: refreshSessionSwitcherSnapshotIfPresented
+        )
+    }
+
+    private var teardownActions: MainWindowLifecycleController.TeardownActions {
+        MainWindowLifecycleController.TeardownActions(
+            clearOpenInEditorShortcutOverride: {
+                ShortcutRoutingPolicy.shared.setOverride(nil, for: AppChromeShortcut.openInEditor.chord)
+            },
+            cancelStatusAggregation: statusAggregationCoalescer.cancel,
+            // The window that installed the gesture-verb layer is gone; drop it so an operator
+            // mutation verb fails closed (unsupported) instead of driving a stale selection
+            // gesture while the app lingers as an accessory. Reappearing reinstalls it via onAppear.
+            detachAutomationGestureVerbs: AutomationIntegrationLifecycle.shared.detachGestureVerbs
+        )
+    }
+
     private var splitViewWithLifecycleHandlers: some View {
         splitViewWithToolbar
             .onAppear {
@@ -756,18 +810,7 @@ struct ContentView: View {
                     repos: repos, webSources: webSources, normalizePath: normalizePath
                 )
                 Task { @MainActor in
-                    await configureAutomationIntegration()
-                    ensureInitialHostSession()
-                    await computeRestorePlanIfEnabled()
-                    prewarmPerfTerminalSurfacesIfNeeded()
-                    resolveSurfaceLifecycle()
-                    applyDiagnosticsFixtureIfNeeded()
-                    applySessionSwitcherFixtureIfNeeded()
-                    pruneRightPaneState()
-                    syncOpenInEditorShortcutRouting()
-                    refreshWorkspaceStatusAggregator()
-                    await hostLumeSmokeAutomation.noteLaunchReady()
-                    await desktopUISmokeAutomation.noteLaunchReady()
+                    await lifecycleController.runLaunchSequence(launchActions)
                 }
                 notificationCoordinator.loadStoredAuth()
                 Task { @MainActor in
@@ -793,28 +836,13 @@ struct ContentView: View {
                 await performDeferredStartupWorkspaceStatusSync()
             }
             .onDisappear {
-                ShortcutRoutingPolicy.shared.setOverride(nil, for: AppChromeShortcut.openInEditor.chord)
-                statusAggregationCoalescer.cancel()
-                // The window that installed the gesture-verb layer is gone; drop it so an operator
-                // mutation verb fails closed (unsupported) instead of driving a stale selection
-                // gesture while the app lingers as an accessory. Reappearing reinstalls it via onAppear.
-                AutomationIntegrationLifecycle.shared.detachGestureVerbs()
+                lifecycleController.runTeardown(teardownActions)
             }
             .onChange(of: deepLinkState.pendingRequest) { _, _ in
                 resolveSurfaceLifecycle()
             }
             .onChange(of: modelSnapshot) { old, new in
-                mainSelectionCoordinator.rebuildCachesIfNeeded(
-                    repos: repos, webSources: webSources, normalizePath: normalizePath
-                )
-                releaseRemovedWebSources(old: old, new: new)
-                reconcileSelectionAfterModelChange()
-                resolveSurfaceLifecycle()
-                applyDiagnosticsFixtureIfNeeded()
-                applySessionSwitcherFixtureIfNeeded()
-                tileTreeStore.pruneRepoSessions(validRepoPaths: normalizedRepoPathSnapshot)
-                refreshWorkspaceStatusAggregator()
-                refreshSessionSwitcherSnapshotIfPresented()
+                lifecycleController.runModelChangeSequence(modelChangeActions(old: old, new: new))
             }
             .onChange(of: inspectorTargetIDSet) { _, _ in
                 pruneRightPaneState()

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowLifecycleController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowLifecycleController.swift
@@ -1,0 +1,93 @@
+//
+//  MainWindowLifecycleController.swift
+//  WorkspaceManager
+//
+//  The main window's three multi-step lifecycle sequences — launch, model change, and teardown —
+//  as ordered code rather than inline modifier bodies. Each step is supplied by the view; what
+//  lives here is the order they run in, which is load-bearing and was previously expressed only
+//  by the sequence of statements inside an `.onAppear` closure.
+//
+
+import Foundation
+
+@MainActor
+struct MainWindowLifecycleController {
+    /// Steps the window runs once, on first appearance.
+    struct LaunchActions {
+        let configureAutomationIntegration: () async -> Void
+        let ensureInitialHostSession: () -> Void
+        let computeRestorePlanIfEnabled: () async -> Void
+        let prewarmPerfTerminalSurfacesIfNeeded: () -> Void
+        let resolveSurfaceLifecycle: () -> Void
+        let applyDiagnosticsFixtureIfNeeded: () -> Void
+        let applySessionSwitcherFixtureIfNeeded: () -> Void
+        let pruneRightPaneState: () -> Void
+        let syncOpenInEditorShortcutRouting: () -> Void
+        let refreshWorkspaceStatusAggregator: () -> Void
+        let noteHostLumeSmokeLaunchReady: () async -> Void
+        let noteDesktopUISmokeLaunchReady: () async -> Void
+    }
+
+    /// Steps the window runs whenever the set of repos, workspaces, or web sources changes.
+    struct ModelChangeActions {
+        let rebuildSelectionCaches: () -> Void
+        let releaseRemovedWebSources: () -> Void
+        let reconcileSelectionAfterModelChange: () -> Void
+        let resolveSurfaceLifecycle: () -> Void
+        let applyDiagnosticsFixtureIfNeeded: () -> Void
+        let applySessionSwitcherFixtureIfNeeded: () -> Void
+        let pruneRepoSessions: () -> Void
+        let refreshWorkspaceStatusAggregator: () -> Void
+        let refreshSessionSwitcherSnapshotIfPresented: () -> Void
+    }
+
+    /// Steps the window runs when it goes away.
+    struct TeardownActions {
+        let clearOpenInEditorShortcutOverride: () -> Void
+        let cancelStatusAggregation: () -> Void
+        let detachAutomationGestureVerbs: () -> Void
+    }
+
+    /// Launch order is load-bearing. Automation integration installs the verb layer before
+    /// anything can drive it; the initial host session must exist before a restore plan is
+    /// computed against it; and the fixtures need the surface lifecycle resolved before they
+    /// select into it. The smoke lanes are told the window is ready last, once every earlier
+    /// step has run, because that signal is what their harnesses wait on.
+    func runLaunchSequence(_ actions: LaunchActions) async {
+        await actions.configureAutomationIntegration()
+        actions.ensureInitialHostSession()
+        await actions.computeRestorePlanIfEnabled()
+        actions.prewarmPerfTerminalSurfacesIfNeeded()
+        actions.resolveSurfaceLifecycle()
+        actions.applyDiagnosticsFixtureIfNeeded()
+        actions.applySessionSwitcherFixtureIfNeeded()
+        actions.pruneRightPaneState()
+        actions.syncOpenInEditorShortcutRouting()
+        actions.refreshWorkspaceStatusAggregator()
+        await actions.noteHostLumeSmokeLaunchReady()
+        await actions.noteDesktopUISmokeLaunchReady()
+    }
+
+    /// Model-change order is load-bearing too: the selection caches are rebuilt first so every
+    /// later step resolves ids against current models rather than a stale index, and selection is
+    /// reconciled before the surface lifecycle so the surface resolves against a valid selection.
+    func runModelChangeSequence(_ actions: ModelChangeActions) {
+        actions.rebuildSelectionCaches()
+        actions.releaseRemovedWebSources()
+        actions.reconcileSelectionAfterModelChange()
+        actions.resolveSurfaceLifecycle()
+        actions.applyDiagnosticsFixtureIfNeeded()
+        actions.applySessionSwitcherFixtureIfNeeded()
+        actions.pruneRepoSessions()
+        actions.refreshWorkspaceStatusAggregator()
+        actions.refreshSessionSwitcherSnapshotIfPresented()
+    }
+
+    /// Teardown drops the window-scoped overrides so a lingering accessory app cannot keep
+    /// routing shortcuts or driving gesture verbs through a window that is gone.
+    func runTeardown(_ actions: TeardownActions) {
+        actions.clearOpenInEditorShortcutOverride()
+        actions.cancelStatusAggregation()
+        actions.detachAutomationGestureVerbs()
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/MainWindowLifecycleControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowLifecycleControllerTests.swift
@@ -1,0 +1,206 @@
+//
+//  MainWindowLifecycleControllerTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Coverage for the order of the main window's launch, model-change, and teardown sequences.
+//  The steps themselves live in the view; what is asserted here is that they run, run once, and
+//  run in the order the surrounding machinery depends on.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("MainWindowLifecycle")
+struct MainWindowLifecycleControllerTests {
+    private let controller = MainWindowLifecycleController()
+
+    /// Records which steps ran, in order. A step name appearing twice is a duplicate run.
+    private final class Recorder {
+        private(set) var steps: [String] = []
+
+        func record(_ name: String) {
+            steps.append(name)
+        }
+
+        func step(_ name: String) -> () -> Void {
+            { [weak self] in self?.record(name) }
+        }
+
+        func asyncStep(_ name: String) -> () async -> Void {
+            { [weak self] in self?.record(name) }
+        }
+
+        func index(of name: String) -> Int? {
+            steps.firstIndex(of: name)
+        }
+
+        /// Whether `first` ran strictly before `second`, requiring both to have run.
+        func ordered(_ first: String, before second: String) -> Bool {
+            guard let a = index(of: first), let b = index(of: second) else { return false }
+            return a < b
+        }
+    }
+
+    private func launchActions(_ recorder: Recorder) -> MainWindowLifecycleController.LaunchActions {
+        MainWindowLifecycleController.LaunchActions(
+            configureAutomationIntegration: recorder.asyncStep("configureAutomationIntegration"),
+            ensureInitialHostSession: recorder.step("ensureInitialHostSession"),
+            computeRestorePlanIfEnabled: recorder.asyncStep("computeRestorePlanIfEnabled"),
+            prewarmPerfTerminalSurfacesIfNeeded: recorder.step("prewarmPerfTerminalSurfaces"),
+            resolveSurfaceLifecycle: recorder.step("resolveSurfaceLifecycle"),
+            applyDiagnosticsFixtureIfNeeded: recorder.step("applyDiagnosticsFixture"),
+            applySessionSwitcherFixtureIfNeeded: recorder.step("applySessionSwitcherFixture"),
+            pruneRightPaneState: recorder.step("pruneRightPaneState"),
+            syncOpenInEditorShortcutRouting: recorder.step("syncOpenInEditorShortcutRouting"),
+            refreshWorkspaceStatusAggregator: recorder.step("refreshWorkspaceStatusAggregator"),
+            noteHostLumeSmokeLaunchReady: recorder.asyncStep("noteHostLumeSmokeLaunchReady"),
+            noteDesktopUISmokeLaunchReady: recorder.asyncStep("noteDesktopUISmokeLaunchReady")
+        )
+    }
+
+    private func modelChangeActions(
+        _ recorder: Recorder
+    ) -> MainWindowLifecycleController.ModelChangeActions {
+        MainWindowLifecycleController.ModelChangeActions(
+            rebuildSelectionCaches: recorder.step("rebuildSelectionCaches"),
+            releaseRemovedWebSources: recorder.step("releaseRemovedWebSources"),
+            reconcileSelectionAfterModelChange: recorder.step("reconcileSelection"),
+            resolveSurfaceLifecycle: recorder.step("resolveSurfaceLifecycle"),
+            applyDiagnosticsFixtureIfNeeded: recorder.step("applyDiagnosticsFixture"),
+            applySessionSwitcherFixtureIfNeeded: recorder.step("applySessionSwitcherFixture"),
+            pruneRepoSessions: recorder.step("pruneRepoSessions"),
+            refreshWorkspaceStatusAggregator: recorder.step("refreshWorkspaceStatusAggregator"),
+            refreshSessionSwitcherSnapshotIfPresented: recorder.step("refreshSessionSwitcher")
+        )
+    }
+
+    private func teardownActions(
+        _ recorder: Recorder
+    ) -> MainWindowLifecycleController.TeardownActions {
+        MainWindowLifecycleController.TeardownActions(
+            clearOpenInEditorShortcutOverride: recorder.step("clearShortcutOverride"),
+            cancelStatusAggregation: recorder.step("cancelStatusAggregation"),
+            detachAutomationGestureVerbs: recorder.step("detachGestureVerbs")
+        )
+    }
+
+    // MARK: - Launch
+
+    @Test("Every launch step runs exactly once")
+    func launchRunsEveryStepOnce() async {
+        let recorder = Recorder()
+
+        await controller.runLaunchSequence(launchActions(recorder))
+
+        #expect(recorder.steps.count == 12)
+        #expect(Set(recorder.steps).count == 12)
+    }
+
+    /// Automation integration installs the verb layer, so it has to be up before anything can
+    /// drive it — including the smoke lanes that wait on the ready signal.
+    @Test("Launch configures automation before anything can drive it")
+    func launchConfiguresAutomationFirst() async {
+        let recorder = Recorder()
+
+        await controller.runLaunchSequence(launchActions(recorder))
+
+        #expect(recorder.steps.first == "configureAutomationIntegration")
+    }
+
+    /// A restore plan is computed against the session set, so the initial host session has to
+    /// exist first or the plan is made against an emptier window than the user will see.
+    @Test("Launch ensures the initial host session before planning a restore")
+    func launchEnsuresSessionBeforeRestorePlan() async {
+        let recorder = Recorder()
+
+        await controller.runLaunchSequence(launchActions(recorder))
+
+        #expect(recorder.ordered("ensureInitialHostSession", before: "computeRestorePlanIfEnabled"))
+    }
+
+    /// The fixtures select into the resolved surface, so surface resolution has to precede them.
+    @Test("Launch resolves the surface before applying fixtures")
+    func launchResolvesSurfaceBeforeFixtures() async {
+        let recorder = Recorder()
+
+        await controller.runLaunchSequence(launchActions(recorder))
+
+        #expect(recorder.ordered("resolveSurfaceLifecycle", before: "applyDiagnosticsFixture"))
+        #expect(recorder.ordered("resolveSurfaceLifecycle", before: "applySessionSwitcherFixture"))
+    }
+
+    /// The smoke harnesses block on these signals, so anything they expect to observe has to
+    /// have already run.
+    @Test("Launch signals the smoke lanes last")
+    func launchSignalsSmokeLanesLast() async {
+        let recorder = Recorder()
+
+        await controller.runLaunchSequence(launchActions(recorder))
+
+        #expect(recorder.steps.suffix(2) == ["noteHostLumeSmokeLaunchReady", "noteDesktopUISmokeLaunchReady"])
+    }
+
+    // MARK: - Model change
+
+    @Test("Every model-change step runs exactly once")
+    func modelChangeRunsEveryStepOnce() {
+        let recorder = Recorder()
+
+        controller.runModelChangeSequence(modelChangeActions(recorder))
+
+        #expect(recorder.steps.count == 9)
+        #expect(Set(recorder.steps).count == 9)
+    }
+
+    /// The rule this slice exists to lock in. Every later step resolves ids against the selection
+    /// caches, so rebuilding them first is what stops the rest of the pass reading a stale index
+    /// after a repo or workspace is deleted.
+    @Test("Model change rebuilds selection caches before anything reads them")
+    func modelChangeRebuildsCachesFirst() {
+        let recorder = Recorder()
+
+        controller.runModelChangeSequence(modelChangeActions(recorder))
+
+        #expect(recorder.steps.first == "rebuildSelectionCaches")
+    }
+
+    /// Surface resolution reads the current selection, so a selection invalidated by the model
+    /// change has to be reconciled before the surface resolves against it.
+    @Test("Model change reconciles selection before resolving the surface")
+    func modelChangeReconcilesBeforeResolvingSurface() {
+        let recorder = Recorder()
+
+        controller.runModelChangeSequence(modelChangeActions(recorder))
+
+        #expect(recorder.ordered("reconcileSelection", before: "resolveSurfaceLifecycle"))
+    }
+
+    /// Sessions for repos that no longer exist are pruned before the aggregator rolls status up,
+    /// so a removed repo cannot contribute a status to the sidebar on its way out.
+    @Test("Model change prunes dead repo sessions before rolling status up")
+    func modelChangePrunesBeforeAggregating() {
+        let recorder = Recorder()
+
+        controller.runModelChangeSequence(modelChangeActions(recorder))
+
+        #expect(recorder.ordered("pruneRepoSessions", before: "refreshWorkspaceStatusAggregator"))
+    }
+
+    // MARK: - Teardown
+
+    @Test("Teardown drops every window-scoped override exactly once")
+    func teardownDropsEveryOverride() {
+        let recorder = Recorder()
+
+        controller.runTeardown(teardownActions(recorder))
+
+        #expect(
+            recorder.steps == [
+                "clearShortcutOverride", "cancelStatusAggregation", "detachGestureVerbs",
+            ]
+        )
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/MainWindowLifecycleControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowLifecycleControllerTests.swift
@@ -29,8 +29,13 @@ struct MainWindowLifecycleControllerTests {
             { [weak self] in self?.record(name) }
         }
 
+        /// Suspends before recording, so an ordering that only holds when nothing yields
+        /// cannot pass: the sequence must actually await each step before running the next.
         func asyncStep(_ name: String) -> () async -> Void {
-            { [weak self] in self?.record(name) }
+            { [weak self] in
+                await Task.yield()
+                self?.record(name)
+            }
         }
 
         func index(of name: String) -> Int? {
@@ -89,14 +94,30 @@ struct MainWindowLifecycleControllerTests {
 
     // MARK: - Launch
 
-    @Test("Every launch step runs exactly once")
-    func launchRunsEveryStepOnce() async {
+    /// The whole contract is the order, so this asserts the complete sequence rather than a
+    /// set — a permutation of the middle steps would otherwise pass every other test here.
+    @Test("Launch runs every step once, in order")
+    func launchRunsEveryStepInOrder() async {
         let recorder = Recorder()
 
         await controller.runLaunchSequence(launchActions(recorder))
 
-        #expect(recorder.steps.count == 12)
-        #expect(Set(recorder.steps).count == 12)
+        #expect(
+            recorder.steps == [
+                "configureAutomationIntegration",
+                "ensureInitialHostSession",
+                "computeRestorePlanIfEnabled",
+                "prewarmPerfTerminalSurfaces",
+                "resolveSurfaceLifecycle",
+                "applyDiagnosticsFixture",
+                "applySessionSwitcherFixture",
+                "pruneRightPaneState",
+                "syncOpenInEditorShortcutRouting",
+                "refreshWorkspaceStatusAggregator",
+                "noteHostLumeSmokeLaunchReady",
+                "noteDesktopUISmokeLaunchReady",
+            ]
+        )
     }
 
     /// Automation integration installs the verb layer, so it has to be up before anything can
@@ -145,14 +166,25 @@ struct MainWindowLifecycleControllerTests {
 
     // MARK: - Model change
 
-    @Test("Every model-change step runs exactly once")
-    func modelChangeRunsEveryStepOnce() {
+    @Test("Model change runs every step once, in order")
+    func modelChangeRunsEveryStepInOrder() {
         let recorder = Recorder()
 
         controller.runModelChangeSequence(modelChangeActions(recorder))
 
-        #expect(recorder.steps.count == 9)
-        #expect(Set(recorder.steps).count == 9)
+        #expect(
+            recorder.steps == [
+                "rebuildSelectionCaches",
+                "releaseRemovedWebSources",
+                "reconcileSelection",
+                "resolveSurfaceLifecycle",
+                "applyDiagnosticsFixture",
+                "applySessionSwitcherFixture",
+                "pruneRepoSessions",
+                "refreshWorkspaceStatusAggregator",
+                "refreshSessionSwitcher",
+            ]
+        )
     }
 
     /// The rule this slice exists to lock in. Every later step resolves ids against the selection


### PR DESCRIPTION
Slice 6a of the `ContentView` decomposition. Refs #1160 — 6b/6c remain, so no `Closes`.

Follows slices [1](https://github.com/fairchild/workspaces/pull/1186)–[5](https://github.com/fairchild/workspaces/pull/1193), rebased over slice 5 (one additive conflict on the controller-declaration block, resolved as in slice 4).

## What moves — and what deliberately doesn't

The three multi-step lifecycle sequences move into `MainWindowLifecycleController`: the `.onAppear` launch task (12 steps), the `.onChange(of: modelSnapshot)` handler (9 steps), and `.onDisappear` (3 steps). The view supplies each step; the controller owns the order.

**I did not relocate the modifier stack itself into a `ViewModifier`,** which is what my re-scope originally described for 6a. Two reasons, both worth stating plainly:

1. **It's a structural view move, and I can't verify it.** Wrapping the chain changes the view tree's shape. It is almost certainly identity-neutral — that's the standard way modifiers are factored — but "almost certainly" is not what you want standing between a refactor and live terminal surfaces, and window capture is still blocked. This is the same reasoning that gated 6c; on inspection 6a splits along the same line.
2. **It costs lines rather than saving them.** The `onChange` keys can't be bundled (bundling would fire every handler on any change), so the modifier needs ~11 separate keys plus ~14 closures — a 25-parameter modifier that is harder to read than what it replaces, and adds no testability since closures aren't assertable.

So 6a as shipped is the identity-neutral, testable half. **`ContentView` grows 28 lines** (naming 24 steps costs more than the inline statements saved) — measured against `main` before slice 5 landed; the file is 3,557 now that slice 5's 51-line reduction is in. I'd rather report that number than bury it: this slice buys tested ordering, not decomposition.

### The rule this locks in

The **order** of all three sequences, which is load-bearing and had no test:

- selection caches rebuild before anything resolves ids against them (a stale index after a repo deletion is how this goes wrong);
- the initial host session exists before a restore is planned against it;
- the surface resolves before the fixtures select into it;
- dead repo sessions are pruned before status rolls up, so a removed repo can't contribute a status on its way out;
- the smoke lanes are signalled **last**, because their harnesses block on that signal.

### View-identity claim, verified

Asked for explicitly, so stated explicitly: **no `.id()` changed, no view was moved, rewrapped, or rebranched, and the modifier chain on `splitViewWithLifecycleHandlers` is unchanged in type, order, and keys.** Only closure *bodies* changed. Codex verified this independently against the diff and reached the same conclusion.

## Verification

- `swift build` clean, no new StrictConcurrency warnings from the touched files; `swift test` — 1,405 tests in 204 suites, all passing after the rebase.
- `mise run lint` clean under `NeverForceUnwrap` / `NeverUseForceTry`.
- 10 new tests covering all three sequences.

## Evidence

Five mutation checks, all confirmed to fail against the broken form. The last two are codex's — it named two permutations my original tests would have accepted, and both now fail:

| Mutation | Result |
|---|---|
| Rebuild selection caches *after* reconciling selection | model-change order test fails |
| Signal the smoke lanes before the launch sequence finishes | smoke-last test fails |
| Plan the restore before ensuring the initial host session | session-before-restore test fails |
| Move `releaseRemovedWebSources` to the end of model change | complete-order test fails *(was an escape)* |
| Swap `pruneRightPaneState` / `refreshWorkspaceStatusAggregator` | complete-order test fails *(was an escape)* |

![s6a-mutation-check](https://evidence.cloudcompute.com/workspaces/pr-1194/20260804-081847-s6a-mutation-check.png)

![s6a-lifecycle-tests](https://evidence.cloudcompute.com/workspaces/pr-1194/20260804-081848-s6a-lifecycle-tests.png)

**No visual evidence, and not because it's blocked.** 6a has no visual surface — it changes sequencing only, renders nothing, and by the identity claim above cannot change what the window draws. A screenshot would show an unchanged main window, which is not evidence of anything this diff does. (Capture is still returning blank frames, but that isn't the reason there's no screenshot here.)

## Review loop

Reflected on the diff, then a directed codex review (`gpt-5.6-sol`, xhigh) over eight named failure modes plus a falsifiable completeness question. Verdict: **pure extraction, yes; recorder tests worth keeping, yes.**

The question I most wanted answered was closure-capture semantics: the action structs now hold unapplied method references that capture a `ContentView` *value*, so do `@State` reads inside them still see live values when the closure runs later inside a `Task`? Codex's answer: clean — the original modifier and `Task` closures already captured that same view value, and copied `@State` wrappers share SwiftUI's installed backing location. It also noted the one place a real bug *would* have arisen — if `normalizedRepoPathSnapshot` had been captured eagerly before the cache rebuild rather than evaluated at step 7 — and confirmed it isn't.

Two findings, both test weaknesses:

1. **Moderate — the tests didn't enforce the complete order.** Count-and-set assertions accept any permutation; only a few pairwise relationships were pinned. Fixed by asserting the full expected arrays (as the teardown test already did), with both of codex's named escapes now mutation-confirmed. It also pointed out the async recorder steps never suspended, so the ordering proof didn't cross a real suspension point — they now `Task.yield()` before recording.
2. **Moderate — production wiring is untested, and stays that way.** The tests build their own action structs, so a mis-wired field in `ContentView.launchActions` — binding `pruneRightPaneState` to the wrong method, passing `old`/`new` reversed, pointing a smoke-ready field at the wrong automation object — would pass everything here. That needs a hosted view. Declined rather than papered over; it's in residual risk below. Codex explicitly distinguished this from the slice 4/5 escapes: those were tests that didn't execute the code they named, whereas these do — the blind spot is the adapter around the controller.

## Mergeability

- Surface: desktop — main window lifecycle sequencing (launch, model change, teardown). No rendering change.
- User-facing behavior changed: No. Extraction only; every step runs once, in the same order, with the same awaits, verified statement-by-statement against `main` in the review's completeness audit (12/12 launch, 9/9 model change, 3/3 teardown).
- Non-happy paths considered: the launch sequence still awaits the four steps that were awaited before, so a slow automation handshake still blocks the steps after it; `normalizedRepoPathSnapshot` is still evaluated at its own step rather than captured up front, so a model change still prunes against post-rebuild paths; teardown still drops all three window-scoped overrides even if the window disappears mid-launch.
- Residual risk or follow-up: the action structs are built in `ContentView` and nothing tests that wiring — a swapped field would compile and pass every test here, and closing it needs a hosted view. `ContentView` grows 28 lines for this slice. The modifier-relocation half of 6a is deferred to join 6c behind the window-capture fix. 6b (alert/sheet presentation) is unaffected and still identity-neutral by the same argument.

Made with [Orca](https://github.com/stablyai/orca) 🐋
