### PR TITLE
fix(factory): count successful reviews, not raw attempts, toward daily cap

### DIFF
--- a/.github/workflows/factory-review-execute.yml
+++ b/.github/workflows/factory-review-execute.yml
@@ -65,10 +65,11 @@ jobs:
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "force_review=$FORCE_REVIEW" >> "$GITHUB_OUTPUT"
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
-      - name: Enforce review daily cap
+      - name: Enforce review daily cap and runaway guard
         working-directory: source
         env:
           FACTORY_REVIEW_DAILY_CAP: ${{ vars.FACTORY_REVIEW_DAILY_CAP || '12' }}
+          FACTORY_REVIEW_RUNAWAY_CAP: ${{ vars.FACTORY_REVIEW_RUNAWAY_CAP || '' }}
           GH_TOKEN: ${{ github.token }}
         run: uv run --script scripts/factory-review.py --authorize
       - name: Admit counterpart review

--- a/scripts/factory-review.py
+++ b/scripts/factory-review.py
@@ -35,6 +35,11 @@ REVIEWER_BOTS = {
 }
 PLATFORM_PREFIXES = (".github/", "infra/")
 DEFAULT_DAILY_REVIEW_CAP = 12
+# The daily cap counts posted reviews; a crash loop (retries that never post a
+# review, see #1179) would otherwise run unbounded. This is a hard ceiling on
+# raw run attempts, independent of outcome.
+RUNAWAY_CAP_MULTIPLIER = 3
+REVIEW_JOB_NAMES = {"april", "plat"}
 CLOSING_REFERENCE_RE = re.compile(
     r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(?P<number>\d+)\b"
 )
@@ -98,6 +103,10 @@ class GitHubClient:
             if len(batch) < 100:
                 return runs
             page += 1
+
+    def workflow_run_jobs(self, run_id: int) -> list[dict[str, Any]]:
+        payload = dict(self.request(f"/repos/{self.repository}/actions/runs/{run_id}/jobs"))
+        return [dict(job) for job in payload.get("jobs") or []]
 
     def _paginated(self, path: str) -> list[dict[str, Any]]:
         items: list[dict[str, Any]] = []
@@ -181,11 +190,27 @@ def parse_daily_cap(value: str | None) -> int:
     return cap
 
 
-def count_daily_runs(
+def parse_runaway_cap(value: str | None, daily_cap: int) -> int:
+    raw = (value or "").strip()
+    if not raw:
+        return daily_cap * RUNAWAY_CAP_MULTIPLIER
+    try:
+        cap = int(raw)
+    except ValueError as error:
+        raise FactoryReviewError(
+            f"FACTORY_REVIEW_RUNAWAY_CAP must be a positive integer, got {raw!r}"
+        ) from error
+    if cap <= 0:
+        raise FactoryReviewError("FACTORY_REVIEW_RUNAWAY_CAP must be a positive integer")
+    return cap
+
+
+def count_daily_run_attempts(
     runs: list[dict[str, Any]],
     current_run_id: str,
     current_run_attempt: int = 1,
 ) -> int:
+    """Count raw execution attempts today, including retries and failures."""
     attempts_by_run = {
         str(run["id"]): max(1, int(run.get("run_attempt") or 1))
         for run in runs
@@ -199,23 +224,62 @@ def count_daily_runs(
     return sum(attempts_by_run.values())
 
 
+def review_was_posted(jobs: list[dict[str, Any]]) -> bool:
+    return any(
+        str(job.get("name") or "") in REVIEW_JOB_NAMES
+        and str(job.get("conclusion") or "").casefold() == "success"
+        for job in jobs
+        if isinstance(job, dict)
+    )
+
+
+def count_daily_successful_reviews(
+    runs: list[dict[str, Any]],
+    review_posted_by_run: dict[str, bool],
+) -> int:
+    """Count distinct runs today whose reviewer job actually posted a review."""
+    run_ids = {
+        str(run["id"])
+        for run in runs
+        if isinstance(run, dict) and run.get("id") is not None
+    }
+    return sum(1 for run_id in run_ids if review_posted_by_run.get(run_id, False))
+
+
 def authorize_execution(
     client: GitHubClient,
     daily_cap: int,
+    runaway_cap: int,
     current_run_id: str,
     current_run_attempt: int,
 ) -> None:
     day = datetime.now(UTC).date().isoformat()
-    daily_run_count = count_daily_runs(
-        client.workflow_runs_on("factory-review-execute.yml", day),
-        current_run_id,
-        current_run_attempt,
-    )
-    print(f"Factory review execution budget: {daily_run_count}/{daily_cap}")
-    if daily_run_count > daily_cap:
+    runs = client.workflow_runs_on("factory-review-execute.yml", day)
+
+    # A crash loop (#1179) never posts a review, so the budget check below
+    # never sees it -- this hard ceiling on raw attempts is what actually
+    # stops it from retrying forever.
+    raw_attempts = count_daily_run_attempts(runs, current_run_id, current_run_attempt)
+    print(f"Factory review raw attempt count: {raw_attempts}/{runaway_cap}")
+    if raw_attempts > runaway_cap:
+        raise FactoryReviewError(
+            f"daily runaway guard of {runaway_cap} run attempts is exceeded "
+            f"({raw_attempts} run attempts) -- possible crash loop"
+        )
+
+    review_posted_by_run = {
+        str(run["id"]): review_was_posted(client.workflow_run_jobs(run["id"]))
+        for run in runs
+        if isinstance(run, dict)
+        and run.get("id") is not None
+        and str(run.get("conclusion") or "").casefold() == "success"
+    }
+    successful_reviews = count_daily_successful_reviews(runs, review_posted_by_run)
+    print(f"Factory review execution budget: {successful_reviews}/{daily_cap}")
+    if successful_reviews >= daily_cap:
         raise FactoryReviewError(
             f"daily review cap of {daily_cap} is exceeded "
-            f"({daily_run_count} run attempts)"
+            f"({successful_reviews} successful reviews posted today)"
         )
 
 
@@ -282,9 +346,14 @@ def main() -> int:
         os.environ.get("GITHUB_API_URL", "https://api.github.com"),
     )
     if args.authorize:
+        daily_cap = parse_daily_cap(os.environ.get("FACTORY_REVIEW_DAILY_CAP"))
+        runaway_cap = parse_runaway_cap(
+            os.environ.get("FACTORY_REVIEW_RUNAWAY_CAP"), daily_cap
+        )
         authorize_execution(
             client,
-            parse_daily_cap(os.environ.get("FACTORY_REVIEW_DAILY_CAP")),
+            daily_cap,
+            runaway_cap,
             require_env("GITHUB_RUN_ID"),
             int(require_env("GITHUB_RUN_ATTEMPT")),
         )

--- a/scripts/factory-review.py
+++ b/scripts/factory-review.py
@@ -39,7 +39,15 @@ DEFAULT_DAILY_REVIEW_CAP = 12
 # review, see #1179) would otherwise run unbounded. This is a hard ceiling on
 # raw run attempts, independent of outcome.
 RUNAWAY_CAP_MULTIPLIER = 3
-REVIEW_JOB_NAMES = {"april", "plat"}
+# The step that actually posts a review, keyed by job name. Checking this
+# step's own conclusion (not the job's, and not the overall run's) is what
+# tells "a review was posted" apart from "the job trivially succeeded because
+# the review step was skipped" (already-reviewed dedup, head changed after
+# admission) or "an unrelated sibling job (e.g. telemetry) failed".
+REVIEW_STEP_NAME_BY_JOB = {
+    "april": "Run April counterpart review",
+    "plat": "Run Plat counterpart review",
+}
 CLOSING_REFERENCE_RE = re.compile(
     r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(?P<number>\d+)\b"
 )
@@ -225,25 +233,54 @@ def count_daily_run_attempts(
 
 
 def review_was_posted(jobs: list[dict[str, Any]]) -> bool:
-    return any(
-        str(job.get("name") or "") in REVIEW_JOB_NAMES
-        and str(job.get("conclusion") or "").casefold() == "success"
-        for job in jobs
-        if isinstance(job, dict)
-    )
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        expected_step = REVIEW_STEP_NAME_BY_JOB.get(str(job.get("name") or ""))
+        if expected_step is None:
+            continue
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            if (
+                str(step.get("name") or "") == expected_step
+                and str(step.get("conclusion") or "").casefold() == "success"
+            ):
+                return True
+    return False
 
 
-def count_daily_successful_reviews(
+def count_daily_review_budget(
     runs: list[dict[str, Any]],
     review_posted_by_run: dict[str, bool],
+    current_run_id: str,
 ) -> int:
-    """Count distinct runs today whose reviewer job actually posted a review."""
-    run_ids = {
-        str(run["id"])
+    """Count runs today that hold a claim on the review budget.
+
+    A posted review holds its claim permanently. A run still in progress
+    holds a provisional claim -- this is what stops a burst of concurrent
+    triggers (one per PR) from all being admitted before any of them
+    resolve, since none would yet show as a posted review. A run that
+    finishes without posting a review (skipped admission, or a crash)
+    releases its claim and drops out of the count -- this is what stops a
+    crash loop from permanently consuming budget it never spent.
+    """
+    runs_by_id = {
+        str(run["id"]): run
         for run in runs
         if isinstance(run, dict) and run.get("id") is not None
     }
-    return sum(1 for run_id in run_ids if review_posted_by_run.get(run_id, False))
+    run_ids = set(runs_by_id) | ({current_run_id} if current_run_id else set())
+
+    def holds_claim(run_id: str) -> bool:
+        if review_posted_by_run.get(run_id, False):
+            return True
+        if run_id == current_run_id:
+            return True
+        status = str((runs_by_id.get(run_id) or {}).get("status") or "")
+        return status != "completed"
+
+    return sum(1 for run_id in run_ids if holds_claim(run_id))
 
 
 def authorize_execution(
@@ -267,19 +304,20 @@ def authorize_execution(
             f"({raw_attempts} run attempts) -- possible crash loop"
         )
 
+    # Deliberately not filtered by the run's overall conclusion: an unrelated
+    # sibling job (e.g. telemetry) failing must not erase a review that the
+    # april/plat job actually posted.
     review_posted_by_run = {
         str(run["id"]): review_was_posted(client.workflow_run_jobs(run["id"]))
         for run in runs
-        if isinstance(run, dict)
-        and run.get("id") is not None
-        and str(run.get("conclusion") or "").casefold() == "success"
+        if isinstance(run, dict) and run.get("id") is not None
     }
-    successful_reviews = count_daily_successful_reviews(runs, review_posted_by_run)
-    print(f"Factory review execution budget: {successful_reviews}/{daily_cap}")
-    if successful_reviews >= daily_cap:
+    review_budget = count_daily_review_budget(runs, review_posted_by_run, current_run_id)
+    print(f"Factory review execution budget: {review_budget}/{daily_cap}")
+    if review_budget > daily_cap:
         raise FactoryReviewError(
             f"daily review cap of {daily_cap} is exceeded "
-            f"({successful_reviews} successful reviews posted today)"
+            f"({review_budget} posted or in-flight reviews today)"
         )
 
 

--- a/scripts/tests/test_factory_review.py
+++ b/scripts/tests/test_factory_review.py
@@ -148,26 +148,35 @@ class FactoryReviewTests(unittest.TestCase):
                 runs,
             )
 
-    def test_review_was_posted_requires_a_successful_reviewer_job(self) -> None:
+    def test_review_was_posted_requires_the_specific_review_step_to_succeed(self) -> None:
+        def job(name: str, step_name: str, step_conclusion: str, job_conclusion: str = "success"):
+            return {
+                "name": name,
+                "conclusion": job_conclusion,
+                "steps": [{"name": step_name, "conclusion": step_conclusion}],
+            }
+
         self.assertTrue(
             factory_review.review_was_posted(
-                [
-                    {"name": "admit", "conclusion": "success"},
-                    {"name": "april", "conclusion": "success"},
-                ]
+                [job("april", "Run April counterpart review", "success")]
             )
         )
         self.assertFalse(
             factory_review.review_was_posted(
-                [{"name": "admit", "conclusion": "success"}]
+                [job("april", "Run April counterpart review", "skipped")]
             ),
-            "admission alone is not a posted review",
+            "a job that trivially succeeded because the review step was skipped "
+            "(dedup, or head changed after admission) did not post a review",
         )
         self.assertFalse(
             factory_review.review_was_posted(
-                [{"name": "plat", "conclusion": "failure"}]
+                [job("plat", "Run Plat counterpart review", "failure", job_conclusion="failure")]
             ),
-            "a crashed reviewer job did not post a review",
+            "a crashed reviewer step did not post a review",
+        )
+        self.assertFalse(
+            factory_review.review_was_posted([{"name": "admit", "conclusion": "success", "steps": []}]),
+            "admission alone is not a posted review",
         )
 
     def test_daily_cap_counts_only_successful_reviews_not_failed_attempts(self) -> None:
@@ -178,9 +187,16 @@ class FactoryReviewTests(unittest.TestCase):
             {"id": 3, "run_attempt": 1, "status": "completed", "conclusion": "success"},
         ]
 
-        def jobs_for(run_id: int) -> list[dict[str, str]]:
+        def jobs_for(run_id: int) -> list[dict[str, object]]:
             posted = {1: True, 2: False, 3: True}
-            return [{"name": "april", "conclusion": "success" if posted[run_id] else "failure"}]
+            conclusion = "success" if posted[run_id] else "failure"
+            return [
+                {
+                    "name": "april",
+                    "conclusion": conclusion,
+                    "steps": [{"name": "Run April counterpart review", "conclusion": conclusion}],
+                }
+            ]
 
         client = mock.Mock()
         client.workflow_runs_on.return_value = runs
@@ -188,12 +204,66 @@ class FactoryReviewTests(unittest.TestCase):
 
         # Two reviews were posted (runs 1 and 3); run 2 failed after five
         # attempts and posted nothing, so it does not count toward the cap.
-        factory_review.authorize_execution(client, daily_cap=3, runaway_cap=30, current_run_id="4", current_run_attempt=1)
+        # The current attempt ("4") reserves the third and final slot.
+        factory_review.authorize_execution(
+            client, daily_cap=3, runaway_cap=30, current_run_id="4", current_run_attempt=1
+        )
 
-        with self.assertRaisesRegex(factory_review.FactoryReviewError, "2 successful reviews"):
+        with self.assertRaisesRegex(factory_review.FactoryReviewError, "daily review cap of 2"):
             factory_review.authorize_execution(
-                client, daily_cap=2, runaway_cap=30, current_run_id="4", current_run_attempt=1
+                client, daily_cap=2, runaway_cap=30, current_run_id="5", current_run_attempt=1
             )
+
+    def test_sibling_job_failure_does_not_erase_a_posted_review(self) -> None:
+        """A telemetry-job failure must not zero out a review the reviewer job posted.
+
+        The run's overall conclusion is 'failure' (telemetry failed), but the
+        april job's own review step succeeded -- that must still count.
+        """
+        runs = [{"id": 1, "run_attempt": 1, "status": "completed", "conclusion": "failure"}]
+        client = mock.Mock()
+        client.workflow_runs_on.return_value = runs
+        client.workflow_run_jobs.return_value = [
+            {
+                "name": "april",
+                "conclusion": "success",
+                "steps": [{"name": "Run April counterpart review", "conclusion": "success"}],
+            },
+            {"name": "telemetry", "conclusion": "failure", "steps": []},
+        ]
+
+        with self.assertRaisesRegex(factory_review.FactoryReviewError, "daily review cap of 1"):
+            factory_review.authorize_execution(
+                client, daily_cap=1, runaway_cap=30, current_run_id="2", current_run_attempt=1
+            )
+
+    def test_in_flight_runs_hold_a_provisional_claim_against_the_cap(self) -> None:
+        """Concurrent triggers across different PRs must not all bypass the cap.
+
+        None of them show as a posted review yet, so without a provisional
+        hold on still-running executions, a burst could admit far more than
+        `daily_cap` concurrent reviews before any of them resolve.
+        """
+        runs = [{"id": 10, "status": "in_progress", "conclusion": None}]
+        client = mock.Mock()
+        client.workflow_runs_on.return_value = runs
+        client.workflow_run_jobs.return_value = []
+
+        with self.assertRaisesRegex(factory_review.FactoryReviewError, "daily review cap of 1"):
+            factory_review.authorize_execution(
+                client, daily_cap=1, runaway_cap=30, current_run_id="20", current_run_attempt=1
+            )
+
+    def test_a_failed_run_releases_its_claim_once_concluded(self) -> None:
+        """A run that finishes without posting a review frees its reservation."""
+        runs = [{"id": 10, "status": "completed", "conclusion": "failure"}]
+        client = mock.Mock()
+        client.workflow_runs_on.return_value = runs
+        client.workflow_run_jobs.return_value = []
+
+        factory_review.authorize_execution(
+            client, daily_cap=1, runaway_cap=30, current_run_id="20", current_run_attempt=1
+        )
 
     def test_runaway_guard_trips_on_raw_attempts_even_with_no_successful_reviews(
         self,

--- a/scripts/tests/test_factory_review.py
+++ b/scripts/tests/test_factory_review.py
@@ -126,18 +126,14 @@ class FactoryReviewTests(unittest.TestCase):
         self.assertEqual(requested.action, "review")
         self.assertEqual(requested.reviewer, "april")
 
-    def test_daily_review_budget_counts_reruns_and_fails_closed(self) -> None:
+    def test_raw_attempt_count_includes_reruns_and_current_attempt(self) -> None:
         runs = [
             {"id": 100, "run_attempt": 2},
             {"id": 101, "run_attempt": 1},
         ]
-        self.assertEqual(factory_review.count_daily_runs(runs, "101"), 3)
-        self.assertEqual(factory_review.count_daily_runs(runs, "102", 3), 6)
+        self.assertEqual(factory_review.count_daily_run_attempts(runs, "101"), 3)
+        self.assertEqual(factory_review.count_daily_run_attempts(runs, "102", 3), 6)
 
-        client = mock.Mock()
-        client.workflow_runs_on.return_value = runs
-        with self.assertRaisesRegex(factory_review.FactoryReviewError, "4 run attempts"):
-            factory_review.authorize_execution(client, 3, "102", 1)
         with self.assertRaisesRegex(factory_review.FactoryReviewError, "positive integer"):
             factory_review.parse_daily_cap("0")
 
@@ -151,6 +147,74 @@ class FactoryReviewTests(unittest.TestCase):
                 api_client.workflow_runs_on("factory-review-execute.yml", "2026-07-14"),
                 runs,
             )
+
+    def test_review_was_posted_requires_a_successful_reviewer_job(self) -> None:
+        self.assertTrue(
+            factory_review.review_was_posted(
+                [
+                    {"name": "admit", "conclusion": "success"},
+                    {"name": "april", "conclusion": "success"},
+                ]
+            )
+        )
+        self.assertFalse(
+            factory_review.review_was_posted(
+                [{"name": "admit", "conclusion": "success"}]
+            ),
+            "admission alone is not a posted review",
+        )
+        self.assertFalse(
+            factory_review.review_was_posted(
+                [{"name": "plat", "conclusion": "failure"}]
+            ),
+            "a crashed reviewer job did not post a review",
+        )
+
+    def test_daily_cap_counts_only_successful_reviews_not_failed_attempts(self) -> None:
+        """Retries and crash-loop failures must not inflate the review budget."""
+        runs = [
+            {"id": 1, "run_attempt": 1, "status": "completed", "conclusion": "success"},
+            {"id": 2, "run_attempt": 5, "status": "completed", "conclusion": "failure"},
+            {"id": 3, "run_attempt": 1, "status": "completed", "conclusion": "success"},
+        ]
+
+        def jobs_for(run_id: int) -> list[dict[str, str]]:
+            posted = {1: True, 2: False, 3: True}
+            return [{"name": "april", "conclusion": "success" if posted[run_id] else "failure"}]
+
+        client = mock.Mock()
+        client.workflow_runs_on.return_value = runs
+        client.workflow_run_jobs.side_effect = lambda run_id: jobs_for(run_id)
+
+        # Two reviews were posted (runs 1 and 3); run 2 failed after five
+        # attempts and posted nothing, so it does not count toward the cap.
+        factory_review.authorize_execution(client, daily_cap=3, runaway_cap=30, current_run_id="4", current_run_attempt=1)
+
+        with self.assertRaisesRegex(factory_review.FactoryReviewError, "2 successful reviews"):
+            factory_review.authorize_execution(
+                client, daily_cap=2, runaway_cap=30, current_run_id="4", current_run_attempt=1
+            )
+
+    def test_runaway_guard_trips_on_raw_attempts_even_with_no_successful_reviews(
+        self,
+    ) -> None:
+        """A pure crash loop must still be stopped even though nothing succeeded."""
+        runs = [{"id": 1, "run_attempt": 40, "status": "completed", "conclusion": "failure"}]
+        client = mock.Mock()
+        client.workflow_runs_on.return_value = runs
+        client.workflow_run_jobs.return_value = [{"name": "april", "conclusion": "failure"}]
+
+        with self.assertRaisesRegex(factory_review.FactoryReviewError, "runaway guard"):
+            factory_review.authorize_execution(
+                client, daily_cap=12, runaway_cap=36, current_run_id="1", current_run_attempt=41
+            )
+
+    def test_runaway_cap_defaults_to_a_multiple_of_the_daily_cap(self) -> None:
+        self.assertEqual(factory_review.parse_runaway_cap(None, 12), 36)
+        self.assertEqual(factory_review.parse_runaway_cap("", 12), 36)
+        self.assertEqual(factory_review.parse_runaway_cap("100", 12), 100)
+        with self.assertRaisesRegex(factory_review.FactoryReviewError, "positive integer"):
+            factory_review.parse_runaway_cap("0", 12)
 
     def test_human_or_draft_pull_request_does_not_enter_review_lane(self) -> None:
         files = [{"filename": "Sources/Feature.swift"}]
@@ -187,6 +251,7 @@ class FactoryReviewTests(unittest.TestCase):
         self.assertIn("--expected-head", executor)
         self.assertIn("FACTORY_EXPECTED_PR_HEAD_SHA", executor)
         self.assertIn("FACTORY_REVIEW_DAILY_CAP", executor)
+        self.assertIn("FACTORY_REVIEW_RUNAWAY_CAP", executor)
         self.assertIn("factory-review.py --authorize", executor)
 
 


### PR DESCRIPTION
## Summary

- `FACTORY_REVIEW_DAILY_CAP` was counting every `factory-review-execute.yml` workflow-run attempt, including crashes and retries -- so a retry storm could exhaust the daily budget without posting any reviews. During the 2026-08-03 merge wave, cap 12 was exhausted at 20 attempts with far fewer reviews actually posted; it was raised 12→30→60 mid-wave, then restored to 12.
- The cap now counts what it's meant to bound: distinct runs whose reviewer job (`april`/`plat`) actually posted a review (the "Run April/Plat counterpart review" step concluding `success`), plus runs still in progress holding a provisional claim. A run that finishes without posting a review -- skipped admission or a crash -- releases its claim and drops out of the count.
- Since failed attempts no longer count against the daily budget, nothing would otherwise stop a crash loop (the reviewer runtime does crash -- #1179) from retrying forever. Added `FACTORY_REVIEW_RUNAWAY_CAP`, a hard ceiling on raw run attempts regardless of outcome, defaulting to 3x the daily cap.

### Design reasoning

**Two separate limits, two separate purposes.** The daily cap bounds review *spend* (each posted review costs a Claude API call); the runaway guard bounds *retry storms* independent of whether they ever succeed. Conflating them was the original bug -- a cap meant to bound spend was actually bounding attempts, so a crash loop starved the budget without spending anything.

**Why in-progress runs hold a provisional claim on the daily cap, not just posted reviews.** If the cap only counted permanently-posted reviews, a burst of concurrent triggers across different PRs (a merge wave, the exact scenario that motivated this issue) could all read the same "not yet at cap" snapshot and all be admitted, since none of them show as a posted review until they finish ~30 minutes later. The provisional claim closes most of that window: a still-running execution reserves a slot that a crash releases and a success converts to permanent. This is a best-effort narrowing of a pre-existing check-then-act race inherent to building a rate limiter on a read-only "list workflow runs" snapshot with no atomic counter -- it is not eliminated (see Residual risk).

## Mergeability

- Surface: infra / agent-runtime (Factory Review Executor workflow + its Python admission script)
- User-facing behavior changed: No end-user UI. Operationally: `FACTORY_REVIEW_DAILY_CAP` now blocks at exactly `daily_cap` posted-or-in-flight reviews per UTC day instead of `daily_cap` raw attempts (including failures); a new optional `FACTORY_REVIEW_RUNAWAY_CAP` (default 3x daily cap) hard-stops raw attempts regardless of outcome.
- Non-happy paths considered: crash-looping reviewer (#1179), concurrent triggers across different PRs racing the cap check, a sibling job (telemetry) failing without affecting the reviewer job's own outcome, a review step skipped by dedup/head-changed still trivially "succeeding" at the job level. See "Review loop" below for what's fixed vs. knowingly deferred.
- Residual risk or follow-up: (1) the cap/guard check lives only in the `admit` job, so GitHub's "re-run failed jobs" (as opposed to a full re-run) bypasses re-authorization -- pre-existing, unchanged by this PR. (2) The provisional in-flight claim narrows but does not eliminate the check-then-act race inherent to a non-atomic snapshot-based limiter. (3) A manually re-run already-succeeded run could lose its claim if the jobs API's latest-attempt view shows a later failure -- narrow, human-triggered, and loosens rather than starves the cap. (4) `scripts/factory-implement.py` has an analogous raw-attempt-counting `count_daily_runs` for `FACTORY_IMPLEMENT_DAILY_CAP` -- explicitly out of scope for #1178, flagged here for a possible follow-up issue.

## Review loop

Directed `codex exec -c model="gpt-5.6-sol" -c model_reasoning_effort="xhigh"` review against the initial commit + working-tree design. Findings and disposition:

1. **[Fixed] Reviewer-job success was neither necessary nor sufficient evidence a review posted.** A job trivially concludes `success` when its review step is *skipped* (already reviewed at this head SHA, or the head changed after admission) -- that was miscounted as a posted review. And gating the jobs-fetch on the run's *overall* conclusion meant an unrelated sibling job (telemetry) failing erased a review the reviewer job had genuinely posted. Fixed: `review_was_posted` now checks the specific "Run April/Plat counterpart review" *step's* own conclusion, and jobs are fetched for every run regardless of the run's overall conclusion.
2. **[Fixed] The concurrency race was open with no mitigation.** Codex is right that reading a snapshot and deciding locally is inherently non-atomic, but the initial version didn't even give in-flight runs a claim, so a burst of concurrent different-PR triggers could all pass while none showed as posted yet. Added the provisional in-flight claim described above -- it narrows the race window, it does not close it (see Residual risk).
3. **[Acknowledged, not fixed -- pre-existing, out of scope] Partial "re-run failed jobs" bypasses both the cap and the guard.** The cap/guard check lives only in the `admit` job; GitHub's "re-run failed jobs" reruns only the failed job (`april`/`plat`) and its dependents, not `admit`, so a human repeatedly clicking that button wouldn't re-trigger `--authorize`. This is identical under the old code (the check lived in the same place) -- not a regression from this fix. Fixing it means restructuring which job(s) gate execution, which is a materially different change from "fix the counting logic"; noted as a follow-up.
4. **[Acknowledged, not fixed -- narrow edge case] Multi-attempt runs are only visible via their latest attempt.** GitHub's jobs-list API defaults to the latest attempt of a run. If a run that already posted a review is later manually re-run (`Re-run all jobs`) and that attempt fails, the run's claim could be lost even though a review really was posted. This under-counts (loosens the cap slightly) rather than over-counts (starves it) -- the opposite, safer direction from the bug this issue fixes -- and requires a human to manually re-run an already-green execution, which is not part of any normal or crash-loop trigger path. Noted as a known limitation rather than fixed, to avoid a much larger change (per-attempt job history) for a low-likelihood, low-severity edge case.
5. **[Acknowledged, pre-existing] The daily boundary is UTC creation-time, not review-completion-time.** Unchanged from the original implementation; not something this fix touches.

Full transcript: `/tmp/codex_review_1178.log` (local to the authoring session).

## Validation

- [x] `uv run --script scripts/tests/test_factory_review.py` -- 15/15 passing (was 8/8 before this change; added coverage for cap-respected, failed-attempts-don't-count, sibling-job-failure, in-flight-provisional-claim, and runaway-guard cases)
- [x] Full `scripts/tests/` suite (all files, matching the CI loop in `.github/workflows/ci-agents.yml`) -- all passing
- [x] Other checks run: none needed (no Swift/web surface touched)

## Evidence

- [x] Test evidence attached (test output)
- [ ] Not a testable change
- [ ] UI evidence attached

Evidence links:

- [factory-review-cap-tests](https://evidence.cloudcompute.com/workspaces/pr-1202/20260804-204251-factory-review-cap-tests.png) -- rendered output of `uv run --script scripts/tests/test_factory_review.py` (15/15) and the full `scripts/tests/` suite (all passing)

## Blockers

- [x] None

Closes #1178
