### PR TITLE
fix(tests): close makeHangingGitStub in WorkspaceOrphanReconcilerTests

### DIFF
--- a/Tests/WorkspaceManagerTests/WorkspaceOrphanReconcilerTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceOrphanReconcilerTests.swift
@@ -500,6 +500,7 @@ struct WorkspaceOrphanReconcilerTests {
         try Data("#!/bin/sh\nexec sleep 30\n".utf8).write(to: url)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
         return url
+    }
 
     @Test("Synthetic root set: the real workspaces root and Lume storage are never statted")
     func syntheticRootNeverStatsRealRoots() async throws {


### PR DESCRIPTION
## What

`WorkspaceOrphanReconcilerTests.swift` has been missing one closing brace since #1244 added the hanging-git stub helper. The struct never terminates, so the whole test target fails to parse — on an otherwise clean checkout of `main`:

```
swiftc:       error: expected '}' in struct   (line 25, the struct's opening brace)
swift-format: error: expected '}' to end struct   (line 672, EOF)
```

`swift test` and `mise run lint` both fail. One brace, after `return url` in `makeHangingGitStub`. No test behavior changes.

Found while setting up the measurement lane for #1251 — `mise run lint` failed on a file I hadn't touched.

## Evidence

`swift test --filter 'MainWindowLifecycle|WorkspaceOrphanReconciler'` — 25 tests, 2 suites, all passing (the `WorkspaceOrphanReconciler` suite could not compile before this change). `mise run lint` exits 0.

![brace-fix-tests](https://evidence.cloudcompute.com/workspaces/pr-1285/20260809-045410-brace-fix-tests.png)

## Mergeability

- **Surface**: `Tests/WorkspaceManagerTests/WorkspaceOrphanReconcilerTests.swift`, one line.
- **Behavior changed**: none at runtime. The test target compiles again, so the 12 tests in the `WorkspaceOrphanReconciler` suite run instead of failing the build.
- **Non-happy paths**: none — the added brace closes a helper whose body was already complete (`return url` was its last statement); the following declaration is a `@Test` that was being parsed as part of the helper.
- **Residual risk**: none identified. Both parsers agree on the location, and the suite passes.

