### PR TITLE
fix(factory): guard evidence-verify writes against body drift, not just SHA drift

### DIFF
--- a/scripts/factory-evidence-verify.py
+++ b/scripts/factory-evidence-verify.py
@@ -40,6 +40,7 @@ FACTORY_PR_MARKER = "<!-- contributor:issue="
 BLOCKED_EVIDENCE_LABEL = "blocked:evidence"
 GH_TIMEOUT = 60
 VALID_STATUSES = {"complete", "blocked", "pending-ci"}
+MAX_WRITE_ATTEMPTS = 3
 
 # Identities whose label application counts as machine-applied. Derived from
 # the contributor identity table so reviewer-only apps never qualify.
@@ -225,6 +226,89 @@ def _write_pr_body(pr_number: int, body: str, env: dict[str, str]) -> bool:
             pass
 
 
+def _updates_targeting_unchanged_entries(
+    body: str,
+    updates: dict[int, dict[str, object]],
+) -> dict[int, dict[str, object]]:
+    """Drop updates whose target index no longer names the check they were
+    computed for — e.g. an owner retargeted that evidence line during a
+    retry. `updates` is keyed by index and blind to entry content, so this
+    is what keeps a stale CI result from landing on an unrelated entry."""
+    entries = evidence_entries(body)
+    if entries is None:
+        return {}
+    current_check_names: dict[int, str | None] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            index = int(entry["index"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        current_check_names[index] = _ci_check_name(str(entry.get("item", "")).strip())
+    return {
+        index: update
+        for index, update in updates.items()
+        if current_check_names.get(index) == update.get("check_name")
+    }
+
+
+def _apply_ci_updates(
+    pr_number: int,
+    head_sha: str,
+    body: str,
+    updates: dict[int, dict[str, object]],
+    env: dict[str, str],
+) -> str | None:
+    """Write `updates` onto the PR body, guarded against concurrent edits.
+
+    Re-reads the PR immediately before writing. A moved head SHA means the
+    PR advanced past what `updates` was computed against, so the write is
+    skipped outright (next check_suite event self-heals). A body that no
+    longer matches what was read at the top of `process_pr` — same SHA, but
+    an owner edited the description in the UI in between — means writing
+    `updates` now would clobber that edit; instead, re-apply `updates` to
+    the freshly-read body and re-check, up to MAX_WRITE_ATTEMPTS times.
+    Before each reapply, updates are narrowed to entries still naming the
+    check they were computed for (see `_updates_targeting_unchanged_entries`),
+    so a mid-flight edit to the evidence block itself can drop a stale
+    result rather than misapply it. This does not close the write itself
+    against a same-instant edit — `gh pr edit` has no conditional-write
+    primitive — it narrows that window to the gap between the final
+    match check and the write call. Returns the body now live on the PR
+    (written, or already up to date), or None if the caller should stop
+    without further evidence-state changes.
+    """
+    for attempt in range(1, MAX_WRITE_ATTEMPTS + 1):
+        safe_updates = _updates_targeting_unchanged_entries(body, updates)
+        if not safe_updates:
+            return body
+        new_body = update_evidence_entries(body, safe_updates)
+        if new_body == body:
+            return body
+        current = _gh_json(["api", f"repos/{{owner}}/{{repo}}/pulls/{pr_number}"], env)
+        current_head = current.get("head") if isinstance(current, dict) else None
+        current_sha = str(current_head.get("sha", "")) if isinstance(current_head, dict) else ""
+        if current_sha != head_sha:
+            log(f"PR #{pr_number} advanced during verification; skipping write")
+            return None
+        current_body = str(current.get("body") or "") if isinstance(current, dict) else ""
+        if current_body != body:
+            log(
+                f"PR #{pr_number} body changed during verification "
+                f"(attempt {attempt}/{MAX_WRITE_ATTEMPTS}); re-applying evidence updates"
+            )
+            body = current_body
+            continue
+        if not _write_pr_body(pr_number, new_body, env):
+            log(f"PR #{pr_number} body update failed")
+            return None
+        log(f"PR #{pr_number}: updated {len(safe_updates)} ci evidence entries")
+        return new_body
+    log(f"PR #{pr_number} body kept changing during verification; giving up without writing")
+    return None
+
+
 def process_pr(pr_number: int, env: dict[str, str]) -> None:
     pr = _gh_json(["api", f"repos/{{owner}}/{{repo}}/pulls/{pr_number}"], env)
     if not isinstance(pr, dict) or pr.get("state") != "open":
@@ -246,19 +330,10 @@ def process_pr(pr_number: int, env: dict[str, str]) -> None:
         for index, check_name in needed:
             run = latest_completed_check_run(check_name, head_sha, env)
             updates[index] = entry_update_for_check_run(check_name, head_sha, run)
-        new_body = update_evidence_entries(body, updates)
-        if new_body != body:
-            current = _gh_json(["api", f"repos/{{owner}}/{{repo}}/pulls/{pr_number}"], env)
-            current_head = current.get("head") if isinstance(current, dict) else None
-            current_sha = str(current_head.get("sha", "")) if isinstance(current_head, dict) else ""
-            if current_sha != head_sha:
-                log(f"PR #{pr_number} advanced during verification; skipping write")
-                return
-            if not _write_pr_body(pr_number, new_body, env):
-                log(f"PR #{pr_number} body update failed")
-                return
-            log(f"PR #{pr_number}: updated {len(updates)} ci evidence entries")
-            body = new_body
+        updated_body = _apply_ci_updates(pr_number, head_sha, body, updates, env)
+        if updated_body is None:
+            return
+        body = updated_body
 
     label_names = {
         str(label.get("name", ""))

--- a/scripts/tests/test_factory_evidence_verify.py
+++ b/scripts/tests/test_factory_evidence_verify.py
@@ -75,6 +75,11 @@ def body_with_entries(entries: list[dict[str, object]]) -> str:
     )
 
 
+def with_owner_edit(body: str, note: str) -> str:
+    """Simulate an owner editing the PR description (not the evidence block)."""
+    return body.replace("## Summary\n- change", f"## Summary\n- change\n- {note}")
+
+
 def pr_payload(
     body: str,
     *,
@@ -283,6 +288,153 @@ class ProcessPrTests(unittest.TestCase):
             verify.process_pr(321, {})
 
         gh.assert_not_called()
+
+
+class BodyChangeRaceGuardTests(unittest.TestCase):
+    """Coverage for #1183: a body edit at a stable head SHA must never be
+    clobbered by a write derived from the stale pre-edit body."""
+
+    maxDiff = None
+
+    def test_stable_sha_body_change_does_not_write_stale_derived_body(self) -> None:
+        body = body_with_entries([ci_entry()])
+        edited_body = with_owner_edit(body, "owner edited the description mid-flight")
+        updates = {
+            1: verify.entry_update_for_check_run(
+                "Web CI",
+                HEAD,
+                {"conclusion": "success", "html_url": "https://example.invalid/run/1"},
+            )
+        }
+        stale_new_body = verify.update_evidence_entries(body, updates)
+
+        written: dict[str, str] = {}
+
+        def fake_write(pr_number, new_body, env):
+            written["body"] = new_body
+            return True
+
+        with (
+            mock.patch.object(
+                verify,
+                "_gh_json",
+                # attempt 1: same SHA, drifted body; attempt 2: stable now
+                side_effect=[
+                    pr_payload(edited_body, head_sha=HEAD),
+                    pr_payload(edited_body, head_sha=HEAD),
+                ],
+            ) as gh_json,
+            mock.patch.object(verify, "_write_pr_body", side_effect=fake_write) as write,
+        ):
+            result = verify._apply_ci_updates(321, HEAD, body, updates, {})
+
+        # Both mocked re-fetches must actually have been consumed — otherwise
+        # this test would pass even if the retry loop short-circuited after
+        # detecting the first drift instead of re-checking the reapplied body.
+        self.assertEqual(gh_json.call_count, 2)
+        write.assert_called_once()
+        self.assertEqual(result, written["body"])
+        self.assertNotEqual(written["body"], stale_new_body)
+        self.assertIn("owner edited the description mid-flight", written["body"])
+        self.assertIn(f"- [complete] {CI_ITEM}", written["body"])
+
+    def test_race_then_reapply_succeeds_and_completes_verification(self) -> None:
+        body = body_with_entries([ci_entry()])
+        edited_body = with_owner_edit(body, "clarify rollout plan")
+        pr_initial = pr_payload(body, labels=["blocked:evidence"])
+        pr_drifted = pr_payload(edited_body, labels=["blocked:evidence"])
+
+        written: dict[str, str] = {}
+        gh_calls: list[list[str]] = []
+
+        def fake_write(pr_number, new_body, env):
+            written["body"] = new_body
+            return True
+
+        with (
+            mock.patch.object(
+                verify, "_gh_json", side_effect=[pr_initial, pr_drifted, pr_drifted]
+            ) as gh_json,
+            mock.patch.object(
+                verify,
+                "latest_completed_check_run",
+                return_value={"conclusion": "success", "html_url": "https://example.invalid/run/1"},
+            ),
+            mock.patch.object(verify, "_write_pr_body", side_effect=fake_write),
+            mock.patch.object(verify, "blocked_label_applied_by_factory", return_value=True),
+            mock.patch.object(verify, "_gh", side_effect=lambda args, env: gh_calls.append(args) or True),
+        ):
+            verify.process_pr(321, {})
+
+        self.assertEqual(gh_json.call_count, 3)
+        self.assertIn("clarify rollout plan", written["body"])
+        self.assertIn(f"- [complete] {CI_ITEM}", written["body"])
+        self.assertIn(
+            ["pr", "edit", "321", "--remove-label", "blocked:evidence"],
+            gh_calls,
+        )
+
+    def test_gives_up_without_writing_when_body_keeps_changing(self) -> None:
+        body = body_with_entries([ci_entry()])
+        drifting_bodies = [
+            with_owner_edit(body, f"edit #{i}") for i in range(1, verify.MAX_WRITE_ATTEMPTS + 1)
+        ]
+        gh_responses = [pr_payload(body, labels=["blocked:evidence"])] + [
+            pr_payload(b, labels=["blocked:evidence"]) for b in drifting_bodies
+        ]
+
+        with (
+            mock.patch.object(verify, "_gh_json", side_effect=gh_responses) as gh_json,
+            mock.patch.object(
+                verify,
+                "latest_completed_check_run",
+                return_value={"conclusion": "success", "html_url": "https://example.invalid/run/1"},
+            ),
+            mock.patch.object(verify, "_write_pr_body") as write,
+            mock.patch.object(verify, "_gh") as gh,
+            mock.patch.object(verify, "log") as log_mock,
+        ):
+            verify.process_pr(321, {})
+
+        # Bounded: exactly one initial fetch plus MAX_WRITE_ATTEMPTS retries —
+        # a fourth call would raise StopIteration and fail this test, proving
+        # the loop can't spin past the documented bound.
+        self.assertEqual(gh_json.call_count, 1 + verify.MAX_WRITE_ATTEMPTS)
+        write.assert_not_called()
+        gh.assert_not_called()
+        self.assertTrue(
+            any("giving up" in call.args[0] for call in log_mock.call_args_list)
+        )
+
+    def test_retargeted_entry_is_dropped_instead_of_misapplied(self) -> None:
+        """If an owner retargets the evidence line itself (not just prose) to
+        a different check between read and write, the stale-index update
+        must be dropped, never slapped onto the now-different entry."""
+        body = body_with_entries([ci_entry()])
+        retargeted_entry = ci_entry(status="pending-ci")
+        retargeted_entry["item"] = "CI: `macOS CI` green on the PR head"
+        retargeted_body = body_with_entries([retargeted_entry])
+        updates = {
+            1: verify.entry_update_for_check_run(
+                "Web CI",
+                HEAD,
+                {"conclusion": "success", "html_url": "https://example.invalid/run/1"},
+            )
+        }
+
+        with (
+            mock.patch.object(
+                verify, "_gh_json", side_effect=[pr_payload(retargeted_body, head_sha=HEAD)]
+            ) as gh_json,
+            mock.patch.object(verify, "_write_pr_body") as write,
+        ):
+            result = verify._apply_ci_updates(321, HEAD, body, updates, {})
+
+        self.assertEqual(gh_json.call_count, 1)
+        write.assert_not_called()
+        self.assertEqual(result, retargeted_body)
+        self.assertNotIn("Web CI", result)
+        self.assertIn("[pending-ci] CI: `macOS CI` green on the PR head", result)
 
 
 class WorkflowContractTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

`scripts/factory-evidence-verify.py`'s `process_pr` only re-checked the PR head SHA immediately before writing an updated body — not whether the body itself had changed. Concrete failure: an owner edits the PR description in the GitHub UI (no new commit, so the SHA doesn't move) between the script's initial read and its write; the old SHA-only guard saw a stable SHA and wrote a body derived from its stale initial read, silently discarding the owner's edit.

The pre-write guard now re-fetches the PR right before writing and compares the **body**, not just the SHA, against what the pending write was computed from:

- SHA moved → skip outright (unchanged: next `check_suite` event self-heals).
- SHA stable, body drifted → re-apply the CI-evidence `updates` to the freshly-read body and re-check, bounded by `MAX_WRITE_ATTEMPTS` (3). Never writes the stale-derived body.
- Drift never stabilizes → give up loudly (log + no write), rather than clobber.
- Reapplication is additionally guarded per-index: if the evidence block itself was retargeted mid-flight (an index now names a different check than the one the fetched result was computed for), that index's stale result is dropped instead of misapplied to the wrong entry (found during the directed codex pass below).

Behavior for the no-race and SHA-moved paths is unchanged — this is a strict extension of the existing guard, not a rewrite.

## Testing

`uv run --script scripts/tests/test_factory_evidence_verify.py` — 16/16 passing (3 new + 1 hardening test in `BodyChangeRaceGuardTests`, covering: stable-SHA body-change race that must not clobber, race-then-reapply success, the give-up path, and the retargeted-entry edge case). Full `scripts/tests/*.py` suite (28 files) also green locally.

Evidence: [test-results](https://evidence.cloudcompute.com/workspaces/pr-1207/20260805-073305-test-results.png)

## Review loop

Ran `codex-review-loop` (gpt-5.6-sol, xhigh) directed at the race-closure claim, bounded-retry correctness, fail-closed behavior on API failure, and test-mock fidelity.

- **Medium — index-only reapplication could misapply a stale CI result to a retargeted evidence entry.** Confirmed real, not a new regression (old code clobbered the *entire* body in this case, which is worse) but an incomplete fix of the pre-existing race. **Fixed**: reapplication now drops any update whose target index no longer names the check it was computed for (`_updates_targeting_unchanged_entries`), with a regression test.
- **Low — final GET→write gap is still non-atomic** (`gh pr edit --body-file` has no conditional-write primitive). Confirmed pre-existing, correctly scoped given the "simplest correct mechanism" directive in #1183 — not chasing ETag/GraphQL cleverness for one narrow gap. Called out explicitly below as residual risk; docstring wording softened to not overstate the guarantee.
- **Low — stale label snapshot**: `process_pr`'s label-clearing branch reads `label_names` from the PR object fetched at the *top* of `process_pr`, not the final re-fetched state. Confirmed pre-existing via `git blame` (predates this diff, from the original #1136/#1137 design) and out of scope for #1183; noted here for a possible separate low-priority issue.
- **Low — test coverage gap**: original three tests didn't assert on `_gh_json` call counts, so a short-circuit bug could pass silently. **Fixed**: all race-guard tests now assert exact call counts against the mocked response list.

## Mergeability

- **Surface**: `scripts/factory-evidence-verify.py` (trusted-lane factory automation script, live since #1149/#1185 via `FACTORY_EVIDENCE_VERIFY_ENABLED=true`) and its test coverage in `scripts/tests/test_factory_evidence_verify.py`. No app/web UI surface.
- **Behavior changed**: the pre-write guard in `process_pr` (now factored into `_apply_ci_updates`) additionally compares body content, not just head SHA, before writing evidence-status updates; retries up to 3 times against a freshly re-read body before giving up. No-race and SHA-moved paths are behavior-identical to `main`.
- **Non-happy paths**: SHA moves mid-flight (skip, unchanged); body drifts and never stabilizes (give up, no write, loud log); body drifts and then stabilizes (reapply, write succeeds); a re-fetch inside the guard fails (`gh api` error) — treated as SHA-advanced, fail-closed skip, matching pre-existing behavior; an evidence-block index gets retargeted mid-flight (that index's stale result is dropped, not misapplied).
- **Residual risk**: the guard narrows but does not fully close the write race — an edit landing in the exact gap between the final body-match check and the `gh pr edit` call is still possible, since the GitHub CLI has no conditional-write primitive for PR bodies. This is judged acceptable per the issue's own guidance to prefer the simplest correct mechanism over ETag/GraphQL cleverness; the retry loop reduces the vulnerable window from "entire verification pass" to "one API round-trip," which is the practically-achievable bound without a bigger mechanism change.

Closes #1183

Made with [Orca](https://github.com/stablyai/orca) 🐋
