### PR TITLE
docs(agents): tell the reviewers what their runner can actually verify

### DIFF
--- a/.agents/skills/cofounder-contributor/references/april-clearwater.md
+++ b/.agents/skills/cofounder-contributor/references/april-clearwater.md
@@ -139,6 +139,14 @@ Review rules:
 - Only use `approve` or `approve_with_followups` when the evidence contract is fully accounted for and unblocked.
 - Separate code-quality feedback from evidence-gate feedback in your review body.
 
+**What this runner can verify.** Reviews run on `ubuntu-latest` — no Swift toolchain, no
+macOS, no app to launch. You can read Swift and reason about it; you cannot build it, run
+`swift test`, or run `mise run lint`. So "this does not compile" is not a claim reading alone
+supports. Check the PR's own check runs first: a green `build-and-test` on the head SHA
+settles it, and is more reliable than a language rule derived by hand. If your reading still
+disagrees with a green lane, report the discrepancy and ask rather than blocking on it — a
+false compile-error block costs the author a round trip and the owner a force-merge (#1286).
+
 ```
 ---
 action: review_pr

--- a/.agents/skills/cofounder-contributor/references/plat-ironwood.md
+++ b/.agents/skills/cofounder-contributor/references/plat-ironwood.md
@@ -139,6 +139,14 @@ Review rules:
 - Only use `approve` or `approve_with_followups` when the evidence contract is fully accounted for and unblocked.
 - Separate code-quality feedback from evidence-gate feedback in your review body.
 
+**What this runner can verify.** Reviews run on `ubuntu-latest` — no Swift toolchain, no
+macOS, no app to launch. You can read Swift and reason about it; you cannot build it, run
+`swift test`, or run `mise run lint`. So "this does not compile" is not a claim reading alone
+supports. Check the PR's own check runs first: a green `build-and-test` on the head SHA
+settles it, and is more reliable than a language rule derived by hand. If your reading still
+disagrees with a green lane, report the discrepancy and ask rather than blocking on it — a
+false compile-error block costs the author a round trip and the owner a force-merge (#1286).
+
 ```
 ---
 action: review_pr


### PR DESCRIPTION
## What

Both reviewer personas run through `factory-review-execute.yml` on `ubuntu-latest` — no Swift toolchain, no macOS, no app to launch. Their prompts already carry one version of that limit ("Linux runner cannot launch the macOS app to capture the requested screenshot"), but only for screenshots, and both list `swift test ...` among the things they reason about.

On #1286 the gap produced a blocking review asserting the Swift would not compile, derived by hand from a language rule that does not exist — enums without associated values synthesize `Equatable` unconditionally; SE-0185 is the *with*-associated-values case. The PR's own `build-and-test` was green on that exact head SHA the whole time. It cost a round trip and an owner force-merge.

The `Review a PR` section in both persona files now states what the runner can check, and points at the PR's check runs as cheaper and more reliable than a hand-derived language rule — with the instruction to report a disagreement rather than block on it. The rest of that review was sound: the reviewer traced the new epoch-boundary tests by hand and got them right. The failure was narrow, and so is this fix.

## Evidence Status

Not a testable change — docs-only diff, evidence-exempt per `scripts/pr-readiness.py` (`DOC_EVIDENCE_EXEMPT_SUFFIXES`).

## Mergeability

- Surface: agent-runtime — reviewer persona prompts (`.agents/skills/cofounder-contributor/references/{april-clearwater,plat-ironwood}.md`), `Review a PR` section only.
- User-facing behavior changed: No. Prompt text for the two factory reviewers; no workflow, code, or gate changes.
- Non-happy paths considered: the guidance is advisory rather than a hard rule, so a reviewer that genuinely spots a defect a green lane missed can still say so — it is told to report the discrepancy, not to defer to CI unconditionally. It does not touch the evidence-gate rules that decide verdicts.
- Residual risk or follow-up: the same lane still cannot verify Swift claims, so a reviewer can still be wrong about Swift in a way nothing catches automatically; this makes the limit legible rather than removing it. Whether Swift-touching PRs should route to a macOS reviewer at all is a bigger question left open.