### PR TITLE
fix(restore): scope the pre-restore tmux kill to sessions this launch holds

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2491,6 +2491,12 @@ struct ContentView: View {
         // pre-restore seed (the default-home fallback) left on those keys, so a
         // resume/reattach surface is created fresh and the coordinator's key-reuse
         // path can't drop its initial command.
+        // Read before retiring: these are the tmux names this launch is holding, and they are
+        // what makes a kill below attributable. After the retire loop the sessions are gone and
+        // the app can no longer tell its own seed from a stranger's session on the shared
+        // socket (#1267).
+        let ownedTmuxSessionNames = Set(tileTreeStore.sessions.map(\.effectiveTmuxSessionName))
+
         for key in restoreController.ownedSessionKeys(in: plan) {
             _ = tileTreeStore.retireSessions(inScope: key)
         }
@@ -2502,7 +2508,16 @@ struct ContentView: View {
         // the retired seed's leftover shell. Names another surface reattaches to
         // are excluded by the controller (#1233).
         let tmuxProbe = TmuxSessionProbe()
-        for sessionName in restoreController.tmuxSessionNamesToKill(in: plan) {
+        let teardownScope = restoreController.tmuxSessionNamesToKill(
+            in: plan,
+            ownedTmuxSessionNames: ownedTmuxSessionNames
+        )
+        for sessionName in teardownScope.skippedUnowned {
+            restoreLog.info(
+                "[Restore] leaving tmux session \(sessionName, privacy: .public) alone: this launch did not create it"
+            )
+        }
+        for sessionName in teardownScope.kill {
             await tmuxProbe.killSession(sessionName)
         }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowRestoreController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowRestoreController.swift
@@ -87,27 +87,49 @@ struct MainWindowRestoreController {
         Set(plan.surfaces.map(\.key))
     }
 
-    /// Tmux session names to kill before restore. The planner only chose resume because the
-    /// prior tmux session is gone, so a live session on the resume surface's directory-derived
-    /// name can only be this launch's seed artifact — killing it stops the resume surface
-    /// `-A`-attaching to a leftover shell instead of starting fresh. A name another surface is
-    /// reattaching to is never killed: a resume and a reattach surface can share a directory,
-    /// and the derived name would then be the reattach target (#1233).
+    /// How the pre-restore tmux pass is split: what may die, and what was left alone because
+    /// this launch cannot claim it.
+    struct TmuxTeardownScope: Equatable {
+        let kill: [String]
+        let skippedUnowned: [String]
+    }
+
+    /// Tmux session names to kill before restore, scoped to sessions this launch owns.
+    ///
+    /// Killing exists so a resume surface starts fresh instead of `-A`-attaching to the shell
+    /// its pre-restore seed left behind. The candidate name is the resume surface's directory
+    /// derivation, and that derivation is the whole problem: `-L workspaces` is a same-user
+    /// shared socket, so the same name can equally belong to a session a person or another
+    /// tool started. The planner concluded "the prior tmux session is gone" at plan time from
+    /// recorded continuity rows, which says nothing about who holds that name now (#1267).
+    ///
+    /// So a candidate only dies when it matches a session this launch is holding —
+    /// `ownedTmuxSessionNames`, the effective names of the sessions about to be retired.
+    /// Everything else is reported in `skippedUnowned` for the caller to log and left running.
+    ///
+    /// A name another surface is reattaching to is never a candidate at all: a resume and a
+    /// reattach surface can share a directory, and the derived name would then be the reattach
+    /// target (#1233).
     func tmuxSessionNamesToKill(
         in plan: RestorePlan,
+        ownedTmuxSessionNames: Set<String>,
         sessionName: (URL) -> String = { GhosttyTerminalConfig.tmuxSessionName(for: $0) }
-    ) -> [String] {
+    ) -> TmuxTeardownScope {
         let reattachTargets = Set(
             plan.surfaces.compactMap { surface -> String? in
                 guard case .reattachTmux(let name) = surface.action else { return nil }
                 return name
             }
         )
-        return plan.surfaces.compactMap { surface in
+        let candidates = plan.surfaces.compactMap { surface -> String? in
             guard case .resumeClaude = surface.action else { return nil }
             let name = sessionName(surface.directory)
             return reattachTargets.contains(name) ? nil : name
         }
+        return TmuxTeardownScope(
+            kill: candidates.filter { ownedTmuxSessionNames.contains($0) },
+            skippedUnowned: candidates.filter { !ownedTmuxSessionNames.contains($0) }
+        )
     }
 
     /// The directory-derived tmux names resume surfaces will `new-session -A`-launch on.

--- a/Tests/WorkspaceManagerAppTests/MainWindowRestoreControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowRestoreControllerTests.swift
@@ -258,7 +258,10 @@ struct MainWindowRestoreControllerTests {
             surface(action: .resumeClaude(agentSessionID: "c"), directory: second),
         ])
 
-        let names = controller.tmuxSessionNamesToKill(in: target) { "wm-\($0.lastPathComponent)" }
+        let names = controller.tmuxSessionNamesToKill(
+            in: target,
+            ownedTmuxSessionNames: ["wm-alpha", "wm-beta"]
+        ) { "wm-\($0.lastPathComponent)" }.kill
 
         #expect(names == ["wm-alpha", "wm-alpha", "wm-beta"])
     }
@@ -275,7 +278,10 @@ struct MainWindowRestoreControllerTests {
                 directory: URL(fileURLWithPath: "/Users/dev/code/gamma")),
         ])
 
-        let names = controller.tmuxSessionNamesToKill(in: target) { "wm-\($0.lastPathComponent)" }
+        let names = controller.tmuxSessionNamesToKill(
+            in: target,
+            ownedTmuxSessionNames: ["wm-alpha", "wm-beta", "wm-gamma"]
+        ) { "wm-\($0.lastPathComponent)" }.kill
 
         #expect(names == ["wm-beta"])
     }
@@ -284,7 +290,16 @@ struct MainWindowRestoreControllerTests {
     func noResumeSurfacesKillNothing() {
         let target = plan([surface(action: .freshShell), surface(action: .reattachTmux(sessionName: "x"))])
 
-        #expect(controller.tmuxSessionNamesToKill(in: target).isEmpty)
+        // Both halves, and a permissive owned set: with an empty set a mutation that treated
+        // fresh/reattach surfaces as candidates would hide them in `skippedUnowned` and still
+        // pass on `kill` alone.
+        let scope = controller.tmuxSessionNamesToKill(
+            in: target,
+            ownedTmuxSessionNames: ["wm-x", "wm-alpha", "x"]
+        ) { "wm-\($0.lastPathComponent)" }
+
+        #expect(scope.kill.isEmpty)
+        #expect(scope.skippedUnowned.isEmpty)
     }
 
     /// The #1233 acceptance criterion: a resume and a reattach surface can share a directory,
@@ -300,10 +315,55 @@ struct MainWindowRestoreControllerTests {
                 directory: URL(fileURLWithPath: "/Users/dev/code/beta")),
         ])
 
-        let names = controller.tmuxSessionNamesToKill(in: target) { "wm-\($0.lastPathComponent)" }
+        let names = controller.tmuxSessionNamesToKill(
+            in: target,
+            ownedTmuxSessionNames: ["wm-alpha", "wm-beta"]
+        ) { "wm-\($0.lastPathComponent)" }.kill
 
         #expect(names == ["wm-beta"])
         #expect(!names.contains("wm-alpha"))
+    }
+
+    /// `-L workspaces` is a same-user shared socket and the candidate name is a directory
+    /// derivation, so the same name can belong to a session a person or another tool started.
+    /// This launch may only kill what it is holding (#1267).
+    @Test("A session this launch does not own survives the pre-restore kill pass")
+    func unownedSessionIsNotKilled() {
+        let target = plan([
+            surface(
+                action: .resumeClaude(agentSessionID: "a"),
+                directory: URL(fileURLWithPath: "/Users/dev/code/alpha"))
+        ])
+
+        let scope = controller.tmuxSessionNamesToKill(
+            in: target,
+            ownedTmuxSessionNames: []
+        ) { "wm-\($0.lastPathComponent)" }
+
+        #expect(scope.kill.isEmpty)
+        #expect(scope.skippedUnowned == ["wm-alpha"])
+    }
+
+    /// The other half of the acceptance: scoping to owned names must not stop the pass from
+    /// reclaiming this launch's own seed, which is the reason the kill exists at all.
+    @Test("This launch's own seed is still reclaimed alongside a foreign session")
+    func ownedSeedIsStillKilledWhileForeignSurvives() {
+        let target = plan([
+            surface(
+                action: .resumeClaude(agentSessionID: "a"),
+                directory: URL(fileURLWithPath: "/Users/dev/code/alpha")),
+            surface(
+                action: .resumeClaude(agentSessionID: "b"),
+                directory: URL(fileURLWithPath: "/Users/dev/code/beta")),
+        ])
+
+        let scope = controller.tmuxSessionNamesToKill(
+            in: target,
+            ownedTmuxSessionNames: ["wm-beta"]
+        ) { "wm-\($0.lastPathComponent)" }
+
+        #expect(scope.kill == ["wm-beta"])
+        #expect(scope.skippedUnowned == ["wm-alpha"])
     }
 
     /// Reattach surfaces launch on the name that was probed alive, so a directory fallback


### PR DESCRIPTION
## What

The pre-restore pass killed the directory derivation of every resume surface's tmux name. That derivation is deterministic and `-L workspaces` is a same-user shared socket, so the name it computes can equally belong to a session a person or another tool started — which is what the wave-3 gate saw when a hand-made session died during startup.

The code stated the assumption that made it safe: *"the planner only chose resume because the prior tmux session is gone, so a live session on the resume surface's deterministic name can only be this launch's seed artifact."* The planner reached that at plan time from recorded continuity rows; it says nothing about who holds the name at kill time. Now it's checked instead of asserted — `executeRestore` reads the effective tmux names of the sessions it is holding before retiring them, and `tmuxSessionNamesToKill` intersects its candidates with that set. What the launch can't claim comes back as `skippedUnowned` and is logged, not killed. The seed the pass exists to reclaim still dies.

One correction to the issue's framing: there is no socket-wide sweep. `list-sessions` appears nowhere in `Sources/`, and this pass is the only launch-time kill. The effect was real; the mechanism was narrower.

## This is partial — `Refs`, not `Closes`

Codex's review caught the hole, and it matters: **a name is not proof of creation.** A seed launched with `new-session -A` on a name a foreign session already holds *adopts* that session, and its name then enters the owned set — re-authorizing the kill this PR is meant to prevent. So the reported scenario survives in the narrower case where the hand-made session's name collides with a directory the app opens.

Closing it needs creation provenance — a per-launch ownership token, or capturing the tmux session id at creation and killing by `=$id` rather than by name. That's a larger change than this seam and belongs in its own pass. The issue stays open for it.

Two related paths are unproven the same way and are **out of scope here** (pre-existing, not touched by this diff): `WorkspaceTerminalTeardownController.swift:63` authorizes on mode + non-remoteness, and `TileTreeStore.swift:1003` on a non-default override + tmux mode. Neither establishes creation ownership. Worth one issue covering all three once the provenance mechanism exists.

## Evidence

![teardown-scoping](https://evidence.cloudcompute.com/workspaces/pr-1291/20260810-024806-teardown-scoping.png)

`swift test --filter MainWindowRestoreController` — 29 tests passed. `mise run lint` exit 0. Mutation check: dropping the ownership intersection fails exactly the two new tests.

The live run is a **negative control, not proof of the fix** — a bystander session on the socket survived a real 14-second launch, but with no resume plan staged the kill path never ran, so it confirms the absence of a socket-wide sweep rather than the scoping. Exercising the kill path live needs a staged continuity fixture with a `resumeClaude` surface whose derivation collides with a foreign name; that belongs at a wave gate, as the issue says.

## Review loop

Directed codex (gpt-5.6-sol, xhigh).

| Finding | Disposition |
|---|---|
| Owned set proves naming, not creation — `-A` adoption re-authorizes the kill (High) | Accepted, not fixed. Downgraded this PR to `Refs`, documented above and on the issue; needs creation provenance |
| Owned set can be incomplete — a seed retired before restore is missed, so `--resume` gets suppressed (Medium) | Accepted as a known limit of a snapshot-based set; same ledger fix. No regression versus today, where that name was killed on a guess |
| Name-reuse ABA across the awaited kills (Medium) | Accepted; same fix — target a stable session id, not a name |
| New tests inject the owned set, so they don't bind the production wiring (Medium) | Acknowledged. Binding it needs an injectable seam in `executeRestore` (sessions, mux mode, probe); noted as follow-up rather than reshaped here |
| `noResumeSurfacesKillNothing` weakened by an empty owned set (Low) | **Fixed** — permissive set, asserts both `kill` and `skippedUnowned` empty |

## Mergeability

- **Surface**: desktop — `MainWindowRestoreController.tmuxSessionNamesToKill` (now returns a `TmuxTeardownScope`), its `ContentView.executeRestore` caller, and the controller's tests.
- **User-facing behavior changed**: on cold-start restore, a tmux session whose name matches a resume surface's directory derivation is left running unless this launch is holding a session with that name. Previously it was killed unconditionally. A logged `[Restore] leaving tmux session … alone` line records each skip.
- **Non-happy paths considered**: no resume surfaces → nothing killed, as before; a reattach target sharing a directory with a resume surface is still excluded before ownership is considered (#1233); a session created after the snapshot is not in the owned set, so it survives — the safe direction; with multiplexing off, `effectiveTmuxSessionName` names sessions that don't exist and the kills are no-ops.
- **Residual risk or follow-up**: the `-A` adoption hole above, which is the reason this doesn't close #1267; a seed retired before restore is no longer killed, so a resume surface could attach to its leftover shell rather than starting fresh (previously killed on an unchecked guess — different failure, not a worse one, and the same ledger closes both).

Refs #1267
