### PR TITLE
feat(feedback): token-authenticated agent API on the feedback store

### DIFF
--- a/infra/feedback-store/CONTRACT.md
+++ b/infra/feedback-store/CONTRACT.md
@@ -99,6 +99,29 @@ Admin publish accepts selected feedback IDs plus editable `title` and `body`, cr
 
 **Dedup:** publish is guarded against double-publishing — re-publishing a row that already has a `github_issue_url` is rejected with a `409` page listing the existing issue(s), so a double-click or retry can't silently mint a duplicate issue. (The guard lives in the shared `publishFeedbackAsIssue` core, which also supports a `force` override for the rare intentional re-publish.)
 
+## Agent API
+
+Token-authenticated JSON lane for trusted agents (the product-triage persona).
+Auth is `Authorization: Bearer <FEEDBACK_AGENT_TOKEN>`; the token is a
+Cloudflare secret binding set on both `feedback-store` and
+`feedback-store-preview`. When the binding is absent the lane answers `503`;
+a missing or wrong token answers `401`. Callers may declare an identity with
+`X-Agent-Actor: <slug>`; it is sanitized and recorded in the audit trail as
+`agent:<slug>` (default `agent:unknown`).
+
+- `GET /api/feedback?status=&kind=&limit=` — newest-first rows (default 50,
+  max 200). Rows never include `ip_hash`.
+- `GET /api/feedback/:id` — one row plus its full audit trail.
+- `PATCH /api/feedback/:id` — JSON `{status?, admin_notes?}`. `status` must be
+  one of `new|triaged|planned|resolved|wont_fix`. Every update writes an
+  `update` audit entry naming the actor.
+- `POST /api/feedback/publish` — JSON `{ids, title, body, force?}`. Runs the
+  same `publishFeedbackAsIssue` core as the admin UI, so the double-publish
+  guard (409 with the existing issue list) and the publish audit entry hold on
+  this lane too.
+
+`scripts/feedback-api.sh` wraps these endpoints for CLI use.
+
 ## Audit trail
 
 `feedback_audit` (append-only) records every publish from the admin UI, so a triage action is always attributable:

--- a/infra/feedback-store/CONTRACT.md
+++ b/infra/feedback-store/CONTRACT.md
@@ -124,6 +124,6 @@ a missing or wrong token answers `401`. Callers may declare an identity with
 
 ## Audit trail
 
-`feedback_audit` (append-only) records every publish from the admin UI, so a triage action is always attributable:
+`feedback_audit` (append-only) records every publish and every agent-lane update, so a triage action is always attributable:
 
-- `id` INTEGER PK, `feedback_id` TEXT, `at` INTEGER ms, `actor` TEXT (the admin login), `action` TEXT (currently `publish`), `detail` TEXT nullable (the issue URL).
+- `id` INTEGER PK, `feedback_id` TEXT, `at` INTEGER ms, `actor` TEXT (the admin login for admin-UI publishes, `agent:<slug>` for agent-lane actions), `action` TEXT (`publish` or `update`), `detail` TEXT nullable (the issue URL for publishes, the request body JSON for updates).

--- a/infra/feedback-store/src/admin.ts
+++ b/infra/feedback-store/src/admin.ts
@@ -1,6 +1,6 @@
 import { ensureSchema } from "./db";
 import { signJWT, verifyJWT } from "./github-verify";
-import type { Env, FeedbackRow } from "./types";
+import { FEEDBACK_STATUSES, type Env, type FeedbackRow } from "./types";
 
 interface AdminSession {
   login: string;
@@ -177,7 +177,7 @@ async function detail(id: string, env: Env, session: AdminSession): Promise<Resp
       <p>GitHub: ${row.github_issue_url ? `<a href="${escapeHTML(row.github_issue_url)}">${escapeHTML(row.github_issue_url)}</a>` : "none"}</p>
       <ul>${attachments || "<li>No attachments</li>"}</ul>
       <form method="post">
-        <label>Status <select name="status">${["new", "triaged", "planned", "resolved", "wont_fix"].map((value) => `<option ${value === row.status ? "selected" : ""}>${value}</option>`).join("")}</select></label>
+        <label>Status <select name="status">${FEEDBACK_STATUSES.map((value) => `<option ${value === row.status ? "selected" : ""}>${value}</option>`).join("")}</select></label>
         <label>Notes <textarea name="admin_notes">${escapeHTML(row.admin_notes ?? "")}</textarea></label>
         <button>Save</button>
       </form>

--- a/infra/feedback-store/src/agent-api.ts
+++ b/infra/feedback-store/src/agent-api.ts
@@ -1,0 +1,180 @@
+/**
+ * Token-authenticated JSON API for trusted agents (product triage lane).
+ * Read/list feedback rows, update status/notes, and publish through the same
+ * guarded core as the admin UI, so dedup and the audit trail hold everywhere.
+ */
+import { ensureSchema, recordAudit } from "./db";
+import { publishFeedbackAsIssue } from "./publish";
+import { FEEDBACK_STATUSES, type Env, type FeedbackAuditRow, type FeedbackRow } from "./types";
+
+const LIST_LIMIT_DEFAULT = 50;
+const LIST_LIMIT_MAX = 200;
+
+export async function handleAgentAPI(request: Request, env: Env): Promise<Response> {
+  if (!env.FEEDBACK_AGENT_TOKEN) {
+    return Response.json({ error: "agent API is not configured" }, { status: 503 });
+  }
+  if (!(await bearerTokenMatches(request, env.FEEDBACK_AGENT_TOKEN))) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  await ensureSchema(env);
+  const url = new URL(request.url);
+  const segments = url.pathname.split("/").filter(Boolean);
+
+  if (segments[0] !== "api" || segments[1] !== "feedback") {
+    return Response.json({ error: "not found" }, { status: 404 });
+  }
+
+  if (request.method === "GET" && segments.length === 2) {
+    return list(url, env);
+  }
+  if (request.method === "POST" && segments.length === 3 && segments[2] === "publish") {
+    return publish(request, env);
+  }
+  if (segments.length === 3) {
+    if (request.method === "GET") return detail(segments[2], env);
+    if (request.method === "PATCH") return update(segments[2], request, env);
+  }
+
+  return Response.json({ error: "not found" }, { status: 404 });
+}
+
+async function list(url: URL, env: Env): Promise<Response> {
+  const status = url.searchParams.get("status") ?? "";
+  const kind = url.searchParams.get("kind") ?? "";
+  const limit = Math.min(
+    Math.max(Number(url.searchParams.get("limit")) || LIST_LIMIT_DEFAULT, 1),
+    LIST_LIMIT_MAX
+  );
+
+  let query = "SELECT * FROM feedback";
+  const clauses: string[] = [];
+  const bindings: (string | number)[] = [];
+  if (status) {
+    clauses.push("status = ?");
+    bindings.push(status);
+  }
+  if (kind) {
+    clauses.push("kind = ?");
+    bindings.push(kind);
+  }
+  if (clauses.length) query += ` WHERE ${clauses.join(" AND ")}`;
+  query += " ORDER BY created_at DESC LIMIT ?";
+  bindings.push(limit);
+
+  const result = await env.FEEDBACK_DB.prepare(query).bind(...bindings).all<FeedbackRow>();
+  return Response.json({ rows: (result.results ?? []).map(publicRow) });
+}
+
+async function detail(id: string, env: Env): Promise<Response> {
+  const row = await env.FEEDBACK_DB.prepare("SELECT * FROM feedback WHERE id = ?")
+    .bind(id)
+    .first<FeedbackRow>();
+  if (!row) return Response.json({ error: "not found" }, { status: 404 });
+
+  const audit = await env.FEEDBACK_DB.prepare(
+    "SELECT * FROM feedback_audit WHERE feedback_id = ? ORDER BY at ASC"
+  )
+    .bind(id)
+    .all<FeedbackAuditRow>();
+
+  return Response.json({ row: publicRow(row), audit: audit.results ?? [] });
+}
+
+async function update(id: string, request: Request, env: Env): Promise<Response> {
+  let body: { status?: string; admin_notes?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const sets: string[] = [];
+  const bindings: string[] = [];
+  if (body.status !== undefined) {
+    if (!(FEEDBACK_STATUSES as readonly string[]).includes(body.status)) {
+      return Response.json(
+        { error: `invalid status; expected one of: ${FEEDBACK_STATUSES.join(", ")}` },
+        { status: 400 }
+      );
+    }
+    sets.push("status = ?");
+    bindings.push(body.status);
+  }
+  if (body.admin_notes !== undefined) {
+    sets.push("admin_notes = ?");
+    bindings.push(String(body.admin_notes));
+  }
+  if (!sets.length) {
+    return Response.json({ error: "nothing to update; pass status and/or admin_notes" }, { status: 400 });
+  }
+
+  const existing = await env.FEEDBACK_DB.prepare("SELECT * FROM feedback WHERE id = ?")
+    .bind(id)
+    .first<FeedbackRow>();
+  if (!existing) return Response.json({ error: "not found" }, { status: 404 });
+
+  await env.FEEDBACK_DB.prepare(`UPDATE feedback SET ${sets.join(", ")} WHERE id = ?`)
+    .bind(...bindings, id)
+    .run();
+  await recordAudit(env, id, actorFrom(request), "update", JSON.stringify(body));
+
+  const updated = await env.FEEDBACK_DB.prepare("SELECT * FROM feedback WHERE id = ?")
+    .bind(id)
+    .first<FeedbackRow>();
+  return Response.json({ row: updated ? publicRow(updated) : null });
+}
+
+async function publish(request: Request, env: Env): Promise<Response> {
+  let body: { ids?: string[]; title?: string; body?: string; force?: boolean };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await publishFeedbackAsIssue(env, {
+    ids: Array.isArray(body.ids) ? body.ids.map(String) : [],
+    title: String(body.title ?? ""),
+    body: String(body.body ?? ""),
+    actor: actorFrom(request),
+    force: body.force === true,
+  });
+
+  if (!result.ok) {
+    return Response.json(
+      { error: result.error, alreadyPublished: result.alreadyPublished },
+      { status: result.status }
+    );
+  }
+  return Response.json({ issueURL: result.issueURL });
+}
+
+/** Audit actor: caller-declared identity, constrained to a safe slug. */
+function actorFrom(request: Request): string {
+  const raw = request.headers.get("X-Agent-Actor") ?? "";
+  const slug = raw.toLowerCase().replace(/[^a-z0-9_.:-]/g, "").slice(0, 64);
+  return slug ? `agent:${slug}` : "agent:unknown";
+}
+
+/** The agent lane never needs the submitter's hashed IP. */
+function publicRow(row: FeedbackRow): Omit<FeedbackRow, "ip_hash"> {
+  const { ip_hash: _ip_hash, ...rest } = row;
+  return rest;
+}
+
+async function bearerTokenMatches(request: Request, expected: string): Promise<boolean> {
+  const match = (request.headers.get("Authorization") ?? "").match(/^Bearer\s+(.+)$/i);
+  if (!match) return false;
+  const encoder = new TextEncoder();
+  const [a, b] = await Promise.all([
+    crypto.subtle.digest("SHA-256", encoder.encode(match[1])),
+    crypto.subtle.digest("SHA-256", encoder.encode(expected)),
+  ]);
+  const av = new Uint8Array(a);
+  const bv = new Uint8Array(b);
+  let diff = 0;
+  for (let i = 0; i < av.length; i += 1) diff |= av[i] ^ bv[i];
+  return diff === 0;
+}

--- a/infra/feedback-store/src/agent-api.ts
+++ b/infra/feedback-store/src/agent-api.ts
@@ -3,7 +3,7 @@
  * Read/list feedback rows, update status/notes, and publish through the same
  * guarded core as the admin UI, so dedup and the audit trail hold everywhere.
  */
-import { ensureSchema, recordAudit } from "./db";
+import { auditStatement, ensureSchema } from "./db";
 import { publishFeedbackAsIssue } from "./publish";
 import { FEEDBACK_STATUSES, type Env, type FeedbackAuditRow, type FeedbackRow } from "./types";
 
@@ -43,9 +43,8 @@ export async function handleAgentAPI(request: Request, env: Env): Promise<Respon
 async function list(url: URL, env: Env): Promise<Response> {
   const status = url.searchParams.get("status") ?? "";
   const kind = url.searchParams.get("kind") ?? "";
-  const limit = Math.min(
-    Math.max(Number(url.searchParams.get("limit")) || LIST_LIMIT_DEFAULT, 1),
-    LIST_LIMIT_MAX
+  const limit = Math.floor(
+    Math.min(Math.max(Number(url.searchParams.get("limit")) || LIST_LIMIT_DEFAULT, 1), LIST_LIMIT_MAX)
   );
 
   let query = "SELECT * FROM feedback";
@@ -83,7 +82,7 @@ async function detail(id: string, env: Env): Promise<Response> {
 }
 
 async function update(id: string, request: Request, env: Env): Promise<Response> {
-  let body: { status?: string; admin_notes?: string };
+  let body: { status?: string; admin_notes?: string | null };
   try {
     body = await request.json();
   } catch {
@@ -91,9 +90,9 @@ async function update(id: string, request: Request, env: Env): Promise<Response>
   }
 
   const sets: string[] = [];
-  const bindings: string[] = [];
+  const bindings: (string | null)[] = [];
   if (body.status !== undefined) {
-    if (!(FEEDBACK_STATUSES as readonly string[]).includes(body.status)) {
+    if (typeof body.status !== "string" || !(FEEDBACK_STATUSES as readonly string[]).includes(body.status)) {
       return Response.json(
         { error: `invalid status; expected one of: ${FEEDBACK_STATUSES.join(", ")}` },
         { status: 400 }
@@ -103,8 +102,11 @@ async function update(id: string, request: Request, env: Env): Promise<Response>
     bindings.push(body.status);
   }
   if (body.admin_notes !== undefined) {
+    if (body.admin_notes !== null && typeof body.admin_notes !== "string") {
+      return Response.json({ error: "admin_notes must be a string or null" }, { status: 400 });
+    }
     sets.push("admin_notes = ?");
-    bindings.push(String(body.admin_notes));
+    bindings.push(body.admin_notes);
   }
   if (!sets.length) {
     return Response.json({ error: "nothing to update; pass status and/or admin_notes" }, { status: 400 });
@@ -115,10 +117,11 @@ async function update(id: string, request: Request, env: Env): Promise<Response>
     .first<FeedbackRow>();
   if (!existing) return Response.json({ error: "not found" }, { status: 404 });
 
-  await env.FEEDBACK_DB.prepare(`UPDATE feedback SET ${sets.join(", ")} WHERE id = ?`)
-    .bind(...bindings, id)
-    .run();
-  await recordAudit(env, id, actorFrom(request), "update", JSON.stringify(body));
+  // One D1 batch = one transaction: the row change and its audit entry land or fail together.
+  await env.FEEDBACK_DB.batch([
+    env.FEEDBACK_DB.prepare(`UPDATE feedback SET ${sets.join(", ")} WHERE id = ?`).bind(...bindings, id),
+    auditStatement(env, id, actorFrom(request), "update", JSON.stringify(body)),
+  ]);
 
   const updated = await env.FEEDBACK_DB.prepare("SELECT * FROM feedback WHERE id = ?")
     .bind(id)

--- a/infra/feedback-store/src/db.ts
+++ b/infra/feedback-store/src/db.ts
@@ -23,6 +23,19 @@ export async function ensureSchema(env: Env): Promise<void> {
   );
 }
 
+/** Bound audit insert, for callers that batch it atomically with the mutation it records. */
+export function auditStatement(
+  env: Env,
+  feedbackId: string,
+  actor: string,
+  action: string,
+  detail?: string
+): D1PreparedStatement {
+  return env.FEEDBACK_DB.prepare(
+    "INSERT INTO feedback_audit (feedback_id, at, actor, action, detail) VALUES (?, ?, ?, ?, ?)"
+  ).bind(feedbackId, Date.now(), actor, action, detail ?? null);
+}
+
 /** Record an actor's action against a feedback row. Never throws on the caller's path. */
 export async function recordAudit(
   env: Env,
@@ -31,9 +44,5 @@ export async function recordAudit(
   action: string,
   detail?: string
 ): Promise<void> {
-  await env.FEEDBACK_DB.prepare(
-    "INSERT INTO feedback_audit (feedback_id, at, actor, action, detail) VALUES (?, ?, ?, ?, ?)"
-  )
-    .bind(feedbackId, Date.now(), actor, action, detail ?? null)
-    .run();
+  await auditStatement(env, feedbackId, actor, action, detail).run();
 }

--- a/infra/feedback-store/src/index.ts
+++ b/infra/feedback-store/src/index.ts
@@ -1,4 +1,5 @@
 import { handleAdmin } from "./admin";
+import { handleAgentAPI } from "./agent-api";
 import { handlePublish } from "./publish";
 import { handleSubmit } from "./submit";
 import type { Env } from "./types";
@@ -14,6 +15,10 @@ export default {
 
       if (request.method === "POST" && url.pathname === "/feedback") {
         return handleSubmit(request, env);
+      }
+
+      if (url.pathname.startsWith("/api/")) {
+        return handleAgentAPI(request, env);
       }
 
       if (url.pathname === "/admin/publish" && request.method === "POST") {

--- a/infra/feedback-store/src/types.ts
+++ b/infra/feedback-store/src/types.ts
@@ -1,9 +1,13 @@
+export const FEEDBACK_STATUSES = ["new", "triaged", "planned", "resolved", "wont_fix"] as const;
+export type FeedbackStatus = (typeof FEEDBACK_STATUSES)[number];
+
 export interface Env {
   FEEDBACK_DB: D1Database;
   FEEDBACK_BUCKET: R2Bucket;
   JWT_SIGNING_SECRET: string;
   ADMIN_SESSION_SECRET: string;
   ADMIN_ALLOWLIST: string;
+  FEEDBACK_AGENT_TOKEN?: string;
   GITHUB_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET: string;
   GITHUB_ISSUE_TOKEN?: string;

--- a/infra/feedback-store/test/agent-api.test.ts
+++ b/infra/feedback-store/test/agent-api.test.ts
@@ -16,6 +16,9 @@ class FakeD1 {
   async exec() {
     return {} as unknown;
   }
+  async batch(statements: FakeStatement[]) {
+    return Promise.all(statements.map((statement) => statement.run()));
+  }
 }
 
 class FakeStatement {
@@ -44,7 +47,10 @@ class FakeStatement {
     }
     rows.sort((a, b) => b.created_at - a.created_at);
     if (this.sql.includes("LIMIT ?")) {
-      rows = rows.slice(0, Number(this.args[arg++]));
+      const limit = this.args[arg++];
+      // Real SQLite rejects non-integer LIMIT bindings ("datatype mismatch").
+      if (!Number.isInteger(limit)) throw new Error("datatype mismatch");
+      rows = rows.slice(0, limit as number);
     }
     return { results: rows.map((r) => ({ ...r })) as T[] };
   }
@@ -158,6 +164,19 @@ describe("agent API reads", () => {
     expect(body.audit[0].actor).toBe("agent:mara");
   });
 
+  test("fractional limit params are floored to a valid integer binding", async () => {
+    const db = new FakeD1();
+    db.feedback.push(makeRow({ id: "a", created_at: 1 }));
+    db.feedback.push(makeRow({ id: "b", created_at: 2 }));
+    db.feedback.push(makeRow({ id: "c", created_at: 3 }));
+
+    const response = await handleAgentAPI(apiRequest("/api/feedback?limit=2.5"), makeEnv(db));
+    const body = (await response.json()) as { rows: { id: string }[] };
+
+    expect(response.status).toBe(200);
+    expect(body.rows.map((r) => r.id)).toEqual(["c", "b"]);
+  });
+
   test("detail 404s on unknown ids", async () => {
     const response = await handleAgentAPI(apiRequest("/api/feedback/missing"), makeEnv(new FakeD1()));
     expect(response.status).toBe(404);
@@ -184,6 +203,25 @@ describe("agent API updates", () => {
     expect(db.audit).toHaveLength(1);
     expect(db.audit[0].actor).toBe("agent:mara");
     expect(db.audit[0].action).toBe("update");
+  });
+
+  test("admin_notes null clears the field; non-string notes are rejected", async () => {
+    const db = new FakeD1();
+    db.feedback.push(makeRow({ id: "a", admin_notes: "old note" }));
+    const env = makeEnv(db);
+
+    const cleared = await handleAgentAPI(
+      apiRequest("/api/feedback/a", { method: "PATCH", body: JSON.stringify({ admin_notes: null }) }),
+      env
+    );
+    const body = (await cleared.json()) as { row: { admin_notes: string | null } };
+    const rejected = await handleAgentAPI(
+      apiRequest("/api/feedback/a", { method: "PATCH", body: JSON.stringify({ admin_notes: 42 }) }),
+      env
+    );
+
+    expect(body.row.admin_notes).toBeNull();
+    expect(rejected.status).toBe(400);
   });
 
   test("rejects unknown statuses and empty updates", async () => {

--- a/infra/feedback-store/test/agent-api.test.ts
+++ b/infra/feedback-store/test/agent-api.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Agent API behavior: bearer auth gate, list/detail reads, validated
+ * status/notes updates with audit entries, and publish routed through the
+ * shared guarded core. In-memory D1 fake; stubbed fetch keeps GitHub out.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { handleAgentAPI } from "../src/agent-api";
+import type { Env, FeedbackRow } from "../src/types";
+
+class FakeD1 {
+  feedback: FeedbackRow[] = [];
+  audit: any[] = [];
+  prepare(sql: string) {
+    return new FakeStatement(this, sql, []);
+  }
+  async exec() {
+    return {} as unknown;
+  }
+}
+
+class FakeStatement {
+  constructor(private db: FakeD1, private sql: string, private args: unknown[]) {}
+  bind(...args: unknown[]) {
+    return new FakeStatement(this.db, this.sql, args);
+  }
+  async first<T>(): Promise<T | null> {
+    const row = this.db.feedback.find((r) => r.id === this.args[0]);
+    return (row ? { ...row } : null) as T | null;
+  }
+  async all<T>(): Promise<{ results: T[] }> {
+    if (this.sql.includes("FROM feedback_audit")) {
+      const rows = this.db.audit.filter((r) => r.feedback_id === this.args[0]);
+      return { results: rows as T[] };
+    }
+    let rows = [...this.db.feedback];
+    let arg = 0;
+    if (this.sql.includes("status = ?")) {
+      const status = this.args[arg++];
+      rows = rows.filter((r) => r.status === status);
+    }
+    if (this.sql.includes("kind = ?")) {
+      const kind = this.args[arg++];
+      rows = rows.filter((r) => r.kind === kind);
+    }
+    rows.sort((a, b) => b.created_at - a.created_at);
+    if (this.sql.includes("LIMIT ?")) {
+      rows = rows.slice(0, Number(this.args[arg++]));
+    }
+    return { results: rows.map((r) => ({ ...r })) as T[] };
+  }
+  async run() {
+    if (this.sql.startsWith("INSERT INTO feedback_audit")) {
+      const [feedback_id, at, actor, action, detail] = this.args;
+      this.db.audit.push({ feedback_id, at, actor, action, detail });
+    } else if (this.sql.startsWith("UPDATE feedback SET github_issue_url")) {
+      const [url, id] = this.args;
+      const row = this.db.feedback.find((r) => r.id === id);
+      if (row) {
+        row.github_issue_url = url as string;
+        row.status = "triaged";
+      }
+    } else if (this.sql.startsWith("UPDATE feedback SET")) {
+      const id = this.args[this.args.length - 1];
+      const row = this.db.feedback.find((r) => r.id === id);
+      if (row) {
+        const sets = this.sql
+          .slice("UPDATE feedback SET ".length, this.sql.indexOf(" WHERE"))
+          .split(", ")
+          .map((clause) => clause.split(" = ")[0]);
+        sets.forEach((column, index) => {
+          (row as any)[column] = this.args[index];
+        });
+      }
+    }
+    return {} as unknown;
+  }
+}
+
+function makeRow(over: Partial<FeedbackRow> = {}): FeedbackRow {
+  return {
+    id: "fb-1",
+    created_at: 1,
+    kind: "bug",
+    message: "it broke",
+    contact_email: null,
+    submitter_login: null,
+    submitter_id: null,
+    app_version: "1.0",
+    os_version: "15",
+    client: "macos",
+    ip_hash: "secret-hash",
+    status: "new",
+    admin_notes: null,
+    github_issue_url: null,
+    attachment_prefix: null,
+    has_screenshot: 0,
+    has_diagnostics: 0,
+    ...over,
+  };
+}
+
+const TOKEN = "test-agent-token";
+
+function makeEnv(db: FakeD1): Env {
+  return {
+    FEEDBACK_DB: db as unknown as D1Database,
+    FEEDBACK_AGENT_TOKEN: TOKEN,
+    GITHUB_ISSUE_TOKEN: "gh-token",
+  } as Env;
+}
+
+function apiRequest(path: string, init: RequestInit = {}, token: string | null = TOKEN): Request {
+  const headers = new Headers(init.headers);
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  return new Request(`https://feedback.example${path}`, { ...init, headers });
+}
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("agent API auth", () => {
+  test("rejects missing and wrong tokens", async () => {
+    const env = makeEnv(new FakeD1());
+    expect((await handleAgentAPI(apiRequest("/api/feedback", {}, null), env)).status).toBe(401);
+    expect((await handleAgentAPI(apiRequest("/api/feedback", {}, "nope"), env)).status).toBe(401);
+  });
+
+  test("503 when the lane is not configured", async () => {
+    const env = { ...makeEnv(new FakeD1()), FEEDBACK_AGENT_TOKEN: undefined } as Env;
+    expect((await handleAgentAPI(apiRequest("/api/feedback"), env)).status).toBe(503);
+  });
+});
+
+describe("agent API reads", () => {
+  test("lists rows filtered by status, without ip_hash", async () => {
+    const db = new FakeD1();
+    db.feedback.push(makeRow({ id: "a", status: "new", created_at: 2 }));
+    db.feedback.push(makeRow({ id: "b", status: "triaged", created_at: 3 }));
+
+    const response = await handleAgentAPI(apiRequest("/api/feedback?status=new"), makeEnv(db));
+    const body = (await response.json()) as { rows: Record<string, unknown>[] };
+
+    expect(body.rows.map((r) => r.id)).toEqual(["a"]);
+    expect("ip_hash" in body.rows[0]).toBe(false);
+  });
+
+  test("detail returns the row plus its audit trail", async () => {
+    const db = new FakeD1();
+    db.feedback.push(makeRow({ id: "a" }));
+    db.audit.push({ feedback_id: "a", at: 5, actor: "agent:mara", action: "update", detail: null });
+
+    const response = await handleAgentAPI(apiRequest("/api/feedback/a"), makeEnv(db));
+    const body = (await response.json()) as { row: { id: string }; audit: { actor: string }[] };
+
+    expect(body.row.id).toBe("a");
+    expect(body.audit[0].actor).toBe("agent:mara");
+  });
+
+  test("detail 404s on unknown ids", async () => {
+    const response = await handleAgentAPI(apiRequest("/api/feedback/missing"), makeEnv(new FakeD1()));
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("agent API updates", () => {
+  test("updates status and notes, recording an attributed audit entry", async () => {
+    const db = new FakeD1();
+    db.feedback.push(makeRow({ id: "a" }));
+
+    const response = await handleAgentAPI(
+      apiRequest("/api/feedback/a", {
+        method: "PATCH",
+        body: JSON.stringify({ status: "triaged", admin_notes: "dup of #123" }),
+        headers: { "X-Agent-Actor": "mara" },
+      }),
+      makeEnv(db)
+    );
+    const body = (await response.json()) as { row: { status: string; admin_notes: string } };
+
+    expect(body.row.status).toBe("triaged");
+    expect(body.row.admin_notes).toBe("dup of #123");
+    expect(db.audit).toHaveLength(1);
+    expect(db.audit[0].actor).toBe("agent:mara");
+    expect(db.audit[0].action).toBe("update");
+  });
+
+  test("rejects unknown statuses and empty updates", async () => {
+    const db = new FakeD1();
+    db.feedback.push(makeRow({ id: "a" }));
+    const env = makeEnv(db);
+
+    const bad = await handleAgentAPI(
+      apiRequest("/api/feedback/a", { method: "PATCH", body: JSON.stringify({ status: "bogus" }) }),
+      env
+    );
+    const empty = await handleAgentAPI(
+      apiRequest("/api/feedback/a", { method: "PATCH", body: JSON.stringify({}) }),
+      env
+    );
+
+    expect(bad.status).toBe(400);
+    expect(empty.status).toBe(400);
+    expect(db.audit).toHaveLength(0);
+  });
+});
+
+describe("agent API publish", () => {
+  test("routes through the guarded core: creates the issue, marks triaged, audits", async () => {
+    const db = new FakeD1();
+    db.feedback.push(makeRow({ id: "a" }));
+    globalThis.fetch = (async () =>
+      Response.json({ html_url: "https://github.com/fairchild/workspaces/issues/999" })) as unknown as typeof fetch;
+
+    const response = await handleAgentAPI(
+      apiRequest("/api/feedback/publish", {
+        method: "POST",
+        body: JSON.stringify({ ids: ["a"], title: "Fix it", body: "Details" }),
+        headers: { "X-Agent-Actor": "mara" },
+      }),
+      makeEnv(db)
+    );
+    const body = (await response.json()) as { issueURL: string };
+
+    expect(body.issueURL).toContain("/issues/999");
+    expect(db.feedback[0].status).toBe("triaged");
+    expect(db.audit[0].action).toBe("publish");
+    expect(db.audit[0].actor).toBe("agent:mara");
+  });
+
+  test("dedup guard still holds: 409 on already-published rows", async () => {
+    const db = new FakeD1();
+    db.feedback.push(makeRow({ id: "a", github_issue_url: "https://github.com/x/1" }));
+
+    const response = await handleAgentAPI(
+      apiRequest("/api/feedback/publish", {
+        method: "POST",
+        body: JSON.stringify({ ids: ["a"], title: "Again", body: "Details" }),
+      }),
+      makeEnv(db)
+    );
+
+    expect(response.status).toBe(409);
+  });
+});

--- a/scripts/feedback-api.sh
+++ b/scripts/feedback-api.sh
@@ -38,13 +38,14 @@ EOF
 
 api() {
   local method="$1" path="$2" body="${3:-}"
-  local args=(-sS -X "$method" "$BASE_URL$path"
-    -H "Authorization: Bearer $FEEDBACK_AGENT_TOKEN"
-    -H "X-Agent-Actor: $ACTOR")
+  local args=(-sS -X "$method" "$BASE_URL$path" -K - -H "X-Agent-Actor: $ACTOR")
   if [[ -n "$body" ]]; then
     args+=(-H "Content-Type: application/json" --data "$body")
   fi
-  curl "${args[@]}"
+  # Auth header arrives via stdin config (-K -) so the token never hits argv.
+  curl "${args[@]}" <<EOF
+header = "Authorization: Bearer $FEEDBACK_AGENT_TOKEN"
+EOF
   echo
 }
 

--- a/scripts/feedback-api.sh
+++ b/scripts/feedback-api.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# CLI for the feedback store's agent API (infra/feedback-store/CONTRACT.md § Agent API).
+# Used by the product-triage persona to list, inspect, update, and publish
+# feedback rows. Requires FEEDBACK_AGENT_TOKEN (auto-sourced from .env).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -z "${FEEDBACK_AGENT_TOKEN:-}" && -f "$REPO_ROOT/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/.env"
+  set +a
+fi
+
+BASE_URL="${FEEDBACK_API_BASE:-https://feedback.cloudcompute.com}"
+ACTOR="${FEEDBACK_AGENT_ACTOR:-cli}"
+
+usage() {
+  cat <<'EOF'
+Usage: feedback-api.sh <command> [args]
+
+Commands:
+  list [status] [kind]          List rows, newest first (status/kind filters optional)
+  show <id>                     One row plus its audit trail
+  update <id> <status> [notes]  Set status (new|triaged|planned|resolved|wont_fix) and optional notes
+  publish <title> <body> <id...>  Publish rows as one GitHub issue (guarded against dupes)
+
+Environment:
+  FEEDBACK_AGENT_TOKEN  required; auto-sourced from repo .env
+  FEEDBACK_API_BASE     default https://feedback.cloudcompute.com
+  FEEDBACK_AGENT_ACTOR  audit identity, default "cli"
+EOF
+  exit 1
+}
+
+[[ $# -ge 1 ]] || usage
+[[ -n "${FEEDBACK_AGENT_TOKEN:-}" ]] || { echo "error: FEEDBACK_AGENT_TOKEN is not set" >&2; exit 1; }
+
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  local args=(-sS -X "$method" "$BASE_URL$path"
+    -H "Authorization: Bearer $FEEDBACK_AGENT_TOKEN"
+    -H "X-Agent-Actor: $ACTOR")
+  if [[ -n "$body" ]]; then
+    args+=(-H "Content-Type: application/json" --data "$body")
+  fi
+  curl "${args[@]}"
+  echo
+}
+
+json_escape() {
+  python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$1"
+}
+
+command="$1"
+shift
+case "$command" in
+  list)
+    query=""
+    [[ -n "${1:-}" ]] && query="status=$1"
+    [[ -n "${2:-}" ]] && query="$query&kind=$2"
+    api GET "/api/feedback${query:+?$query}"
+    ;;
+  show)
+    [[ $# -eq 1 ]] || usage
+    api GET "/api/feedback/$1"
+    ;;
+  update)
+    [[ $# -ge 2 ]] || usage
+    id="$1"
+    body="{\"status\": $(json_escape "$2")"
+    [[ $# -ge 3 ]] && body="$body, \"admin_notes\": $(json_escape "$3")"
+    body="$body}"
+    api PATCH "/api/feedback/$id" "$body"
+    ;;
+  publish)
+    [[ $# -ge 3 ]] || usage
+    title="$1"
+    text="$2"
+    shift 2
+    ids=""
+    for id in "$@"; do
+      ids="$ids$(json_escape "$id"),"
+    done
+    api POST "/api/feedback/publish" \
+      "{\"ids\": [${ids%,}], \"title\": $(json_escape "$title"), \"body\": $(json_escape "$text")}"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/scripts/feedback-api.sh
+++ b/scripts/feedback-api.sh
@@ -6,10 +6,13 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 if [[ -z "${FEEDBACK_AGENT_TOKEN:-}" && -f "$REPO_ROOT/.env" ]]; then
-  set -a
-  # shellcheck disable=SC1091
-  source "$REPO_ROOT/.env"
-  set +a
+  # Extract only the token in a subshell so unrelated .env secrets never enter
+  # this process (or its curl/python children).
+  FEEDBACK_AGENT_TOKEN="$(
+    # shellcheck disable=SC1091
+    source "$REPO_ROOT/.env" >/dev/null 2>&1
+    printf '%s' "${FEEDBACK_AGENT_TOKEN:-}"
+  )"
 fi
 
 BASE_URL="${FEEDBACK_API_BASE:-https://feedback.cloudcompute.com}"
@@ -38,7 +41,7 @@ EOF
 
 api() {
   local method="$1" path="$2" body="${3:-}"
-  local args=(-sS -X "$method" "$BASE_URL$path" -K - -H "X-Agent-Actor: $ACTOR")
+  local args=(-sS --fail-with-body -X "$method" "$BASE_URL$path" -K - -H "X-Agent-Actor: $ACTOR")
   if [[ -n "$body" ]]; then
     args+=(-H "Content-Type: application/json" --data "$body")
   fi


### PR DESCRIPTION
## Summary

Adds a JSON agent lane to the feedback worker so the product-triage persona (Mara, #1270) can read and update feedback without the browser-OAuth admin UI:

- `GET /api/feedback` (status/kind/limit filters), `GET /api/feedback/:id` (row + audit trail), `PATCH /api/feedback/:id` (validated status + string|null notes, row change and audit entry in one transactional D1 batch), `POST /api/feedback/publish` (reuses the shared `publishFeedbackAsIssue` core — dedup guard and publish audit hold on both lanes).
- Auth: `FEEDBACK_AGENT_TOKEN` bearer secret (503 unconfigured, 401 mismatch, constant-time digest compare). Audit actors are namespaced `agent:<slug>` from a sanitized `X-Agent-Actor` header, so the agent lane can't impersonate admin logins. Rows never expose `ip_hash`.
- `scripts/feedback-api.sh` CLI wrapper: token via curl stdin config (never argv), `--fail-with-body` exit codes, scoped .env token extraction.
- CONTRACT.md § Agent API + refreshed audit-trail contract; shared `FEEDBACK_STATUSES` vocabulary now feeds both admin UI and agent lane.

**Deploy note:** `FEEDBACK_AGENT_TOKEN` must be set as a Cloudflare secret on `feedback-store` and `feedback-store-preview` before first use; the lane answers 503 until then.

## Review loop

Directed codex (gpt-5.6-sol, xhigh) review after self-reflection (reflection fix: token moved out of curl argv pre-review). Findings and dispositions:

1. **Major — PATCH mutation/audit non-atomic** → fixed (D1 `batch()`, one transaction).
2. **Major — CLI exits 0 on HTTP errors** → fixed (`--fail-with-body`).
3. **Minor — `admin_notes: null` stored as string "null"** → fixed (string|null validation; null clears).
4. **Minor — fractional `limit` binds a non-integer (SQLite datatype mismatch)** → fixed (floor); test fake now rejects non-integer LIMIT bindings so it can't mask this class again.
5. **Minor — `set -a` .env sourcing exports unrelated secrets** → fixed (subshell extraction of the one needed var).
6. **Major — pre-existing (#766): concurrent publishes race past the 409 guard** → filed as #1272, not folded in.
7. **Major — pre-existing (#766): publish UPDATE and audit are separate commits** → filed as #1272.
8. **Nit — audit-trail contract stale** → fixed in CONTRACT.md.

Codex confirmed: no auth bypass on any /api/* path variant, no SQL injection (all values bound, clause/binding order verified), agent actors cannot collide with admin attribution.

## Validation

- `bun test`: 13 pass / 0 fail (auth gate, reads, ip_hash stripping, notes typing, limit flooring, audit attribution, publish dedup)
- `tsc --noEmit` clean; `bash -n` + ShellCheck clean

## Evidence

![feedback-agent-api-tests](https://evidence.cloudcompute.com/workspaces/pr-1273/20260808-090037-feedback-agent-api-tests.png)

## Mergeability

- **Surface**: `infra/feedback-store` Cloudflare Worker + `scripts/feedback-api.sh`; no app or web code.
- **User-facing behavior changed**: none for app users; admin UI unchanged except the status dropdown now renders from the shared vocabulary. New authenticated API surface for agents.
- **Non-happy paths considered**: unconfigured token (503), bad/missing token (401), unknown ids (404), invalid status / non-string notes / empty patch / malformed JSON (400), double-publish (409 preserved), transient audit-write failure (transactional batch), fractional limit params.
- **Residual risk or follow-up**: pre-existing publish-path race + non-atomic publish audit tracked in #1272; secret must be provisioned on both workers before the lane is live; the D1 fake still doesn't simulate write failures (atomicity is enforced by construction via `batch`, not by a failure-injection test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
