### PR TITLE
fix(tests): restore CI gate on WebNextServerServiceTests pending #1195

### DIFF
--- a/Tests/WorkspaceManagerTests/WebNextServerServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/WebNextServerServiceTests.swift
@@ -14,7 +14,12 @@ import Testing
 
 @testable import WorkspaceManagerCore
 
-@Suite("WebNextServerService")
+@Suite(
+    "WebNextServerService",
+    .disabled(
+        if: ProcessInfo.processInfo.environment["CI"] != nil,
+        "Spawn-heavy suite whose readiness budgets fail under hosted-runner load despite #1189's timing fixes (7 tests failed twice on PR #1194's run at any budget the child's 30s sleep allows). Runs locally. Load-adaptive rework tracked in #1195."
+    ))
 struct WebNextServerServiceTests {
     // MARK: - Fixture
 


### PR DESCRIPTION
Restores the suite-level `.disabled(if: CI)` gate on `WebNextServerServiceTests` that #1189 removed. Post-merge evidence: the suite passed three consecutive post-#1189 runs, then failed the same 7 tests twice in a row (original + rerun) on PR #1194's `build-and-test` (run 30891674244) with the 35s spawn-latency pattern — load-dependent, unrelated to #1194's diff. Load-adaptive rework tracked in #1195; the gate message names it.

Evidence: [failing run 30891674244](https://github.com/fairchild/workspaces/actions/runs/30891674244) (2× same-suite failure on unrelated diff); local `swift build --build-tests` green; `swift-format lint --strict` clean on the touched file.

## Mergeability
- **Surface**: CI test execution only — one `@Suite` trait in a test file; zero production code.
- **Behavior changed**: WebNextServerServiceTests no longer runs in CI (still runs locally); restores the exact #1176 state with an updated reason string pointing at #1195.
- **Non-happy paths**: none new — the gate is declarative; if the CI env var is absent the suite runs as before.
- **Residual risk**: web-next server-service regressions ride on local runs until #1195 lands; identical to the accepted #1176→#1189 interim posture.

Refs #1195.