### PR TITLE
fix: unbreak main CI — test-target compile break and a frozen docs date

### DIFF
--- a/Tests/WorkspaceManagerTests/WorkspaceOrphanReconcilerTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceOrphanReconcilerTests.swift
@@ -500,6 +500,7 @@ struct WorkspaceOrphanReconcilerTests {
         try Data("#!/bin/sh\nexec sleep 30\n".utf8).write(to: url)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
         return url
+    }
 
     @Test("Synthetic root set: the real workspaces root and Lume storage are never statted")
     func syntheticRootNeverStatsRealRoots() async throws {

--- a/web/e2e/fast/docs.spec.ts
+++ b/web/e2e/fast/docs.spec.ts
@@ -130,9 +130,13 @@ test.describe("Public docs", () => {
 	test("shows friendly page metadata before exact details", async ({ page }) => {
 		await page.goto("/docs/performance/dashboard");
 
-		await expect(page.locator("#doc-updated")).toHaveText("Updated Mar 22, 2026");
+		// The perf dashboard is a generated doc, so its timestamp moves with every
+		// perf run — the property under test is the friendly shape, not a date.
+		await expect(page.locator("#doc-updated")).toHaveText(
+			/^Updated [A-Z][a-z]{2} \d{1,2}, \d{4}$/,
+		);
 		await expect(page.locator("#doc-updated")).not.toContainText(
-			"2026-03-22T10:29:08-0700",
+			/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
 		);
 		await expect(page.getByText("Document details")).toHaveCount(0);
 		await expect(page.locator("#content")).not.toContainText("Last updated:");


### PR DESCRIPTION
`main` has been red since 2026-08-08 on three workflows (CI, CI Fallback, Web CI), which blocks cutting v0.24.0. Two independent causes, both fixed here.

## 1. The test target does not compile

#1244 added `makeHangingGitStub` without its closing brace:

```swift
private func makeHangingGitStub(in directory: URL) throws -> URL {
    ...
    return url
                                    // ← missing }
@Test("Synthetic root set: ...")
```

Every declaration after it nested inside the function, so the struct never closed — `WorkspaceOrphanReconcilerTests.swift:672:2: error: expected '}' to end struct` at EOF.

Worth noting: because the target never compiled, **the two hanging-git tests #1244 added have never executed anywhere.** CI failed at build, not at test. This PR runs them for the first time — all 10 tests in the suite pass.

## 2. A generated doc's timestamp was frozen into an assertion

`web/e2e/fast/docs.spec.ts` pinned `toHaveText("Updated Mar 22, 2026")` against `docs/performance/dashboard.md` — a *generated* perf artifact. #1249 regenerated it to `2026-08-07T08:12:53-0700`, so the page began rendering "Updated Aug 7, 2026".

The behavior the test names — friendly date shown, raw ISO timestamp withheld — was never broken. Both assertions now match shape rather than a literal, so neither rots on the next perf run.

## Verification

![ci-green-verification](https://evidence.cloudcompute.com/workspaces/pr-1284/20260809-045215-ci-green-verification.png)

| Check | Result |
|---|---|
| `swift build --build-tests` | Build complete (486.85s), 0 errors |
| `swift test --filter WorkspaceOrphanReconciler` | 10/10 passed |
| `pnpm run test:e2e:docs` | 13/13 passed |
| `swift-format lint --strict` | clean |
| `pnpm run lint` (biome, 174 files) | clean |
| `pnpm run typecheck` | clean |

The web fix is backed by a mutation check rather than a green run alone: reverting only the assertion to `main`'s version reproduces CI's failure locally, byte-for-byte — `Expected: "Updated Mar 22, 2026"` / `Received: "Updated Aug 7, 2026"` — and restoring it clears. That rules out the test passing for some unrelated local reason.

## Mergeability

- Surface: desktop (test target) + web (`web/` E2E suite). No production code paths touched — one test file, one spec file.
- User-facing behavior changed: No.
- Non-happy paths considered: The docs assertion now accepts any `Mon D, YYYY` date, so it no longer detects a *wrong* date — it still fails if the element is empty, missing, or leaks a raw ISO timestamp, which is what the test is named for. Narrower shape-matching would re-pin the value and rot again.
- Residual risk or follow-up: A generated artifact under `docs/` feeding an exact-match E2E assertion is a pattern that will recur. Worth a follow-up issue on whether generated docs belong in the E2E fixture set at all. Separately: #1244 merged into a red `main`, and the main-merge ruleset did not stop it — how a non-compiling commit landed is worth a look independent of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
