### PR TITLE
fix(factory): deliver the model task via stdin, not argv (ARG_MAX)

### DIFF
--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -845,9 +845,13 @@ def run_claude(
             cmd.extend(["--tools", tools, "--allowedTools", scoped_tool_rules(tools, write_scope)])
         cmd.extend(["--max-budget-usd", budget])
         effective_timeout = timeout or 1200
-    cmd.append(task)
+    # The task embeds PR diffs and bodies, which on large PRs exceeds the OS
+    # ARG_MAX for a single argv element (observed: OSError "Argument list too
+    # long: 'npx'" on #1203's review runs). --print mode reads the prompt from
+    # stdin when no positional prompt is given, so deliver it there instead.
     raw_output = run_checked(
         cmd,
+        input=task,
         timeout=effective_timeout,
         cwd=cwd or REPO_ROOT,
         env=env,

--- a/scripts/tests/test_run_contributor.py
+++ b/scripts/tests/test_run_contributor.py
@@ -349,6 +349,26 @@ class RunContributorEvidenceTests(unittest.TestCase):
         self.assertEqual(run_checked.call_args.kwargs["cwd"], Path("/tmp/model-workspace"))
         self.assertFalse(trust_file_written)
 
+    def test_task_travels_via_stdin_not_argv(self) -> None:
+        # Diff-carrying tasks on large PRs exceeded ARG_MAX as an argv element
+        # (OSError "Argument list too long: npx" on #1203's review runs); the
+        # prompt must ride stdin, which --print reads when no positional
+        # prompt is given.
+        with mock.patch.object(
+            run_contributor,
+            "run_checked",
+            return_value=mock.Mock(stdout="ok"),
+        ) as run_checked:
+            run_contributor.run_claude(
+                "system",
+                "big task payload",
+                {"PATH": "/usr/bin"},
+                mode="cli",
+            )
+        command = run_checked.call_args.args[0]
+        self.assertNotIn("big task payload", command)
+        self.assertEqual(run_checked.call_args.kwargs["input"], "big task payload")
+
     def test_cli_mode_pre_approves_every_exposed_tool(self) -> None:
         with mock.patch.object(
             run_contributor,


### PR DESCRIPTION
Root cause of #1179's content-heavy review crashes, finally caught in a clean traceback on #1203's verdict runs: `OSError: [Errno 7] Argument list too long: 'npx'` — the diff-carrying `task` string rode argv, so any PR whose content pushes the command line past ARG_MAX fails deterministically (and reruns cannot help, which is why #1203's broke the rerun-always-works pattern). Fix: drop the positional prompt and deliver `task` via stdin (`run_checked` already supports `input=`; `--print` reads stdin when no positional prompt is given). The `--system-prompt` argv element remains — it is template-bounded, not content-carrying.

Evidence: `uv run --script scripts/tests/test_run_contributor.py` — 96 tests green including the new `test_task_travels_via_stdin_not_argv` regression (asserts the task is absent from argv and present as stdin input). [Failing run with the traceback](https://github.com/fairchild/workspaces/actions/runs/31072282017).

- [x] Not a testable change beyond unit level without a >ARG_MAX live PR; the failing-run link is the field evidence.

## Mergeability
- **Surface**: factory review/implement runtime only — one invocation change in run-contributor.py plus its regression test; no workflows, no app code.
- **Behavior changed**: the model prompt arrives via stdin instead of a positional argv element; identical content, no size ceiling.
- **Non-happy paths**: stdin delivery is unaffected by timeout/failure handling (run_checked's input= path already used elsewhere); an empty task now yields an empty stdin rather than an empty argv arg — same model-visible result.
- **Residual risk**: if a future claude CLI version changed stdin semantics under --print, reviews would fail loudly at the next run; the regression test pins our side of the contract.

Unblocks #1203's pending verdict re-reviews (they run this script from main). Refs #1179.