### PR TITLE
docs(agents): encode binding-mutation-check testing lesson in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,7 @@ Tests use **Swift Testing** (`@Suite`, `@Test`, `#expect`), not XCTest. Test beh
 - Test observable behavior, not implementation details
 - Protect data contracts: Codable roundtrips, git porcelain format values
 - Use `defer { cleanup() }` for temp directories
+- For behavior-preserving refactors, verify tests bind by mutating the extracted logic and confirming failures; a surviving mutation means the test gets rewritten, not the check dropped.
 
 ## Two Web Apps
 


### PR DESCRIPTION
## Summary

- The #1160 decomposition arc (slices 1-6, PRs #1186-#1198) caught fake test coverage twice via one discipline: every extraction test suite ran a mutation check, and a mutation check that *passes* is a found defect in the test, not a pass — slice 4's initially-passing mutation exposed a test that claimed to cover empty-stored-id normalization while never exercising it; slice 5's exposed a shape-only snapshot assertion.
- Adds a fourth rule to AGENTS.md § Testing, in the existing voice of the three sibling rules: behavior-preserving refactors verify tests bind by mutating the extracted logic and confirming failures; a surviving mutation means the test gets rewritten, not the check dropped.

## Token budget

AGENTS.md § Startup Instruction Budget states a target of staying under ~4,500 tokens (cl100k_base) "unless the added guidance is more important than the recurring context cost." Measured with `tiktoken`:

- Before: 4500 tokens
- After: 4534 tokens (+34, +0.75%)

PR #1182, which established this budget, documents it explicitly as "a soft target (no CI gate)." This addition encodes a discipline that caught two real defects in the #1160 arc, which is the case the exception clause anticipates. No unrelated section was trimmed to force an exact fit, since this issue scopes the change to § Testing only — a docs-only, single-file, single-section diff.

Evidence (before/after token count + diff, rendered via qlmanage per the non-UI evidence lane):

![agents-mutation-rule-token-budget](https://evidence.cloudcompute.com/workspaces/pr-1200/20260804-201823-agents-mutation-rule-token-budget.png)

## Test plan

- [x] Docs-only change — no `swift test` / `pnpm test` required.
- [x] Token count measured with `tiktoken` (cl100k_base): 4500 → 4534.
- [x] § Testing re-read end to end after the edit for coherence with the other three rules.

## Mergeability

- Surface: docs (AGENTS.md / CLAUDE.md via symlink)
- User-facing behavior changed: No — no app, web, or CI behavior changes; this only adds one guidance rule to agent-facing repo documentation.
- Non-happy paths considered: n/a (docs-only, additive single bullet) — verified the token-budget arithmetic before/after rather than assuming, and confirmed the addition doesn't duplicate anything in the existing pattern table or rules list.
- Residual risk or follow-up: AGENTS.md now sits 34 tokens (0.75%) over its stated ~4,500-token soft target; no other change is proposed to offset it, per the budget section's own "unless more important" exception and PR #1182's characterization of the budget as a soft target.

Closes #1199

Made with [Orca](https://github.com/stablyai/orca) 🐋
