### PR TITLE
chore(ci): retire the lume-macos lane — agent evidence moves to hosted macos-15

### DIFF
--- a/.agents/skills/cofounder-contributor/SKILL.md
+++ b/.agents/skills/cofounder-contributor/SKILL.md
@@ -53,7 +53,7 @@ uv run .agents/skills/cofounder-contributor/scripts/run-contributor.py \
 
 ## Evidence upload
 
-When running on the `lume-macos` runner (macOS VM), agents can capture and upload screenshots as PR evidence:
+When running on a macOS runner with a GUI session — the `gather` job in `_evidence.yml` on hosted `macos-15` — agents can capture and upload screenshots as PR evidence:
 
 ```bash
 # Capture a screenshot

--- a/.agents/skills/self-hosted-runners/SKILL.md
+++ b/.agents/skills/self-hosted-runners/SKILL.md
@@ -2,27 +2,34 @@
 name: self-hosted-runners
 description: >
   Inspect, recover, and operate this repo's self-hosted GitHub Actions
-  runners across the signing-host and lume-macos lanes.
+  runners on the signing-host lane.
   Use when jobs are queued, runners show offline or busy unexpectedly,
-  release jobs do not start, a Lume runner VM needs recovery, or when
-  you need a host fallback runner on the current machine.
+  release jobs do not start, or when you need a host fallback runner on
+  the current machine.
 ---
 
 # Self-Hosted Runners
 
 Use this skill when the problem is runner health, scheduling, or lane ownership rather than repo code.
 
-This repo has two self-hosted lanes:
+This repo has one self-hosted lane:
 
 - `signing-host` for release signing and notarization
-- `lume-macos` for macOS CI and agent execution
 
-Two things that used to be self-hosted no longer are, so do not go looking for a
-lane when one of these is the real question. Behavioral UI smoke runs on
-GitHub-hosted `macos-15` (`ui-smoke-advisory.yml`). Perf benchmarks run on the
+Everything else that used to be self-hosted no longer is, so do not go looking
+for a lane when one of these is the real question. Behavioral UI smoke runs on
+GitHub-hosted `macos-15` (`ui-smoke-advisory.yml`). Agent evidence — the
+`gather` job in `_evidence.yml` — runs on hosted `macos-15` too; the
+`lume-macos` VM lane that once carried it is retired. Perf benchmarks run on the
 owner's laptop, opt-in per approved session
 (`docs/decisions/perf-measurement-laptop-optin.md`) — the `tart-ui` lane that
-once carried both is retired.
+once carried those is retired as well.
+
+`.github/actionlint.yaml` lists the only labels a workflow may target, so a
+reach for a retired lane fails lint rather than queueing against nothing.
+
+Run `./scripts/runners.py` to see every runner on the current machine with its
+local config, launchd state, and GitHub registration reconciled.
 
 ## Quick Start
 
@@ -39,38 +46,18 @@ Include one specific run when a queued or failed run is the immediate problem:
   --run-id 24034959203
 ```
 
-Probe the `lume-macos` guest directly over SSH:
-
-```bash
-./.agents/skills/self-hosted-runners/scripts/probe_lume_runner_guest.py
-```
-
-If `lume get` does not report the guest IP but direct SSH is known to work:
-
-```bash
-./.agents/skills/self-hosted-runners/scripts/probe_lume_runner_guest.py \
-  --ip 192.168.8.233
-```
-
-If you already know the lane is `lume-macos`, use the Lume guest probe before guessing.
-
 ## Workflow
 
 ### 1. Inspect the current lane state
 
 - Run `summarize_runner_state.py` first.
-- Identify which lane is actually blocked: `signing-host` or `lume-macos`.
+- `signing-host` is the only lane, so a blocked job is either that lane or not a
+  lane problem at all. A job queued against any other label is a workflow bug —
+  check `.github/actionlint.yaml`.
 - If a specific run is queued or failed, pass `--run-id`.
 - Read [references/recovery-order.md](references/recovery-order.md) for the standard recovery order.
 
 ### 2. Recover the lane with the smallest safe change
-
-For `lume-macos`:
-
-1. Confirm the VM exists and is running.
-2. Probe the guest over SSH with `probe_lume_runner_guest.py`.
-3. If the guest runner registration is stale, re-register it.
-4. If the guest is missing Xcode or is otherwise not build-ready, stop using it for CI and switch to a host fallback runner.
 5. If a host fallback runner goes online and then flips offline while the local process is still alive, treat that as a host-side communication problem rather than a repo problem.
 
 For `signing-host`:
@@ -81,13 +68,13 @@ For `signing-host`:
 
 ### 3. Use the lane-specific repo runbooks
 
-Primary docs:
+Primary doc:
 
-- `docs/development/lume-runner-setup.md`
 - `docs/development/signing-runner-setup.md`
 
-`docs/development/tart-runner-setup.md` is archival — the lane it provisions is
-retired. Read it only if a Tart lane is being stood up from scratch again.
+`docs/development/lume-runner-setup.md` and `docs/development/tart-runner-setup.md`
+are archival — both lanes they provision are retired. Read them only if a VM lane
+is being stood up from scratch again.
 
 Use the skill scripts to narrow the failure mode first, then jump into the lane-specific doc section you need.
 
@@ -100,11 +87,9 @@ Important patterns:
 - `registration has been deleted`: the runner must be re-registered
 - `A session for this runner already exists`: a stale session or a still-running local process is blocking a new listener
 - `online` then `offline` while `busy`: likely host-side communication loss, not a simple label problem
-- `xcode-select` points to Command Line Tools and no `Xcode.app` exists: the Lume guest is not build-ready for macOS CI
 
 ### 5. Prefer stable recovery paths
 
-- Prefer direct SSH into the Lume guest once passwordless SSH works.
 - Prefer a fresh host fallback runner name and directory over trying to salvage a strange local runner state.
 - Prefer proving that a runner can stay online and accept one job before relying on it for release work.
 
@@ -119,17 +104,15 @@ Use for host-plus-GitHub runner triage.
 - optionally summarizes one specific run's jobs
 - inspects known local runner directories and recent diagnostic signatures
 
-### `probe_lume_runner_guest.py`
+### `runners.py`
 
-Use for `lume-macos` guest recovery.
-
-- checks VM state from `lume get`
-- connects over direct SSH when an IP is available
-- reports guest OS, Xcode readiness, runner service state, and recent guest runner log signatures
+Use for a full picture of every runner on the current machine: `./scripts/runners.py`.
+Reconciles local `.runner` config, launchd state, and GitHub registration, and
+reports a runner as dead when launchd has given up on it permanently.
 
 ## Guardrails
 
 - Do not assume queued means "no runner exists". A runner can be online briefly, accept a session, then lose communication.
-- Do not keep rerunning jobs on a Lume guest that is missing Xcode.
+- Do not stand a VM lane back up to fix a queued job. Both VM lanes are retired; a job queued against one is a workflow bug, not a runner outage.
 - Do not keep reusing a host fallback runner name that has session-conflict behavior. Register a fresh runner name if needed.
 - When a runner process is alive locally but GitHub shows it offline, classify that as a host-side problem first.

--- a/.agents/skills/self-hosted-runners/agents/openai.yaml
+++ b/.agents/skills/self-hosted-runners/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Self-Hosted Runners"
-  short_description: "Inspect and recover this repo's signing-host and lume-macos lanes."
+  short_description: "Inspect and recover this repo's signing-host lane."
   default_prompt: "Use $self-hosted-runners to inspect the current GitHub runner inventory, classify which lane is blocked, recover the smallest viable runner path, and explain the next action."

--- a/.agents/skills/self-hosted-runners/references/recovery-order.md
+++ b/.agents/skills/self-hosted-runners/references/recovery-order.md
@@ -16,34 +16,40 @@ Questions to answer first:
 - Which labels does that job require?
 - Which runners advertise those labels right now?
 
-## 2. Prefer the native lane first
+## 2. Confirm the job targets a lane that still exists
 
-For `lume-macos`, try the Lume guest first:
+`signing-host` is the only self-hosted lane. `lume-macos` and `tart-ui` are both
+retired and `.github/actionlint.yaml` rejects them, so a job waiting on either is
+a workflow bug — fix the workflow rather than standing a VM back up.
+
+For a fuller local picture than `summarize_runner_state.py` gives:
 
 ```bash
-uv run --script .agents/skills/self-hosted-runners/scripts/probe_lume_runner_guest.py
+./scripts/runners.py
 ```
 
-If the guest is healthy, keep the lane on the VM.
+It reconciles local runner config, launchd, and GitHub registration, and reports
+`dead` when launchd has permanently given up on a runner.
 
 ## 3. Re-register stale runners instead of poking blindly
 
 If the logs say the registration was deleted, do not just restart the listener. Re-register it with a fresh token.
 
+GitHub deletes registrations for runners that have not connected recently, so an
+idle lane can die on its own and stay dead — launchd logs `no retry needed` and
+never restarts it.
+
 ## 4. Verify build readiness before rerunning CI
 
-For `lume-macos`, verify:
+For `signing-host`, verify:
 
-- SSH works
 - the runner service can start
 - `xcodebuild -version` works
 - `xcode-select -p` points at a real Xcode app
 
-If those fail, do not rerun the workflow on that guest.
+If those fail, do not rerun the workflow on that host.
 
-## 5. Use a host fallback only when the native lane is not viable
-
-If the Lume guest is not build-ready, register a fresh host fallback runner with a fresh name and the `lume-macos` label.
+## 5. Use a fresh host runner rather than salvaging a strange one
 
 Prefer a fresh directory and name over reusing a strange local runner state.
 

--- a/.claude/commands/april.md
+++ b/.claude/commands/april.md
@@ -1,10 +1,10 @@
-We're building a team of AI agents that contribute to this codebase autonomously. April is our first agent — she picks up issues, writes code, produces evidence, and opens PRs. She runs on a Lume macOS VM on this laptop via a GitHub Actions self-hosted runner (`lume-macos`).
+We're building a team of AI agents that contribute to this codebase autonomously. April is our first agent — she picks up issues, writes code, produces evidence, and opens PRs. She runs on GitHub-hosted `macos-15`; the `lume-macos` VM lane she used to run on is retired.
 
 Start by getting oriented:
 
 1. Check April's last 5 runs: `gh run list --repo fairchild/workspaces --workflow "Agent: April Clearwater" --limit 5`
 2. Check open PRs: `gh pr list --repo fairchild/workspaces --state open`
 3. Check issues ready for agents: `gh issue list --repo fairchild/workspaces --label agent:ready`
-4. Check the Lume runner is online: `gh api repos/fairchild/workspaces/actions/runners --jq '.runners[] | select(.labels[].name == "lume-macos") | {name, status}'`
+4. Check runner health on this machine: `./scripts/runners.py` (April needs no self-hosted runner, but a dead `signing-host` still blocks releases)
 
 Then summarize: what's working, what's stuck, what to focus on next. Fix any failures, merge what's ready, and suggest what to trigger or unblock.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,9 +1,10 @@
-# Only lanes that workflows may legitimately target. `tart-ui` is absent on
-# purpose: the lane is retired (docs/decisions/perf-measurement-laptop-optin.md),
-# so actionlint now flags any workflow that reaches for it again.
+# Only lanes that workflows may legitimately target. `tart-ui` and `lume-macos`
+# are absent on purpose: both lanes are retired (tart-ui per
+# docs/decisions/perf-measurement-laptop-optin.md, lume-macos per #1288
+# follow-up — agent evidence moved to hosted macos-15), so actionlint now flags
+# any workflow that reaches for either again.
 self-hosted-runner:
   labels:
-    - lume-macos
     - signing-host
 
 config-variables: null

--- a/.github/workflows/_evidence.yml
+++ b/.github/workflows/_evidence.yml
@@ -56,8 +56,14 @@ permissions:
 
 jobs:
   gather:
-    runs-on: [self-hosted, lume-macos]
-    timeout-minutes: 20
+    # Hosted, not self-hosted: the lume-macos lane is retired. Build and test
+    # are already proven on this image by ci-fallback.yml. The screenshot step
+    # below has not run on a hosted session before — it stays continue-on-error
+    # so evidence degrades to build+test rather than failing the job.
+    runs-on: macos-15
+    # Sized for a cold hosted image, not a warm local runner. ci-fallback.yml
+    # budgets 90 for the same build; 60 covers gather's narrower step list.
+    timeout-minutes: 60
     outputs:
       build_succeeded: ${{ steps.ghosttykit.outcome == 'success' && steps.build.outcome == 'success' }}
       tests_succeeded: ${{ inputs.test_commands_json == '[]' || steps.tests.outcome == 'success' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Rules: no local-only proof (upload via `evidence.sh`); blocked evidence is an ex
 
 ## High-Signal Lessons (unconditional)
 
-- **Never use bare `self-hosted` for workflows in this repo.** Use GitHub-hosted macOS (`macos-15`) for generic build/test jobs and for the UI smoke lane (`ui-smoke-advisory.yml`), `[self-hosted, lume-macos]` for agent execution (preferred, with ubuntu-latest fallback), and `[self-hosted, signing-host]` for release/signing/notarization. Perf benchmarks are not a CI lane: they run laptop-local, opt-in per run, per `docs/decisions/perf-measurement-laptop-optin.md`.
+- **Never use bare `self-hosted` for workflows in this repo.** Use GitHub-hosted macOS (`macos-15`) for generic build/test jobs, for the UI smoke lane (`ui-smoke-advisory.yml`), and for agent evidence (`_evidence.yml`); use `[self-hosted, signing-host]` for release/signing/notarization. `signing-host` is the only self-hosted lane — `lume-macos` and `tart-ui` are retired and `.github/actionlint.yaml` rejects them. Perf benchmarks are not a CI lane: they run laptop-local, opt-in per run, per `docs/decisions/perf-measurement-laptop-optin.md`.
 - **Ship a diagnostic probe instead of your third guess.** When you're guessing, stop and instrument.
 - **The tracker lags the code — verify before planning from it.** Before sequencing work from open issues, `rg` the acceptance criteria against the tree; close what's done in the same cycle that ships it (`Closes #N` in every implementing PR).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ workspaces/
 
 ## CI Runner Lanes
 
-Generic lint/build/test CI runs on GitHub-hosted macOS (`macos-15`) and is path-scoped to product, test, build, and release inputs so docs, backlog, skill, and changelog-only pushes do not consume the hosted macOS queue. The behavioral UI smoke lane (`ui-smoke-advisory.yml`) runs on the same hosted `macos-15` image. Self-hosted jobs must use explicit lanes: `[self-hosted, lume-macos]` for agent execution and `[self-hosted, signing-host]` for release/signing/notarization.
+Generic lint/build/test CI runs on GitHub-hosted macOS (`macos-15`) and is path-scoped to product, test, build, and release inputs so docs, backlog, skill, and changelog-only pushes do not consume the hosted macOS queue. The behavioral UI smoke lane (`ui-smoke-advisory.yml`) and the agent evidence lane (`_evidence.yml`) run on the same hosted `macos-15` image. Self-hosted work uses one explicit lane: `[self-hosted, signing-host]` for release/signing/notarization.
 
 Performance benchmarks are not a CI lane. They run on the owner's laptop, opt-in per run, because the contract budgets are `Mac16,13`-derived and no cloud runner can carry them — see [docs/decisions/perf-measurement-laptop-optin.md](./docs/decisions/perf-measurement-laptop-optin.md) for the protocol and the measurement-hygiene preconditions.
 

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -4,7 +4,7 @@ Master record of hard-won, repo-wide lessons: full statement, rationale, and his
 
 ## Unconditional — fire from root `AGENTS.md`
 
-- **Never use bare `self-hosted` for workflows in this repo.** Use GitHub-hosted macOS (`macos-15`) for generic build/test jobs and for the UI smoke lane (`ui-smoke-advisory.yml`), `[self-hosted, lume-macos]` for agent execution (preferred, with ubuntu-latest fallback), and `[self-hosted, signing-host]` for release/signing/notarization. Perf benchmarks are not a CI lane: they run laptop-local, opt-in per run, per `docs/decisions/perf-measurement-laptop-optin.md`.
+- **Never use bare `self-hosted` for workflows in this repo.** Use GitHub-hosted macOS (`macos-15`) for generic build/test jobs, for the UI smoke lane (`ui-smoke-advisory.yml`), and for agent evidence (`_evidence.yml`); use `[self-hosted, signing-host]` for release/signing/notarization. `signing-host` is the only self-hosted lane — `lume-macos` and `tart-ui` are retired and `.github/actionlint.yaml` rejects them. Perf benchmarks are not a CI lane: they run laptop-local, opt-in per run, per `docs/decisions/perf-measurement-laptop-optin.md`.
 - **Ship a diagnostic probe instead of your third guess.** Terminal arc #306→#309: two guess-fixes merged green and failed in production; one temporary probe (#308) revealed the root cause in a single ship cycle. When you're guessing, stop and instrument.
 - **The tracker lags the code — verify before planning from it.** Three grooming/planning passes in a row (2026-06-28 ×2, 2026-07-02) found open issues whose work had already shipped. Before sequencing work from open issues, `rg` the acceptance criteria against the tree; close what's done in the same cycle that ships it (`Closes #N` in every implementing PR).
 

--- a/docs/development/lume-integration.md
+++ b/docs/development/lume-integration.md
@@ -167,7 +167,7 @@ This note exists because the raw SwiftPM output has behaved differently from the
 
 ## Daemon Reliability
 
-The Lume daemon (`com.trycua.lume_daemon`) must be running for CI, agent workflows, and the app's VM features to work. Without a keepalive mechanism, daemon outages are silent — CI jobs queue indefinitely on the `lume-macos` runner.
+The Lume daemon (`com.trycua.lume_daemon`) must be running for the app's VM features to work. Without a keepalive mechanism, daemon outages are silent. CI no longer depends on it: the `lume-macos` runner lane is retired and agent evidence runs on hosted `macos-15`.
 
 ### LaunchAgent with KeepAlive
 


### PR DESCRIPTION
## Why

The four `lume-macos` runners died on 2026-07-27: GitHub deleted their registrations during an idle stretch, launchd logged *"Runner listener exit with terminated error, stop the service, no retry needed"*, and never restarted them. **Nobody noticed for four weeks.**

They stayed invisible because their only consumer — the `gather` job in `_evidence.yml` — has evaluated to `skipped` on every trigger since. `factory-implement.yml` and `agent-executor.yml` fire constantly; `gather` has not run once. A dormant job pointed at a dead label is a trap that springs the first time the condition passes, and then the job queues against a label no runner advertises until it times out.

This also closes a loop #1280 opened. That PR retired the `tart-ui` VM lane when perf moved laptop-opt-in. `lume-macos` was the other VM lane. After this, **`signing-host` — a native runner — is the only self-hosted lane left.**

## What changes

**`gather` moves to `macos-15`.** Build and test are already proven on that image by `ci-fallback.yml`, which builds this app there today. The screenshot step is the one genuine unknown: `dev-smoke.sh` launches the app, requires a visible window, and captures it, which has never run on a hosted session. It stays `continue-on-error: true` behind `needs_screenshot_evidence`, so if hosted macOS can't do it, evidence degrades to build+test rather than the job failing.

Considered and rejected: **Xcode Cloud**. It's already wired up here and `ci_pre_xcodebuild.sh` genuinely runs lint, `swift build`, `swift build -c release`, and `swift test` — so it covers the build/test evidence. But it builds `WorkSpacesXcodeCloudHarness.framework`, a deliberately inert harness, so it structurally cannot launch a window or screenshot anything. It also can't be a `runs-on:` target. It remains a useful independent build/test signal; it can't replace `gather`.

**Timeout 20 → 60.** Twenty minutes was sized for a warm local runner. `ci-fallback.yml` budgets 90 for a broader step list, so 60 covers `gather`.

**`lume-macos` struck from `.github/actionlint.yaml`** — the same guard `tart-ui` got, so reaching for the lane again fails lint instead of queueing against nothing.

**Docs follow the code.** The `self-hosted-runners` skill described `lume-macos` as a live lane with VM recovery instructions and an SSH probe. That is exactly what a future agent would have read while chasing a job queued against runners that no longer exist — the same silent-staleness this whole thread has been about. Also updated: `AGENTS.md`, `CONTRIBUTING.md`, `docs/agents/lessons.md`, `recovery-order.md`, `cofounder-contributor`, `.claude/commands/april.md` (which told the reader to check a Lume runner's status), and the CI claim in `docs/development/lume-integration.md`.

Left alone deliberately: `README.md`, `docs/development/lume-*.md`, and `mise run dev-lume-macos-smoke`. Those are the **product's** Lume VM features, not the CI lane. `docs/development/lume-runner-setup.md` is kept and marked archival, matching how #1280 treated `tart-runner-setup.md`. `probe_lume_runner_guest.py` is also kept rather than deleted, per the 2026-08-02 parked-scripts decision — say the word if you'd rather it go.

## Local cleanup (already done, reversible)

The four dead LaunchAgents are unloaded and only `blue-workspaces` remains loaded. Their plists plus nine retired VM runner directories (7 lume, 2 tart-ui) are archived at `~/.local/share/retired-runners-20260809` — **10 GB**, moved not deleted, so `_diag` forensics survive. Deleting it is one `rm -rf` whenever you're satisfied.

`./scripts/runners.py` before and after:

```
before:  1 live · 4 dead · 7 stale dirs · 12 total     exit 1
after:   1 live · 0 dead · 2 stale dirs · 3 total      exit 0
```

The two remaining stale directories are `fairchild/services` and `fairchild/code-cadence` — different repos, untouched, flagged rather than assumed.

Worth noting from the after-run: `blue-workspaces` now shows `last job 1h ago`, not 29 days. The v0.24.0 release ran through it while this work was in progress, which independently confirms the signing lane, the job hooks, and the activity log are all live.

## Testing

- The `scripts/tests/*.py` suite still passes — CI's `test` job is green on this PR, and no test changed here.
- `actionlint` passes. The two `SC2129` style notes in `release.yml` are **pre-existing on `main`** (verified by running actionlint on `main`: same 2).
- Guard verified by mutation: temporarily reintroducing `runs-on: [self-hosted, lume-macos]` makes actionlint reject it — *"label 'lume-macos' is unknown… signing-host"* — then removed.
- `scripts/check-markdown-links.py` passes — 808 files, no broken relative links.
- YAML parse-checked: `gather` resolves to `runs-on: macos-15`, `timeout-minutes: 60`, actionlint labels `['signing-host']`.
- No workflow behavior is exercised by this PR beyond lint, since `gather` is dormant; the first real hosted run will be whenever the factory wakes.

## Mergeability

- Surface: infra — CI lane topology and the agent-facing runner docs. No product code.
- User-facing behavior changed: No app-facing change. For CI, agent evidence builds move from a dead self-hosted VM lane to hosted `macos-15`; screenshot evidence may or may not survive that move and degrades gracefully if not.
- Non-happy paths considered: hosted macOS can't run `dev-smoke.sh` (step is `continue-on-error` behind a flag — evidence degrades to build+test); hosted build exceeds 20 min (timeout raised to 60); someone reaches for the retired label again (actionlint rejects it, verified); the archived runners are needed back (moved not deleted, 10 GB recoverable in place); `signing-host` unaffected and confirmed live by the v0.24.0 release.
- Residual risk or follow-up: `gather` is dormant, so this is unexercised until the factory runs — the first hosted run is where screenshot evidence gets its real answer. Deferred: job hooks are wired on only 1 of the 3 remaining runner dirs and record no conclusion or duration; the 10 GB archive still needs a deliberate delete; `fairchild/services` and `fairchild/code-cadence` have stale runner dirs that are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
