### PR TITLE
refactor(app): extract alert and sheet presentation bindings from ContentView (#1160 slice 6b)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -884,14 +884,12 @@ struct ContentView: View {
             .mainWindowErrorAlert($errorPresenter)
             .alert(
                 workspaceOrphanController.confirmationTitle(for: workspaceOrphanState.pendingCleanup),
-                isPresented: Binding(
-                    get: { workspaceOrphanState.pendingCleanup != nil },
-                    set: { if !$0 { workspaceOrphanState.pendingCleanup = nil } }
-                )
+                isPresented: MainWindowPresentation.isPresented($workspaceOrphanState.pendingCleanup)
             ) {
                 Button("Clean", role: .destructive) {
-                    guard let item = workspaceOrphanState.pendingCleanup else { return }
-                    workspaceOrphanState.pendingCleanup = nil
+                    guard
+                        let item = MainWindowPresentation.consume($workspaceOrphanState.pendingCleanup)
+                    else { return }
                     Task { @MainActor in
                         await cleanWorkspaceOrphan(item)
                     }
@@ -906,9 +904,9 @@ struct ContentView: View {
             }
             .alert(
                 "Could Not Complete Provider Setup",
-                isPresented: Binding(
-                    get: { workspaceProviderSetupCoordinator.errorMessage != nil },
-                    set: { if !$0 { workspaceProviderSetupCoordinator.clearError() } }
+                isPresented: MainWindowPresentation.isPresented(
+                    workspaceProviderSetupCoordinator.errorMessage,
+                    onDismiss: { workspaceProviderSetupCoordinator.clearError() }
                 )
             ) {
                 Button("OK", role: .cancel) { workspaceProviderSetupCoordinator.clearError() }
@@ -917,14 +915,13 @@ struct ContentView: View {
             }
             .alert(
                 "Close Terminal?",
-                isPresented: Binding(
-                    get: { viewState.terminalCloseConfirmation != nil },
-                    set: { if !$0 { viewState.terminalCloseConfirmation = nil } }
-                )
+                isPresented: MainWindowPresentation.isPresented($viewState.terminalCloseConfirmation)
             ) {
                 Button("Close", role: .destructive) {
-                    guard let confirmation = viewState.terminalCloseConfirmation else { return }
-                    viewState.terminalCloseConfirmation = nil
+                    guard
+                        let confirmation = MainWindowPresentation.consume(
+                            $viewState.terminalCloseConfirmation)
+                    else { return }
                     forceCloseTerminalTab(sessionID: confirmation.sessionID)
                 }
                 Button("Cancel", role: .cancel) {
@@ -939,13 +936,9 @@ struct ContentView: View {
                 )
             }
             .sheet(
-                item: Binding(
-                    get: { workspaceProviderSetupCoordinator.confirmationRequest },
-                    set: { request in
-                        if request == nil {
-                            workspaceProviderSetupCoordinator.cancelPendingAction()
-                        }
-                    }
+                item: MainWindowPresentation.item(
+                    workspaceProviderSetupCoordinator.confirmationRequest,
+                    onDismiss: { workspaceProviderSetupCoordinator.cancelPendingAction() }
                 )
             ) { request in
                 WorkspaceProviderSetupConfirmationSheet(
@@ -959,9 +952,8 @@ struct ContentView: View {
                 )
             }
             .sheet(
-                item: Binding(
-                    get: { workspaceProviderSetupCoordinator.progressPresentation },
-                    set: { _ in }
+                item: MainWindowPresentation.undismissableItem(
+                    workspaceProviderSetupCoordinator.progressPresentation
                 )
             ) { presentation in
                 WorkspaceProviderSetupProgressSheet(presentation: presentation)
@@ -1129,11 +1121,9 @@ struct ContentView: View {
     }
 
     private var pendingCodePreviewNavigationBinding: Binding<Bool> {
-        Binding(
-            get: { codePreviewNavigationState.pending != nil },
-            set: { isPresented in
-                if !isPresented { codePreviewNavigationState.clearPending() }
-            }
+        MainWindowPresentation.isPresented(
+            codePreviewNavigationState.pending,
+            onDismiss: { codePreviewNavigationState.clearPending() }
         )
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowPresentation.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowPresentation.swift
@@ -1,0 +1,79 @@
+//
+//  MainWindowPresentation.swift
+//  WorkspaceManager
+//
+//  Bridges between the main window's "pending item" state and the bindings SwiftUI's alert and
+//  sheet modifiers want. Every confirmation in the window is driven by an optional — non-nil
+//  presents, dismissal clears — and every confirming button has to take that value before it
+//  acts. Both rules were previously re-implemented inline at each call site.
+//
+
+import SwiftUI
+
+enum MainWindowPresentation {
+    /// `true` while `item` is non-nil.
+    ///
+    /// Only a dismissal clears the source. A `true` write is deliberately ignored: SwiftUI can
+    /// re-assert presentation, and inventing an item to satisfy it is not this binding's job —
+    /// the item is what decides, not the flag.
+    static func isPresented<Item>(_ item: Binding<Item?>) -> Binding<Bool> {
+        Binding(
+            get: { item.wrappedValue != nil },
+            set: { isPresented in
+                if !isPresented { item.wrappedValue = nil }
+            }
+        )
+    }
+
+    /// As above, but dismissal runs `onDismiss` rather than assigning `nil`, for sources that own
+    /// their own teardown — a coordinator that has to cancel pending work, not merely forget a
+    /// value it was holding.
+    static func isPresented<Item>(
+        _ item: @escaping @autoclosure () -> Item?,
+        onDismiss: @escaping () -> Void
+    ) -> Binding<Bool> {
+        Binding(
+            get: { item() != nil },
+            set: { isPresented in
+                if !isPresented { onDismiss() }
+            }
+        )
+    }
+
+    /// An `item:` binding whose dismissal runs `onDismiss`. Same rule as above, for the `sheet(item:)`
+    /// form that hands the item to its content builder.
+    static func item<Item>(
+        _ item: @escaping @autoclosure () -> Item?,
+        onDismiss: @escaping () -> Void
+    ) -> Binding<Item?> {
+        Binding(
+            get: item,
+            set: { newValue in
+                if newValue == nil { onDismiss() }
+            }
+        )
+    }
+
+    /// An `item:` binding that ignores dismissal entirely: the sheet closes when its owner
+    /// finishes the work, never because the user waved it away. Pair with
+    /// `interactiveDismissDisabled(true)` so the two agree.
+    static func undismissableItem<Item>(
+        _ item: @escaping @autoclosure () -> Item?
+    ) -> Binding<Item?> {
+        Binding(get: item, set: { _ in })
+    }
+
+    /// Takes the pending value and clears it in one step.
+    ///
+    /// Confirming buttons must consume *before* they act. The action can present again — a
+    /// cleanup that rescans, a close that raises a new confirmation — and a source still holding
+    /// the answered value would re-show the alert the user just dismissed. Returns `nil` when
+    /// there is nothing pending, which is the guard SwiftUI needs because a button action can
+    /// still arrive after the state cleared.
+    @discardableResult
+    static func consume<Item>(_ item: Binding<Item?>) -> Item? {
+        guard let value = item.wrappedValue else { return nil }
+        item.wrappedValue = nil
+        return value
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/MainWindowPresentationTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowPresentationTests.swift
@@ -1,0 +1,188 @@
+//
+//  MainWindowPresentationTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Coverage for the two rules every main-window confirmation depends on: an optional decides
+//  presentation and only a dismissal clears it, and a confirming button takes the pending value
+//  before it acts so the alert it just answered cannot re-present.
+//
+
+import SwiftUI
+import Testing
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("MainWindowPresentation")
+struct MainWindowPresentationTests {
+    /// Stands in for the view state an alert reads, so the `@autoclosure` overloads re-evaluate
+    /// their source the way they do against a live `@State`.
+    private final class Box<Item> {
+        var value: Item?
+        init(_ value: Item? = nil) { self.value = value }
+
+        var binding: Binding<Item?> {
+            Binding(get: { self.value }, set: { self.value = $0 })
+        }
+    }
+
+    // MARK: - Presentation from an optional
+
+    @Test("An alert presents exactly while its item is set")
+    func presentationFollowsTheItem() {
+        let box = Box<String>()
+        let isPresented = MainWindowPresentation.isPresented(box.binding)
+
+        #expect(isPresented.wrappedValue == false)
+
+        box.value = "pending"
+
+        #expect(isPresented.wrappedValue)
+    }
+
+    @Test("Dismissing clears the item")
+    func dismissingClearsTheItem() {
+        let box = Box("pending")
+        let isPresented = MainWindowPresentation.isPresented(box.binding)
+
+        isPresented.wrappedValue = false
+
+        #expect(box.value == nil)
+    }
+
+    /// The item is what decides presentation, so a `true` write has nothing to act on. Inventing
+    /// a value to satisfy it would present an alert about nothing.
+    @Test("Setting presented true does not invent an item")
+    func settingPresentedTrueDoesNothing() {
+        let box = Box<String>()
+        let isPresented = MainWindowPresentation.isPresented(box.binding)
+
+        isPresented.wrappedValue = true
+
+        #expect(box.value == nil)
+        #expect(isPresented.wrappedValue == false)
+    }
+
+    /// The case that actually binds the "only a dismissal clears" rule: SwiftUI re-asserting
+    /// presentation on a live alert must not destroy the item the alert is about. Asserting this
+    /// against an already-empty source proves nothing, because clearing nothing looks identical.
+    @Test("Re-asserting presentation leaves a live item intact")
+    func reassertingPresentationKeepsTheItem() {
+        let box = Box("pending")
+        let isPresented = MainWindowPresentation.isPresented(box.binding)
+
+        isPresented.wrappedValue = true
+
+        #expect(box.value == "pending")
+        #expect(isPresented.wrappedValue)
+    }
+
+    // MARK: - Sources that own their teardown
+
+    @Test("A coordinator-backed alert runs its own teardown on dismissal")
+    func coordinatorTeardownRunsOnDismissal() {
+        let box = Box("failed")
+        var teardownCount = 0
+        let isPresented = MainWindowPresentation.isPresented(
+            box.value,
+            onDismiss: { teardownCount += 1 }
+        )
+
+        #expect(isPresented.wrappedValue)
+
+        isPresented.wrappedValue = false
+
+        #expect(teardownCount == 1)
+        // The teardown owns the clearing; the binding must not also assign.
+        #expect(box.value == "failed")
+    }
+
+    @Test("Re-asserting presentation does not run the teardown")
+    func coordinatorTeardownIgnoresTrue() {
+        let box = Box("failed")
+        var teardownCount = 0
+        let isPresented = MainWindowPresentation.isPresented(
+            box.value,
+            onDismiss: { teardownCount += 1 }
+        )
+
+        isPresented.wrappedValue = true
+
+        #expect(teardownCount == 0)
+    }
+
+    @Test("An item sheet cancels its pending work when dismissed")
+    func itemSheetCancelsOnDismissal() {
+        let box = Box("request")
+        var cancelCount = 0
+        let binding = MainWindowPresentation.item(box.value, onDismiss: { cancelCount += 1 })
+
+        #expect(binding.wrappedValue == "request")
+
+        binding.wrappedValue = nil
+
+        #expect(cancelCount == 1)
+    }
+
+    @Test("Assigning a new item does not cancel pending work")
+    func itemSheetIgnoresNonNilWrites() {
+        let box = Box("request")
+        var cancelCount = 0
+        let binding = MainWindowPresentation.item(box.value, onDismiss: { cancelCount += 1 })
+
+        binding.wrappedValue = "another"
+
+        #expect(cancelCount == 0)
+    }
+
+    /// The progress sheet closes when its owner finishes, never because the user waved it away.
+    @Test("An undismissable sheet ignores dismissal entirely")
+    func undismissableSheetIgnoresDismissal() {
+        let box = Box("in progress")
+        let binding = MainWindowPresentation.undismissableItem(box.value)
+
+        #expect(binding.wrappedValue == "in progress")
+
+        binding.wrappedValue = nil
+
+        #expect(box.value == "in progress")
+        #expect(binding.wrappedValue == "in progress")
+    }
+
+    // MARK: - Consume before acting
+
+    @Test("Consuming returns the pending value and clears it")
+    func consumeReturnsAndClears() {
+        let box = Box("item")
+
+        #expect(MainWindowPresentation.consume(box.binding) == "item")
+        #expect(box.value == nil)
+    }
+
+    /// The rule this extraction locks in. A confirming action can present again — a cleanup that
+    /// rescans, a close that raises the next confirmation — so the value has to be gone before
+    /// the action runs, or the answered alert comes straight back.
+    @Test("A second consume finds nothing, so the answered alert cannot re-present")
+    func consumeIsSingleShot() {
+        let box = Box("item")
+
+        let first = MainWindowPresentation.consume(box.binding)
+        let second = MainWindowPresentation.consume(box.binding)
+
+        #expect(first == "item")
+        #expect(second == nil)
+
+        let isPresented = MainWindowPresentation.isPresented(box.binding)
+        #expect(isPresented.wrappedValue == false)
+    }
+
+    /// A button action can still arrive after the state cleared, so consuming an empty source has
+    /// to be a no-op rather than a crash or a spurious action.
+    @Test("Consuming nothing returns nil and leaves the source alone")
+    func consumeEmptyIsANoOp() {
+        let box = Box<String>()
+
+        #expect(MainWindowPresentation.consume(box.binding) == nil)
+        #expect(box.value == nil)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/MainWindowPresentationTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowPresentationTests.swift
@@ -124,7 +124,7 @@ struct MainWindowPresentationTests {
         #expect(cancelCount == 1)
     }
 
-    @Test("Assigning a new item does not cancel pending work")
+    @Test("Assigning a new item does not cancel pending work, and does not take effect")
     func itemSheetIgnoresNonNilWrites() {
         let box = Box("request")
         var cancelCount = 0
@@ -133,6 +133,8 @@ struct MainWindowPresentationTests {
         binding.wrappedValue = "another"
 
         #expect(cancelCount == 0)
+        // The source is the authority; the binding never writes through to it.
+        #expect(binding.wrappedValue == "request")
     }
 
     /// The progress sheet closes when its owner finishes, never because the user waved it away.
@@ -146,6 +148,48 @@ struct MainWindowPresentationTests {
         binding.wrappedValue = nil
 
         #expect(box.value == "in progress")
+        #expect(binding.wrappedValue == "in progress")
+    }
+
+    // MARK: - Freshness of the autoclosure sources
+
+    /// These three factories read their source through an `@autoclosure`, so every getter call
+    /// must re-evaluate it. Constructing from an already-set value proves nothing — an
+    /// implementation that snapshotted once would look identical. Each of these starts empty and
+    /// asserts the binding sees a value that arrived *after* construction.
+    @Test("A coordinator-backed alert sees an error raised after it was built")
+    func coordinatorAlertReadsTheCurrentValue() {
+        let box = Box<String>()
+        let isPresented = MainWindowPresentation.isPresented(box.value, onDismiss: {})
+
+        #expect(isPresented.wrappedValue == false)
+
+        box.value = "failed"
+
+        #expect(isPresented.wrappedValue)
+    }
+
+    @Test("An item sheet sees a request raised after it was built")
+    func itemSheetReadsTheCurrentValue() {
+        let box = Box<String>()
+        let binding = MainWindowPresentation.item(box.value, onDismiss: {})
+
+        #expect(binding.wrappedValue == nil)
+
+        box.value = "request"
+
+        #expect(binding.wrappedValue == "request")
+    }
+
+    @Test("An undismissable sheet sees progress that started after it was built")
+    func undismissableSheetReadsTheCurrentValue() {
+        let box = Box<String>()
+        let binding = MainWindowPresentation.undismissableItem(box.value)
+
+        #expect(binding.wrappedValue == nil)
+
+        box.value = "in progress"
+
         #expect(binding.wrappedValue == "in progress")
     }
 


### PR DESCRIPTION
Slice 6b of the `ContentView` decomposition. Refs #1160 — the final gated slice (6c plus the deferred 6a half) remains, so no `Closes`.

Follows slices [1](https://github.com/fairchild/workspaces/pull/1186)–[6a](https://github.com/fairchild/workspaces/pull/1194), rebased over slice 4.

## What moves

The six hand-rolled `Binding(get:set:)` bridges behind the main window's alerts and sheets, into `MainWindowPresentation`:

| Surface | Replacement |
|---|---|
| Orphan cleanup alert | `isPresented($workspaceOrphanState.pendingCleanup)` |
| Provider setup error alert | `isPresented(_:onDismiss:)` — coordinator owns its teardown |
| Terminal close confirmation | `isPresented($viewState.terminalCloseConfirmation)` |
| Provider confirmation sheet | `item(_:onDismiss:)` — dismissal cancels pending work |
| Provider progress sheet | `undismissableItem(_:)` — closes when its owner finishes, never by the user |
| Code-preview unsaved-changes dialog | `isPresented(_:onDismiss:)` |

Plus `consume(_:)`, which the two destructive confirming buttons now route through.

`ContentView` drops 10 lines (3,529 → 3,516 on the rebased tree). Modest — but unlike 6a it moves in the right direction, because this replaces duplicated boilerplate rather than naming steps that were already one-liners.

### The rule this locks in

**Present-and-consume**, re-implemented inline at six call sites and tested at none:

- an optional decides presentation, and **only a dismissal clears it** — a `true` write must not destroy the item the alert is about, and must not invent one;
- some sources own their teardown (a coordinator that has to *cancel* pending work, not merely forget a value), and one ignores dismissal entirely;
- a confirming button **takes the pending value before it acts**, because the action can present again — a cleanup that rescans, a close that raises the next confirmation — and a source still holding the answered value would re-show the alert the user just dismissed.

### Identity-neutral, by construction

This changes **how a `Binding` value is built, not where any view sits**. Same modifiers, same order, same argument types, no `.id` touched, no view moved, rewrapped, or rebranched. That is a stronger claim than 6a's deferred half could make, and it's why this slice wasn't gated on the capture fix. Codex verified it independently against the diff.

## Verification

- `swift build` clean, no new StrictConcurrency warnings; `swift test` — 1,433 tests in 205 suites, all passing after the rebase.
- `mise run lint` clean under `NeverForceUnwrap` / `NeverUseForceTry`.
- 15 new tests across the presentation factories and `consume`.

## Evidence

**Window capture works again** — the host session is unlocked, so this is a real screenshot rather than the deferred marker on #1191/#1194. It shows the live orphan-cleanup banner: its Clean button is what sets `workspaceOrphanState.pendingCleanup`, the exact optional this slice's `isPresented` and `consume` now bridge. The whole presentation stack is composed and rendering behind it. I did not click through to the alert itself — it is a destructive action against real leftovers on a shared machine.

![phase-1-release](https://evidence.cloudcompute.com/workspaces/pr-1196/20260804-085130-phase-1-release.png)

Four mutation checks. Two of them started as **passing**, which is the useful part:

| Mutation | Result |
|---|---|
| `consume` returns without clearing | 2 tests fail |
| The coordinator teardown never runs | 1 test fails |
| `isPresented` clears on *any* set, not only dismissal | **passed at first** — test tightened, then fails |
| Snapshot the autoclosure source once instead of re-reading | **passed at first** — test tightened, then fails |

![s6b-mutation-check](https://evidence.cloudcompute.com/workspaces/pr-1196/20260804-085130-s6b-mutation-check.png)

![s6b-presentation-tests](https://evidence.cloudcompute.com/workspaces/pr-1196/20260804-085131-s6b-presentation-tests.png)

## Review loop

Reflected on the diff, then a directed codex review (`gpt-5.6-sol`, xhigh) over seven named failure modes plus a falsifiable completeness question. Verdict: **a pure, identity-neutral extraction; no source-level blockers.** Its completeness table confirms all six replaced bindings equivalent on both get and set.

The question I most wanted answered was autoclosure capture — three factories take their source as an `@autoclosure` rather than a `Binding`, so a snapshot instead of a live read would make alerts fail to appear or fail to dismiss. Codex confirmed the autoclosure is invoked on every getter call, with the same capture shape as the original explicit closures, for both the `@ObservedObject` and `@State` sources. It also confirmed overload resolution is unambiguous by arity and labels, and that routing `consume`'s write through a projected member binding introduces no transaction or animation difference.

Two findings, both coverage:

1. **Low — autoclosure freshness wasn't regression-tested.** My tests all constructed from an already-set value and never mutated it, so an eager-snapshot implementation would have passed. Each now starts empty and asserts the binding sees a value that arrived *after* construction; mutation-confirmed. Also strengthened the item-sheet test, which asserted only that a non-nil write skips cancellation and not that it fails to take effect.
2. **Low — the call-site ordering isn't proven.** `consume`-before-act is tested on the helper, but nothing executes the two `ContentView` buttons, so a future regression calling `forceCloseTerminalTab` before consuming would pass this suite. Needs a hosted view; declined and recorded below.

Worth naming: **this is the third slice running where a mutation check passed and exposed a test that named a rule it didn't exercise** (slice 4's empty-id normalization, slice 5's shape-only snapshot assertion, and both of this slice's). The pattern is consistent — a test constructed from the already-correct end state can't distinguish the rule from its absence.

## Mergeability

- Surface: desktop — main window alert and sheet presentation (orphan cleanup, provider setup error/confirmation/progress, terminal close, unsaved-changes dialog)
- User-facing behavior changed: No. Extraction only; all six bindings verified equivalent on get and set, and the two confirming buttons keep their exact consume-then-act order.
- Non-happy paths considered: a `true` write to a live alert still leaves its item intact; a coordinator-backed alert still runs its own teardown rather than silently assigning nil; the progress sheet still cannot be dismissed by the user; a confirming action arriving after the state cleared still returns early instead of acting on nothing; and a second consume still finds nothing, which is what stops an answered alert re-presenting.
- Residual risk or follow-up: the helper tests use a plain `Box` rather than real SwiftUI state, so they cover closure mechanics only — installed `@State` location behavior, `@ObservedObject` invalidation, and SwiftUI's own dismissal writes are out of their reach, as is the consume-before-act ordering at the two `ContentView` call sites. Both need a hosted view. The final gated slice (6c plus 6a's deferred modifier relocation) remains, and with capture working again it is now unblocked.
