### PR TITLE
docs: reconcile triage-labels.md and mergeability-standard.md after label removal

### DIFF
--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -36,14 +36,14 @@ Not yet CI-enforced; it's the cheapest surface today. If drift shows up, a readi
 | Label | Meaning |
 | --- | --- |
 | `needs-triage` | Maintainer needs to evaluate the issue. |
-| `needs-info` | Waiting on the reporter for specific missing information. Prefer this over the generic GitHub `question` label. |
 | `task` | Planned work item. Combine with `agent` for agent pipeline work. |
 | `ready` | Ready for the owning lane to act. `agent` + `ready` means an agent may claim it. `human` + `ready` means a human may pick it up. |
 | `claimed` | Actively owned and in progress. For agent work, claim comments and assignees identify which agent owns it. |
 | `review` | A PR exists and is awaiting review. |
 | `mergeable` | Additive review signal: an agent reviewed and approved the linked PR; owner merge is now appropriate. |
 | `blocked` | Progress is blocked by a dependency that should be resolved before work continues. |
-| `wontfix` | Closed or closing as not planned. |
+
+`needs-info` and `wontfix` were deleted in the 2026-08-02 label hygiene sweep (#1159) as never-applied. Waiting on the reporter for missing information is no longer label-tracked — leave a comment and keep the issue in `needs-triage`. Closing as not planned uses GitHub's native "not planned" issue-close reason instead of a label.
 
 Exactly one of `ready`, `claimed`, and `review` should be present on an active `agent` + `task` issue. `mergeable` may stack with `review`.
 
@@ -86,10 +86,10 @@ These two labels keep the open backlog actionable without deleting history. They
 | Label in mattpocock/skills | Label in this repo | Meaning |
 | --- | --- | --- |
 | `needs-triage` | `needs-triage` | Maintainer needs to evaluate the issue. |
-| `needs-info` | `needs-info` | Waiting on the reporter for more information. |
+| `needs-info` | *(no label — comment on the issue)* | Waiting on the reporter for more information; not label-tracked since the 2026-08-02 sweep removed the unused `needs-info` label. |
 | `ready-for-agent` | `agent` + `ready` | Fully specified, approved, unblocked, and available for an AFK agent to claim. |
 | `ready-for-human` | `human` + `ready` | Ready for a human to implement, review, or operate. |
-| `wontfix` | `wontfix` | Will not be actioned. |
+| `wontfix` | *(no label — close as "not planned")* | Will not be actioned; use GitHub's native "not planned" issue-close reason since the 2026-08-02 sweep removed the unused `wontfix` label. |
 
 ## Dimension Labels
 

--- a/docs/development/agent-factory-v2-plan.md
+++ b/docs/development/agent-factory-v2-plan.md
@@ -56,7 +56,7 @@ Model capability was at most secondary: agents did what the pipeline permitted. 
 
 | Stage | Persona | Trigger | Does | Builds on |
 |---|---|---|---|---|
-| Triage | Peter | issue opened; feedback poll cron | understand/reproduce; route small+clear → `ready`, large/ambiguous → `spec`, unclear → `needs-info`, someday → `idea`; sanitize + dedup feedback | new |
+| Triage | Peter | issue opened; feedback poll cron | understand/reproduce; route small+clear → `ready`, large/ambiguous → `spec`, unclear → comment + leave in `needs-triage` (no dedicated label since the `needs-info` label was removed 2026-08-02), someday → `idea`; sanitize + dedup feedback | new |
 | Spec | Peter | `spec` applied | write `specs/<slug>/PRODUCT.md` + `TECH.md`; open spec-only PR | new; Warp's spec-skill shape |
 | Implement | April or Plat | `ready` applied | claim → branch → implement → evidence → PR (`Closes #N`) | evidence lane (`_evidence.yml`, `evidence.sh`) reused as-is |
 | Review | the counterpart | agent PR opened | review against mergeability standard; apply `mergeable` | the one organically working v1 behavior |

--- a/docs/development/mergeability-standard.md
+++ b/docs/development/mergeability-standard.md
@@ -16,7 +16,7 @@ Work is mergeable when it is correct, coherent with the product, reviewable, ver
 - Visual changes ship visual evidence: before/after screenshots (or after-only when the before state is gone or irrelevant) for any user-visible UI change, captured via the fixture lane, the capture-only handshake, or a VM lane. Narrative-only claims do not clear the gate; if capture is genuinely blocked, mark `blocked:evidence` with the reason.
 - State what changed, how it was verified, and what residual risk or follow-up remains.
 - If evidence is blocked, say so explicitly before merge and explain what approval or environment is needed.
-- Use machine-readable blocker labels when a PR is not merge-ready: `blocked:ci`, `blocked:secrets`, `blocked:evidence`, or `blocked:review`.
+- Use machine-readable blocker labels when a PR is not merge-ready: `blocked:ci`, `blocked:secrets`, or `blocked:evidence`. (`blocked:review` was deleted in the 2026-08-02 label hygiene sweep as unused; a PR needing revision after review simply stays on `review` until fixed — no separate blocker label covers that state.)
 
 ## Required PR Body Section
 


### PR DESCRIPTION
Reconciles `docs/agents/triage-labels.md` and `docs/development/mergeability-standard.md` (plus one more stale reference found in `docs/development/agent-factory-v2-plan.md`) against the current label set after the 2026-08-02 tracker-hygiene sweep (#1159) deleted `needs-info`, `wontfix`, and `blocked:review` as never-applied labels.

**Verified against `gh label list --repo fairchild/workspaces`** before writing — confirmed `needs-info`, `wontfix`, and `blocked:review` no longer exist, and confirmed `blocked:ci`/`blocked:secrets` are the generic `blocked:*` prefix convention recognized by `scripts/pr-readiness.py` (created on demand, same pattern as `blocked:evidence` in `_evidence.yml`) rather than pre-registered labels — so they stayed as-is.

**Changes:**
- `docs/agents/triage-labels.md`: dropped the `needs-info`/`wontfix` rows from the State Labels table, added a short note on what covers those states now (a plain comment + `needs-triage` for missing info; GitHub's native "not planned" close reason instead of `wontfix`), and updated the two corresponding rows in the Matt Pocock Triage Mapping table to show "no label" rather than a deleted one.
- `docs/development/mergeability-standard.md`: dropped `blocked:review` from the blocker-label line; noted that a PR needing revision after review just stays on `review` — no dedicated blocker label ever covered that state (it was deleted for being unused, not replaced).
- `docs/development/agent-factory-v2-plan.md`: found via a repo-wide sweep — the Triage stage's routing table referenced `needs-info` as a routing target; updated to describe the current no-label mechanism.

No replacement labels were invented — each removed label's state is described honestly as either now-uncovered-by-a-label or covered by an existing native GitHub mechanism.

Docs-only change; `codex-review-loop` skipped per repo convention.

## Evidence

Diff summary (rendered via `qlmanage`, uploaded per the headless-evidence pattern):

![docs-label-reconciliation-diff](https://evidence.cloudcompute.com/workspaces/pr-1201/20260804-202018-docs-label-reconciliation-diff.png)

`git diff --check` clean; no code paths touched.

## Mergeability

- Surface: docs — `docs/agents/triage-labels.md`, `docs/development/mergeability-standard.md`, `docs/development/agent-factory-v2-plan.md`
- User-facing behavior changed: No — prose-only reconciliation, no label/workflow/script changes
- Non-happy paths considered: n/a — docs-only; verified no remaining stale references to the three deleted labels survive outside the new explanatory prose (`rg` sweep of `docs/` post-edit)
- Residual risk or follow-up: None — `blocked:ci`/`blocked:secrets` are intentionally left as-is (valid `blocked:*`-convention names per `pr-readiness.py`, not yet needed/created, same pattern as `blocked:evidence`); the 55 unmerged stale branches flagged in #1159 remain a separate, un-actioned human call

Closes #1181

Made with [Orca](https://github.com/stablyai/orca) 🐋
