### PR TITLE
docs(cd): record Vercel Git disconnect boundary

### DIFF
--- a/.github/workflows/web-next-preview.yml
+++ b/.github/workflows/web-next-preview.yml
@@ -1,8 +1,8 @@
 name: Web Next Preview
 
-# Opt-in Vercel preview for web-next. Vercel's native Git deployments are
-# disabled for this project (web-next/vercel.json git.deploymentEnabled=false),
-# so previews are created only here — and only when a PR that touches web-next/**
+# Opt-in Vercel preview for web-next. The Vercel project's Git provider is
+# disconnected; web-next/vercel.json also sets git.deploymentEnabled=false as
+# defense in depth. Previews are created only here — and only when a PR touches web-next/**
 # (or this workflow) carries the `preview` label. Label the PR to deploy; remove
 # it to stop redeploying on subsequent pushes. `unlabeled` is in the trigger list
 # so removing the label enters this PR's concurrency group and cancels an

--- a/scripts/cd/README.md
+++ b/scripts/cd/README.md
@@ -23,7 +23,7 @@ After: every push to `main` produces a preview deployment, gets validated agains
 
 **Rolling failure issues, not per-failure issues.** One issue per validator (`CD: playwright failures on main`, `CD: lighthouse failures on main`), identified by hidden HTML markers. New failures append a comment; the issue auto-reopens if closed. Production validation uses one open `cd-failure:prod` issue for the prod surface, and the next green prod validation comments on and closes open auto-opened prod failure issues. Avoids issue-tracker flooding during a regression burst.
 
-**Configuration as code.** The Vercel Git auto-deploy guard lives in each project's `vercel.json` (`git.deploymentEnabled = false`) — `web/vercel.json` for `spaces-web`, `web-next/vercel.json` for `web-next` — not in dashboard settings. Vercel stays connected for metadata, while GitHub Actions owns PR previews and production promotion.
+**Actions-owned Vercel deployments.** The Git provider is disconnected from both Vercel projects, so GitHub Actions exclusively owns PR previews and production promotion. Each project's `vercel.json` also keeps `git.deploymentEnabled = false` — `web/vercel.json` for `spaces-web`, `web-next/vercel.json` for `web-next` — as defense in depth if a project is ever reconnected. The project-level disconnect is required because Vercel resolves the configured Root Directory before it can read a nested `vercel.json`; a branch without `web/` or `web-next/` would otherwise fail before reaching the guard.
 
 **Targeted PR previews (spaces-web).** `.github/workflows/web-preview.yml` deploys Vercel previews only for PRs that touch `web/**`. Non-web PRs do not create Vercel deployments or preview comments.
 
@@ -80,7 +80,7 @@ After: every push to `main` produces a preview deployment, gets validated agains
 | `scripts/cd/bootstrap-preview.py` | Interactive setup wizard for first-time configuration. Prompts for tokens, writes secrets to GitHub + Cloudflare, generates `web/vercel.json`. |
 | `scripts/cd/config.toml` | Declarative manifest. Workers, preview health URLs, secret names, GitHub Actions secrets. **Add a worker = one TOML block.** |
 | `scripts/cd/.env.bootstrap.example` | Template for the gitignored `.env.bootstrap` where the operator's tokens live locally. |
-| `web/vercel.json` | Generated. Contains `git.deploymentEnabled = false` — disables Vercel's automatic Git deployments so Actions owns PR previews and production promotion. |
+| `web/vercel.json` | Generated defense-in-depth guard. Contains `git.deploymentEnabled = false`; the project-level Git disconnect is the primary auto-deploy control. |
 | `web/playwright.config.ts` | Honors `PLAYWRIGHT_BASE_URL` to target deployed URLs; `deployment-smoke` is the remote-safe preview/prod project. |
 | `web/lighthouserc.json` | Perf budgets: LCP ≤2500ms, CLS ≤0.1, TBT ≤200ms, perf score ≥0.9. Desktop preset, 3 runs, median assertions. URL passed at invocation via `--collect.url`. |
 | `web/scripts/{playwright,lhci}-findings.mjs` | Render validator JSON output into markdown tables for the failure-issue body. |
@@ -145,6 +145,6 @@ What still requires you (no API exists for these):
 - **Why monolithic `cd.yml` not split workflows.** Promote needs `needs:` semantics across web + workers. Splitting loses the "all validators must pass before any promote" atomicity.
 - **Why `deployment-smoke` Playwright project only.** `full` and parts of `fast` need seeded DB state; deployed preview/prod validation must use only tests that are meaningful against the real serverless app.
 - **Why separate R2 bucket for evidence-store preview.** Preview test writes would otherwise pollute the prod keyspace and share the prod auth token's blast radius. 7-day lifecycle on `evidence-screenshots-preview` keeps storage cost ~$0.
-- **Why `vercel.json` over dashboard branch flip.** Code-controlled, survives project recreation, visible in diffs. Vercel's deprecated `github.enabled` is the legacy form; `git.deploymentEnabled` is current.
+- **Why disconnect Git and keep `vercel.json`.** Disconnecting the provider prevents Vercel from creating a deployment before it discovers that a branch lacks the configured Root Directory. The checked-in `git.deploymentEnabled = false` guard is still useful defense in depth if a project is reconnected; Vercel's deprecated `github.enabled` is the legacy form.
 - **Why Actions-owned PR previews.** Vercel's ignored-build path still creates canceled deployments; the path-filtered workflow avoids deployments entirely for non-web PRs.
 - **Why pinned tool versions (`vercel@51`, `wrangler@4`, `@lhci/cli@0.14.x`).** CLI behavior changes silently break CD. Renovate/Dependabot surfaces upgrades through PR.

--- a/scripts/cd/bootstrap-preview.py
+++ b/scripts/cd/bootstrap-preview.py
@@ -415,13 +415,14 @@ def step_vercel(
     if ids:
         ok(f"orgId={mask(ids[0])}  projectId={mask(ids[1])}")
 
-    # Disable Vercel's git auto-deployments in code (no dashboard step).
+    # Keep a code-level guard in case the project-level Git provider is reconnected.
     print()
     info(bold("Disable Vercel Git auto-deployments (via vercel.json)"))
     teach(
-        "Sets `git.deploymentEnabled = false` in web/vercel.json so Vercel's Git "
-        "integration stays connected for metadata without auto-deploying pushes or PRs. "
-        "GitHub Actions owns PR previews and production promotion."
+        "Sets `git.deploymentEnabled = false` in web/vercel.json as defense in depth. "
+        "Keep the Vercel project's Git provider disconnected: Vercel resolves the Root "
+        "Directory before reading this nested file, so branches without web/ otherwise "
+        "fail before the guard runs. GitHub Actions owns deployment."
     )
     ensure_vercel_json_disables_git_auto_deploys(runner, prompt, project_dir)
 

--- a/scripts/cd/config.toml
+++ b/scripts/cd/config.toml
@@ -12,8 +12,9 @@ slug = "fairchild/workspaces"
 [vercel]
 # Directory containing the Next.js app and the Vercel project link.
 # The bootstrap also writes/merges `git.deploymentEnabled = false` into
-# <project_dir>/vercel.json so Vercel's git integration stops auto-deploying
-# branches and PRs. No dashboard step required.
+# <project_dir>/vercel.json as defense in depth. Keep the Vercel project's Git
+# provider disconnected: branches without <project_dir> fail before Vercel can
+# read this nested guard.
 project_dir = "web"
 
 [[workers]]


### PR DESCRIPTION
## Summary

- record the project-level Git disconnect as the primary control for `spaces-web` and `web-next`
- retain each app's checked-in `git.deploymentEnabled=false` as defense in depth
- explain why the nested guard cannot stop a deployment when the branch lacks the configured Root Directory

## Root cause and operational fix

The latest failed previews both came from `factory/ops-data`, a branch without either app directory:

- [`spaces-web` deployment `dpl_CXtvp2knTUQTphmiEKMj6KiKrYjT`](https://vercel.com/cloudcompute/spaces-web/dpl_CXtvp2knTUQTphmiEKMj6KiKrYjT): `Root Directory "web/" does not exist`
- [`web-next` deployment `dpl_2kzGCTm8fWffaun2BEwyR7yfG6gX`](https://vercel.com/cloudcompute/web-next/dpl_2kzGCTm8fWffaun2BEwyR7yfG6gX): `Root Directory "web-next" does not exist`

Vercel resolves Root Directory before reading the nested `vercel.json`, so neither checked-in auto-deploy guard could run. I disconnected `fairchild/workspaces` from both Vercel projects. A second scoped CLI check now returns `No Git repository connected` for each project. Domains, environment variables, current deployments, and Actions-owned CLI deployments are unchanged.

## Verification

- `uv run --script scripts/cd/bootstrap-preview.py --help`
- `git -c core.whitespace=trailing-space,space-before-tab diff --check`
- refreshed from `origin/main` before branching
