### PR TITLE
feat(factory): require one approving review on main-merge

### DIFF
--- a/config/github/rulesets/main-merge.json
+++ b/config/github/rulesets/main-merge.json
@@ -30,7 +30,7 @@
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": false,
         "require_last_push_approval": false,
-        "required_approving_review_count": 0,
+        "required_approving_review_count": 1,
         "required_review_thread_resolution": true,
         "required_reviewers": []
       },


### PR DESCRIPTION
Flips `required_approving_review_count` 0 → 1 in `config/github/rulesets/main-merge.json` — the #1206 follow-through now that its sequencing gates are satisfied: worker-identity is live (#1203/#1210 merged; owner approval counts on bot-authored PRs, April/Plat approve as Apps), and the reviewer runtime's deterministic ARG_MAX crash is fixed (#1212) with retry-once for transients (#1209). Zero open PRs at flip time, so nothing gets stranded mid-flight.

After merge, the live ruleset gets applied via `uv run --script scripts/github-settings.py apply` and verified with `check` (the config-as-code contract in that script's doc block); I'll run both and post the check output here.

- [x] Not a testable change (docs-only, config)

## Mergeability
- **Surface**: config-as-code for the main-merge ruleset; no code paths.
- **Behavior changed**: once applied, merging to main requires ≥1 formal approving review — previously approvals were possible but optional. `dismiss_stale_reviews_on_push: true` stays, so every push needs a fresh approval; the factory re-review flow covers that.
- **Non-happy paths**: a PR whose reviewer runs all crash would be unmergeable until a rerun/fresh run succeeds or a human approves — mitigated by #1209/#1212, and the owner can always approve bot-authored PRs now.
- **Residual risk**: emergency merges need a real approval or a ruleset bypass by the owner; that friction is the point of the change.

Closes #1206.
