### PR TITLE
docs(perf): localize the #1251 residual to the first surface's time-to-first-byte

### DIFF
--- a/docs/performance/investigation-2026-08-08-launch-bimodality.md
+++ b/docs/performance/investigation-2026-08-08-launch-bimodality.md
@@ -72,11 +72,48 @@ a different window.
 
 The clue worth carrying forward is that **the step size differs by lane while the fast mode
 does not**. The fast mode sits at ~550 ms in both lanes; the slow mode is ~830 ms without
-activation and ~1030 ms with it. A fixed timer would add the same amount in both. A wait on
-an event — the window becoming key, first-responder assignment, surface realization landing
-in a later run-loop pass — would take longer exactly where activation puts more work in
-front of it. That is a hypothesis, not a finding; the next pass instruments the first-layout
-and surface-realization path rather than guessing a fourth time.
+activation and ~1030 ms with it. A fixed timer would add the same amount in both; a wait on
+an event would not.
+
+## Where the step actually is (2026-08-09)
+
+The first-layout hypothesis above is **falsified**, and it did not need new instrumentation
+to falsify — the captures already contained the answer. Every sample in both lanes ends on
+`trigger=terminal_set_title`, so the interval always closes the same way, and aligning a fast
+run's log timeline against a slow one shows them identical to within ~20 ms through
+`surface_create_succeeded`. The entire gap appears afterwards.
+
+Correlating per sample:
+
+| lane | pearson(`launch_to_first_prompt`, first shell's `terminal_first_output`) |
+|---|---|
+| `debug_no_activate` | r = 1.000 (n=10) |
+| `debug_activate` | r = 1.000 (n=10) |
+
+All of the launch variance is the first shell's time to first output. Surface creation itself
+is constant (~390 ms in both modes); the split lives entirely between
+`surface_create_succeeded` and the shell's first byte — ~103 ms in the fast mode against
+~416 ms in the slow one.
+
+Two things narrow it further:
+
+- **The second shell never pays it.** The repo-selection session created ~100 ms later in the
+  same process reaches first output in 89–120 ms (no-activate) and 137–174 ms (activate),
+  every sample, with no bimodality. Whatever this is, it is a first-surface cost.
+- **It is not the shell.** Clean profile mode spawns `/bin/zsh -f` — no rc files at all.
+  Spawning exactly that under a PTY outside the app, 20 samples, gives 7–69 ms with a median
+  of 22 ms and one mode. zsh is three orders away from explaining a 300 ms step.
+
+So the residual is inside the app's own surface-to-first-byte path: after libghostty reports
+the surface created, the first PTY's first byte arrives either ~100 ms or ~420 ms later, and
+only for the first surface of the process. Ruled out at this point: the continuity manifest,
+the bootstrap branch, which path seeded the session, SwiftUI's first layout pass, surface
+creation, machine load, and the shell.
+
+The next probe belongs inside that window — when libghostty actually forks the PTY relative
+to `surface_create_succeeded`, and when its read loop is first scheduled. Distinguishing "the
+child is forked late" from "the child is forked promptly and its output is delivered late"
+is the fork in the road, and neither is observable from the logs the app emits today.
 
 ## Reference consequences
 


### PR DESCRIPTION
## What

The next step this document recommended — instrument the first-layout / surface-realization path — is wrong, and the captures it was written from already contained the refutation. No new instrumentation was needed to find it; the logs were already timestamped.

Every sample in both lanes closes `launch_to_first_prompt` on `trigger=terminal_set_title`, so the interval always ends the same way. Aligning a fast run's log timeline against a slow one shows them identical to within ~20 ms through `surface_create_succeeded`, and the entire gap appears after it. Per sample:

| lane | pearson(`launch_to_first_prompt`, first shell's `terminal_first_output`) |
|---|---|
| `debug_no_activate` | r = 1.000 (n=10) |
| `debug_activate` | r = 1.000 (n=10) |

All of the launch variance is the first shell's time to first output. Surface creation itself is constant (~390 ms in both modes); the split lives between `surface_create_succeeded` and the first byte — ~103 ms fast against ~416 ms slow.

Two facts narrow it to the *first* surface:

- **The second shell never pays it.** The repo-selection session created ~100 ms later in the same process reaches first output in 89–120 ms (no-activate) / 137–174 ms (activate) on every sample, no bimodality.
- **It is not the shell.** Clean mode spawns `/bin/zsh -f` — no rc files. Spawning exactly that under a PTY outside the app gives 7–69 ms over 20 samples, median 22, one mode.

Ruled out across this issue now: the continuity manifest, the bootstrap branch, which path seeded the session, SwiftUI's first layout pass, surface creation, machine load, and the shell.

## Evidence Status

Not a testable change — docs-only diff, evidence-exempt per `scripts/pr-readiness.py` (`DOC_EVIDENCE_EXEMPT_SUFFIXES`). The analysis derives from the capture artifacts recorded in #1286 (`/tmp/workspaces-perf-baseline-20260808-220702` and `-220920`); the correlations and the PTY probe are reproduced in the document itself.

## Mergeability

- Surface: docs — `docs/performance/investigation-2026-08-08-launch-bimodality.md`, one new section plus a corrected closing paragraph.
- User-facing behavior changed: No. Documentation only; no code, harness, or contract changes.
- Non-happy paths considered: n/a for a docs diff. The claim itself is falsifiable — anyone can re-derive the r = 1.000 correlation from the per-sample `terminal_first_output` values in the capture logs, and the PTY probe is 20 lines.
- Residual risk or follow-up: the mechanism inside the surface-to-first-byte window is still unknown, and distinguishing "forked late" from "delivered late" needs instrumentation the app does not have today. #1251 stays open for it.

Refs #1251