### PR TITLE
feat(release): gate on committed perf benchmarks, pin mise, run hosted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,11 @@ permissions:
 
 jobs:
   build-sign-notarize-release:
-    # Release signing/notarization stays on the dedicated signing lane so it
-    # never contends with generic CI or Tart UI automation.
-    runs-on: [self-hosted, signing-host]
+    # Hosted. Signing and notarization take every credential from repository
+    # secrets — the certificate is imported into a temporary keychain created
+    # and destroyed by this job — so nothing here depends on a particular
+    # machine's login keychain.
+    runs-on: macos-15
     environment: release
     timeout-minutes: 120
     permissions:
@@ -103,8 +105,7 @@ jobs:
           if command -v mise >/dev/null 2>&1; then
             mise --version
           else
-            echo "::error::mise is required on the signing host; install it out of band before running release"
-            exit 1
+            brew install mise
           fi
 
       - name: Build GhosttyKit
@@ -240,16 +241,13 @@ jobs:
       - name: Verify signed app bundle
         run: ./scripts/verify-release-bundle.sh build/WorkSpaces.app
 
-      - name: Verify installed-build release performance
-        run: ./scripts/verify-installed-perf.sh --allow-skip-noninteractive build/WorkSpaces.app build/release-installed-perf
-
-      - name: Upload installed-build perf verification artifact
-        if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        with:
-          name: release-installed-perf-${{ github.run_id }}
-          path: build/release-installed-perf
-          if-no-files-found: warn
+      # Installed-build perf verification is deliberately absent. Perf moved to
+      # laptop-opt-in in #1280 (docs/decisions/perf-measurement-laptop-optin.md);
+      # this job kept a copy that #1280 missed, and it blocked v0.24.0 by
+      # launching the app on a session that cannot produce launch telemetry.
+      # Per that ADR's #1238 rule — a skipped measurement must never be
+      # indistinguishable from a passing one — the perf artifact is removed with
+      # the step rather than left emitting an empty result that reads as green.
 
       - name: Notarize and package DMG
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,14 +99,17 @@ jobs:
             exit 1
           fi
 
+      # Pinned by SHA like every other action here. mise resolves the toolchain
+      # that builds the signed binary, so it must not be bootstrapped from an
+      # unpinned source — the previous "fail closed, install it out of band"
+      # rule protected that on a host we controlled, and a SHA-pinned action is
+      # how the same guarantee is kept on an ephemeral hosted image.
       - name: Ensure mise
-        run: |
-          set -euo pipefail
-          if command -v mise >/dev/null 2>&1; then
-            mise --version
-          else
-            brew install mise
-          fi
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          version: 2026.1.10
+          install: true
+          cache: true
 
       - name: Build GhosttyKit
         run: ./scripts/build-ghosttykit.sh
@@ -241,13 +244,15 @@ jobs:
       - name: Verify signed app bundle
         run: ./scripts/verify-release-bundle.sh build/WorkSpaces.app
 
-      # Installed-build perf verification is deliberately absent. Perf moved to
-      # laptop-opt-in in #1280 (docs/decisions/perf-measurement-laptop-optin.md);
-      # this job kept a copy that #1280 missed, and it blocked v0.24.0 by
-      # launching the app on a session that cannot produce launch telemetry.
-      # Per that ADR's #1238 rule — a skipped measurement must never be
-      # indistinguishable from a passing one — the perf artifact is removed with
-      # the step rather than left emitting an empty result that reads as green.
+      # Reads committed evidence instead of measuring. This job runs on a hosted
+      # image with no display, where launching the app yields no launch telemetry
+      # — that is what blocked v0.24.0. Perf is measured on a laptop, opt-in, per
+      # docs/decisions/perf-measurement-laptop-optin.md, and recorded in
+      # docs/performance_benchmarks.csv. Pass at 0 releases stale, warn at 1,
+      # block at 2, and fail outright when the file is missing: #1238's rule is
+      # that a skipped measurement must never read as a passing one.
+      - name: Verify release performance benchmarks are current
+        run: ./scripts/check-perf-benchmarks.py --tag "${{ github.ref_type == 'tag' && github.ref_name || 'HEAD' }}" --format github
 
       - name: Notarize and package DMG
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -158,11 +158,12 @@ Developer ID, notarization, and Sparkle release secrets.
 
 The workflow is split into three jobs:
 
-- `build-sign-notarize-release` runs on `[self-hosted, signing-host]` with
-  read-only repository permissions. It imports the Developer ID certificate into
-  a temporary keychain, builds and signs the app, notarizes the DMG, generates
+- `build-sign-notarize-release` runs on GitHub-hosted `macos-15` with read-only
+  repository permissions. It imports the Developer ID certificate into a
+  temporary keychain, builds and signs the app, notarizes the DMG, generates
   the Sparkle appcast, uploads release assets as workflow artifacts, then
-  deletes the temporary keychain.
+  deletes the temporary keychain. Every credential comes from repository
+  secrets, so the job carries no dependency on a particular machine.
 - `publish-github-release` runs on `ubuntu-latest` with `contents: write`. It
   downloads the signed artifacts and creates or updates the GitHub Release.
 - `validate-published-release-assets` runs on GitHub-hosted macOS with
@@ -295,7 +296,7 @@ users.
 
    - Workflow: `.github/workflows/release.yml`
    - Trigger: `push` tag `v*`
-   - Runner lane: `[self-hosted, signing-host]`
+   - Runner: GitHub-hosted `macos-15`
    - Protected environment: `release`
 
    Guardrails:
@@ -304,8 +305,8 @@ users.
      requested release tag.
    - Release preflight waits for in-flight `build-and-test` checks on the exact
      source commit before signing starts.
-   - Temporary signing keychain is cleaned up and prior keychain defaults are
-     restored on the shared `signing-host` runner.
+   - Temporary signing keychain is created and destroyed within the job, so a
+     failed run leaves no signing material behind on the runner.
 
 4. **Final download and update check**
 

--- a/docs/performance_benchmarks.csv
+++ b/docs/performance_benchmarks.csv
@@ -1,0 +1,2 @@
+release_tag,commit,timestamp,scenario,build_kind,protocol_epoch,launch_to_first_prompt_median_ms,repo_hydration_median_ms,repo_click_to_focus_median_ms,workspace_click_to_focus_median_ms,os_version,arch,model,notes
+v0.23.0,4dfb83f2,2026-07-11T04:15:00Z,installed_clean_shell,installed,isolated-preferences,,,,,,,,seed row — metrics intentionally blank; see docs/performance_benchmarks.md

--- a/docs/performance_benchmarks.md
+++ b/docs/performance_benchmarks.md
@@ -1,0 +1,111 @@
+# Release performance benchmarks
+
+`docs/performance_benchmarks.csv` is the committed record of how the app performed
+at each release. The release workflow reads it as evidence rather than measuring
+anything itself, which is what lets releases run on a hosted runner while perf
+measurement stays where it can be trusted — a real Mac with a real display.
+
+## Why the numbers are committed rather than measured at release time
+
+Perf measurement moved to laptop-opt-in in
+[#1280](https://github.com/fairchild/workspaces/pull/1280), recorded in
+[`docs/decisions/perf-measurement-laptop-optin.md`](decisions/perf-measurement-laptop-optin.md).
+The release job kept a copy of the old in-CI check that #1280 missed. It launched
+the real app and waited for launch telemetry, which a CI session cannot produce,
+and it blocked v0.24.0 with `missing installed perf metrics` after signing had
+already succeeded.
+
+Deleting that check outright would have traded one failure for a quieter one: no
+perf signal at all, and nothing to notice its absence. That runs into the rule the
+ADR states directly, from [#1238](https://github.com/fairchild/workspaces/issues/1238):
+
+> **A skipped measurement must never be indistinguishable from a passing one.**
+
+So the gate stayed and changed what it checks. It no longer asks *"is this build
+fast?"* — it asks *"did anyone measure recently?"* — and it gets louder the longer
+the answer is no.
+
+## What the gate does
+
+`scripts/check-perf-benchmarks.py` compares the newest `release_tag` in the CSV
+against the `v*` tags that exist, and grades the gap:
+
+| Releases since the last benchmarked one | Result |
+|---|---|
+| 0 — this release has a row | pass |
+| 1 | **warn**, release proceeds |
+| 2 or more | **fail**, release blocked |
+
+Missing or empty CSV fails rather than passes, for the same reason: absent
+evidence must not read as good news.
+
+One release of slack is deliberate. Benchmarking is a manual, opt-in act on a
+machine you have to be sitting at, so requiring it for every release would either
+block releases or train you to fake the row. Two consecutive unmeasured releases
+is a different thing — that is the point where a regression can hide behind a
+number nobody has looked at since.
+
+Run the gate yourself the way CI does:
+
+```bash
+./scripts/check-perf-benchmarks.py --tag v0.25.0
+./scripts/check-perf-benchmarks.py --tag v0.25.0 --format github   # CI annotations
+```
+
+## Generating a row
+
+Benchmarks come from the same runner the perf lane already uses. On the laptop,
+against an installed build:
+
+```bash
+./scripts/build-release.sh
+./scripts/perf-runner.sh --scenario installed_clean_shell
+```
+
+That writes a canonical `summary.json`. Append it to the launch-lane history and
+read the medians back out:
+
+```bash
+./scripts/perf-history-record.py --summary <path-to-summary.json>
+```
+
+Then add one row to `docs/performance_benchmarks.csv` with the release tag you are
+about to cut. Commit it on the release PR, before the tag is pushed — the gate
+reads the file at the commit being released, so a row added afterwards does not
+count for that release.
+
+## Columns
+
+Field names match `HISTORY_FIELDNAMES` in `scripts/perf_history.py` so a row can be
+lifted from the launch-lane history without renaming anything.
+
+| Column | Meaning |
+|---|---|
+| `release_tag` | the `v*` tag these numbers describe — the only field the gate reads |
+| `commit` | short SHA the measurement ran against |
+| `timestamp` | ISO-8601 UTC, when the measurement was taken |
+| `scenario` | `perf-runner.sh` scenario id, e.g. `installed_clean_shell` |
+| `build_kind` | `installed` or `debug` — installed is what ships |
+| `protocol_epoch` | measurement protocol; rows are only comparable within one epoch |
+| `launch_to_first_prompt_median_ms` | launch until the first shell prompt is ready |
+| `repo_hydration_median_ms` | repo list populated |
+| `repo_click_to_focus_median_ms` | click a repo until it is focused |
+| `workspace_click_to_focus_median_ms` | click a workspace until it is focused |
+| `os_version`, `arch`, `model` | host the measurement ran on |
+| `notes` | free text — anomalies, why a number moved |
+
+### protocol_epoch is not decoration
+
+Rows from different epochs are not comparable. `legacy-unisolated` runs read
+whatever the persistent UserDefaults domain happened to hold and had no guard
+against measuring alongside a live instance, so a delta across that boundary mixes
+an app change with a protocol change ([#1251](https://github.com/fairchild/workspaces/issues/1251)).
+Record the epoch the run actually used and compare within it.
+
+## The seed row
+
+The first row is `v0.23.0` — the last release that shipped — with blank metrics and
+a note saying so. It exists to give the gate a starting point rather than to assert
+anything about that build's speed. Blank metric cells are honest about being
+unmeasured; the gate only reads `release_tag`, so a seed row grants exactly one
+release of grace and no more. The next real release needs real numbers.

--- a/scripts/check-perf-benchmarks.py
+++ b/scripts/check-perf-benchmarks.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Release gate: has anyone measured performance recently?
+
+The release job cannot measure perf itself — it runs on a hosted image with no
+display, and launching the app there produces no launch telemetry (that is what
+blocked v0.24.0). Perf measurement lives on the laptop, opt-in, per
+docs/decisions/perf-measurement-laptop-optin.md.
+
+So this gate reads committed evidence instead: docs/performance_benchmarks.csv,
+one row per release. It grades the gap between the newest benchmarked release and
+the release being cut — pass at 0, warn at 1, fail at 2 or more. Absent or empty
+evidence fails, because #1238's rule is that a skipped measurement must never be
+indistinguishable from a passing one.
+
+Usage: check-perf-benchmarks.py --tag v0.25.0 [--format github]
+Exit 0 when evidence is current or one release stale, 1 when it is older or missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CSV = REPO_ROOT / "docs" / "performance_benchmarks.csv"
+BLOCK_AFTER = 2
+RELEASE_TAG_GLOB = "v*"
+
+
+def release_tags(repo_root: Path) -> list[str]:
+    """Every v* tag, oldest first, ordered by when the tag was created.
+
+    creatordate rather than version sort: a tag cut out of order still lands
+    where it actually happened, and that is what "releases since" means.
+    """
+    result = subprocess.run(
+        ["git", "tag", "--list", RELEASE_TAG_GLOB, "--sort=creatordate"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def benchmarked_tags(csv_path: Path) -> list[str]:
+    if not csv_path.is_file():
+        return []
+    with csv_path.open(newline="") as handle:
+        return [
+            row["release_tag"].strip()
+            for row in csv.DictReader(handle)
+            if (row.get("release_tag") or "").strip()
+        ]
+
+
+def releases_since(tags: list[str], benchmarked: set[str], current: str) -> int:
+    """How many releases have happened since the newest benchmarked one.
+
+    Counts the release being cut, so a tag with its own row scores 0 and a tag
+    whose predecessor was the last measured one scores 1.
+    """
+    ordered = [tag for tag in tags if tag != current] + [current]
+    for distance, tag in enumerate(reversed(ordered)):
+        if tag in benchmarked:
+            return distance
+    # No benchmarked tag appears in release history — the row references a tag
+    # that does not exist, or tags are unavailable. Freshness cannot be shown,
+    # so it is not assumed: floor the answer at the blocking distance rather
+    # than let a short history read as nearly current.
+    return max(len(ordered), BLOCK_AFTER)
+
+
+def emit(level: str, message: str, style: str) -> None:
+    if style == "github" and level in ("warning", "error"):
+        print(f"::{level}::{message}")
+    else:
+        print(f"{level}: {message}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--tag", required=True, help="release tag being cut, e.g. v0.25.0")
+    parser.add_argument("--csv", type=Path, default=DEFAULT_CSV)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--format", choices=("plain", "github"), default="plain")
+    args = parser.parse_args()
+
+    benchmarked = benchmarked_tags(args.csv)
+    if not benchmarked:
+        emit(
+            "error",
+            f"No performance benchmarks found in {args.csv.relative_to(REPO_ROOT) if args.csv.is_relative_to(REPO_ROOT) else args.csv}. "
+            "Release blocked: absent evidence is not a passing measurement. "
+            "See docs/performance_benchmarks.md to generate a row.",
+            args.format,
+        )
+        return 1
+
+    gap = releases_since(release_tags(args.repo_root), set(benchmarked), args.tag)
+    newest = benchmarked[-1]
+
+    if gap == 0:
+        print(f"ok: {args.tag} has committed performance benchmarks")
+        return 0
+
+    if gap < BLOCK_AFTER:
+        emit(
+            "warning",
+            f"No performance benchmarks for {args.tag}; newest is {newest} "
+            f"({gap} release behind). Release proceeds, but the next one is blocked "
+            "unless benchmarks are updated. See docs/performance_benchmarks.md.",
+            args.format,
+        )
+        return 0
+
+    emit(
+        "error",
+        f"Performance benchmarks are {gap} releases stale (newest: {newest}, releasing: {args.tag}). "
+        f"Release blocked at {BLOCK_AFTER}. Run ./scripts/perf-runner.sh on a laptop and add a row "
+        "to docs/performance_benchmarks.csv — see docs/performance_benchmarks.md.",
+        args.format,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_perf_benchmarks.py
+++ b/scripts/tests/test_check_perf_benchmarks.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Tests for the release performance-benchmark evidence gate.
+
+Intent: the gate replaced a check that measured perf during release and failed on
+a display-less runner. What matters now is that it grades staleness correctly and
+never treats missing evidence as good news — #1238's rule that a skipped
+measurement must not be indistinguishable from a passing one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check-perf-benchmarks.py"
+
+spec = importlib.util.spec_from_file_location("check_perf_benchmarks", SCRIPT_PATH)
+assert spec and spec.loader
+gate = importlib.util.module_from_spec(spec)
+sys.modules["check_perf_benchmarks"] = gate
+spec.loader.exec_module(gate)
+
+HEADER = "release_tag,commit,timestamp,scenario,build_kind,protocol_epoch,notes\n"
+
+
+def write_csv(path: Path, tags: list[str]) -> None:
+    rows = "".join(f"{tag},abc1234,2026-01-01T00:00:00Z,installed_clean_shell,installed,e1,\n" for tag in tags)
+    path.write_text(HEADER + rows)
+
+
+class StalenessTests(unittest.TestCase):
+    """Distance is counted in releases, not commits or days."""
+
+    TAGS = ["v0.21.0", "v0.22.0", "v0.23.0", "v0.24.0"]
+
+    def test_release_with_its_own_row_is_current(self) -> None:
+        self.assertEqual(gate.releases_since(self.TAGS, {"v0.24.0"}, "v0.24.0"), 0)
+
+    def test_one_release_since_the_last_benchmark(self) -> None:
+        self.assertEqual(gate.releases_since(self.TAGS, {"v0.23.0"}, "v0.24.0"), 1)
+
+    def test_two_releases_since_the_last_benchmark(self) -> None:
+        self.assertEqual(gate.releases_since(self.TAGS, {"v0.22.0"}, "v0.24.0"), 2)
+
+    def test_unreleased_tag_still_counts_against_the_newest_benchmark(self) -> None:
+        # Cutting v0.25.0, which has no tag yet, with only v0.23.0 measured.
+        self.assertEqual(gate.releases_since(self.TAGS, {"v0.23.0"}, "v0.25.0"), 2)
+
+    def test_benchmark_referencing_an_unknown_tag_is_maximally_stale(self) -> None:
+        # A row naming a tag that never shipped proves nothing about freshness.
+        self.assertEqual(gate.releases_since(self.TAGS, {"v0.01.0"}, "v0.24.0"), 4)
+
+    def test_unknown_tag_blocks_even_when_history_is_shorter_than_the_threshold(self) -> None:
+        # Short history must not make "cannot verify" look like "nearly current".
+        self.assertGreaterEqual(gate.releases_since([], {"v0.23.0"}, "v0.25.0"), gate.BLOCK_AFTER)
+
+
+class ExitCodeTests(unittest.TestCase):
+    """The gate's contract with the release workflow is its exit code."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.csv = self.root / "performance_benchmarks.csv"
+        run = lambda *args: subprocess.run(args, cwd=self.root, check=True, timeout=30, capture_output=True)
+        run("git", "init", "-q")
+        run("git", "config", "user.email", "t@example.com")
+        run("git", "config", "user.name", "t")
+        # Real tags: the gate measures distance in releases, so a repo without
+        # them exercises only the degenerate "cannot verify" path.
+        for tag in ("v0.23.0", "v0.24.0", "v0.25.0"):
+            (self.root / "f").write_text(tag)
+            run("git", "add", "f")
+            run("git", "commit", "-qm", tag)
+            run("git", "tag", tag)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def run_gate(self, tag: str) -> int:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--tag", tag, "--csv", str(self.csv), "--repo-root", str(self.root)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        ).returncode
+
+    def test_missing_file_blocks_rather_than_passes(self) -> None:
+        # The whole point: no evidence must not read as good evidence.
+        self.assertEqual(self.run_gate("v0.25.0"), 1)
+
+    def test_header_only_file_blocks(self) -> None:
+        self.csv.write_text(HEADER)
+        self.assertEqual(self.run_gate("v0.25.0"), 1)
+
+    def test_blank_release_tag_does_not_count_as_evidence(self) -> None:
+        self.csv.write_text(HEADER + ",abc1234,2026-01-01T00:00:00Z,s,installed,e1,\n")
+        self.assertEqual(self.run_gate("v0.25.0"), 1)
+
+    def test_current_release_passes(self) -> None:
+        write_csv(self.csv, ["v0.25.0"])
+        self.assertEqual(self.run_gate("v0.25.0"), 0)
+
+    def test_one_release_stale_warns_but_does_not_block(self) -> None:
+        write_csv(self.csv, ["v0.24.0"])
+        self.assertEqual(self.run_gate("v0.25.0"), 0)
+
+    def test_two_releases_stale_blocks(self) -> None:
+        # No tags exist in this fresh repo, so v0.23.0 sits 2 behind v0.25.0.
+        write_csv(self.csv, ["v0.23.0"])
+        self.assertEqual(self.run_gate("v0.25.0"), 1)
+
+
+class CommittedDataTests(unittest.TestCase):
+    """The real CSV must stay readable by the gate that depends on it."""
+
+    def test_committed_csv_parses_and_has_release_tags(self) -> None:
+        tags = gate.benchmarked_tags(REPO_ROOT / "docs" / "performance_benchmarks.csv")
+        self.assertTrue(tags, "committed benchmarks CSV yields no release tags")
+        for tag in tags:
+            self.assertTrue(tag.startswith("v"), f"release_tag should be a v* tag: {tag}")
+
+    def test_explainer_exists_alongside_the_data(self) -> None:
+        self.assertTrue((REPO_ROOT / "docs" / "performance_benchmarks.md").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_security_hardening.py
+++ b/scripts/tests/test_security_hardening.py
@@ -223,11 +223,29 @@ class SecurityHardeningTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, workflow)
 
-    def test_release_workflow_fails_closed_when_mise_is_missing(self) -> None:
+    def test_release_workflow_never_bootstraps_mise_from_an_unpinned_source(self) -> None:
+        """mise resolves the toolchain that builds the signed binary.
+
+        The original rule was "fail closed, install it out of band", which held
+        while release ran on a host we provisioned by hand. On an ephemeral
+        hosted image nothing is installed out of band, so the invariant is
+        restated rather than dropped: mise may be provisioned, but only from a
+        SHA-pinned action, never from a package manager resolving whatever is
+        current at release time.
+        """
         workflow = (REPO_ROOT / ".github/workflows/release.yml").read_text()
-        self.assertIn("mise is required on the signing host", workflow)
-        self.assertIn("exit 1", workflow)
-        self.assertNotIn("brew install mise", workflow)
+
+        for unpinned in ("brew install mise", "curl", "| sh", "| bash"):
+            self.assertNotIn(unpinned, workflow, f"unpinned mise bootstrap: {unpinned}")
+
+        self.assertRegex(
+            workflow,
+            r"uses: jdx/mise-action@[0-9a-f]{40}",
+            "mise must come from a SHA-pinned action",
+        )
+        self.assertRegex(
+            workflow, r"version: \d{4}\.\d+\.\d+", "the mise version itself must be pinned"
+        )
 
     def test_mise_configs_keep_trust_surface_small(self) -> None:
         allowed = {


### PR DESCRIPTION
## Why

v0.24.0 failed and was never published. It failed **after** signing succeeded, at a step that had no business being in the release job.

Run [31345686688](https://github.com/fairchild/workspaces/actions/runs/31345686688), step 15 of 23:

```
missing installed perf metrics: terminal_first_output, first_prompt_ready
##[error]Process completed with exit code 1.
```

Steps 1–14 all passed — branch policy, CI preflight, secrets validation, cert import, provisioning profile, notarization preflight, signed build, bundle verification. Step 15 launched the real app on a non-interactive runner session and waited 12s for launch telemetry that such a session cannot emit. Notarization (17) and everything downstream skipped.

That step is a **#1280 orphan**. That PR moved perf to laptop-opt-in, wrote `docs/decisions/perf-measurement-laptop-optin.md`, and deleted `perf-validation.yml` and `tart-ui-smoke.yml` — but missed the copy embedded in the release job. It sat for four months and then blocked a release. `release.yml:19` still carried a comment about "Tart UI automation," a lane retired in that same PR.

## What changes

**The perf gate stays — it now checks committed evidence instead of measuring.** Deleting it (my first attempt on this branch) traded a loud failure for a silent one. Instead, `docs/performance_benchmarks.csv` carries one row per release and `scripts/check-perf-benchmarks.py` grades the gap:

| Releases since the last benchmarked one | Result |
|---|---|
| 0 | pass |
| 1 | **warn**, release proceeds |
| 2+ | **fail**, release blocked |

Missing or empty evidence blocks. That is the #1238 rule the ADR states directly — *a skipped measurement must never be indistinguishable from a passing one* — and "nobody measured" is precisely what it exists to surface. Distance is counted in `v*` tags, so it tracks releases rather than time. When no benchmarked tag can be found in release history the answer is floored at the blocking distance: freshness that cannot be shown is not assumed.

Real output against this repo:

```
$ ./scripts/check-perf-benchmarks.py --tag v0.24.0 --format github
::warning::No performance benchmarks for v0.24.0; newest is v0.23.0 (1 release behind).
Release proceeds, but the next one is blocked unless benchmarks are updated.
exit 0

$ ./scripts/check-perf-benchmarks.py --tag v0.25.0 --format github
::error::Performance benchmarks are 2 releases stale (newest: v0.23.0, releasing: v0.25.0).
Release blocked at 2.
exit 1
```

So re-running **v0.24.0 warns and proceeds**; v0.25.0 blocks until real numbers land.

`docs/performance_benchmarks.md` explains the format, how to generate a row via `perf-runner.sh` + `perf-history-record.py`, and why `protocol_epoch` makes rows comparable only within an epoch (#1251). Column names match `HISTORY_FIELDNAMES` in `perf_history.py` so a row lifts out of the launch-lane history without renaming. The seed row is `v0.23.0` with **blank metrics and a note saying it asserts nothing** about that build — it grants exactly one release of grace.

**`runs-on` → `macos-15`.** Credentials were never the blocker: `setup-release-secrets.sh` provisions the full set and all are present. The job imports the cert into a temporary keychain it creates (step 9) and destroys (step 23); notarization reads `APPLE_API_KEY_*` from secrets. I enumerated every step — the perf step was the only one that launched the app, and steps 17-22 take inputs entirely from secrets and prior-step outputs.

**mise is provisioned from a SHA-pinned action.** My first attempt used `brew install mise` and CI caught it: `test_security_hardening` asserts *by name* that `release.yml` must not do that. mise resolves the toolchain that builds the signed binary, and this repo pins that supply chain deliberately — a constrained `.mise.toml` set, a locked Zig. The old rule was *"fail closed, install it out of band"*, which held while release ran on a hand-provisioned host. An ephemeral image has no out-of-band, so **the invariant is restated rather than dropped**: mise may be provisioned, but only from a SHA-pinned action at a pinned version.

> ⚠️ **This PR edits a security test.** `test_release_workflow_fails_closed_when_mise_is_missing` becomes `test_release_workflow_never_bootstraps_mise_from_an_unpinned_source`. It is strictly stronger than what it replaces — it still rejects `brew install mise`, and additionally rejects `curl`/`| sh`/`| bash` bootstraps the old assertion never covered, while requiring both a 40-char SHA pin and a pinned version. Worth reviewing on its own merits rather than as a mechanical fix.

## What this deliberately does not do

**`blue-workspaces` stays registered, and `signing-host` stays in `actionlint.yaml`.**

Notarization has been demonstrated nowhere on hosted. It skipped in v0.24.0, and last succeeded on self-hosted on 2026-07-11. It reads only secrets and network so it *should* port — but "should" is not evidence, and the whole reason this release broke is a step that looked fine until it ran. The self-hosted lane stays available until a real release notarizes on `macos-15`. Reverting is one line.

Removing the runner is a follow-up, gated on that proof.

## Validation

- **`scripts/tests/test_check_perf_benchmarks.py` — 14 tests pass**, covering staleness distance, the exit-code contract, missing/empty/blank-tag evidence blocking rather than passing, and that the committed CSV stays parseable by the gate that depends on it.
- `test_security_hardening.py` passes on the new mise invariant. Its one remaining failure is **pre-existing on `main`** and local-only — stray `.mise.toml` files under `.claude/worktrees/`, which is gitignored, so CI's fresh checkout does not see them.
- Full sweep of `scripts/tests/*.py`: no suite fails that does not also fail on `main`.
- `actionlint` clean. The two `SC2129` notes are pre-existing on `main`.
- YAML parse-checked: `runs-on: macos-15`, mise from `jdx/mise-action@7e36c90…`, benchmark gate present, notarize step intact.
- Gate exercised against the real repo — output above.
- The workflow itself only runs on a release tag or dispatch, so **the real test is re-running v0.24.0**.

## Mergeability

- Surface: infra — release pipeline. No product code.
- User-facing behavior changed: releases build, sign, and notarize on GitHub-hosted `macos-15` instead of a Mac in the office. Released artifacts are unchanged. Releases no longer carry an installed-perf check; perf is laptop-opt-in per #1280.
- Non-happy paths considered: hosted notarization unproven — `blue-workspaces` and the `signing-host` label are retained so revert is one line; cold image lacks mise — now installed via brew, matching the proven `ci-fallback.yml` path; perf regression ships unnoticed — real risk, accepted, and it is where #1280 already put that responsibility; signing material left behind on a shared runner — the keychain is created and destroyed within the job, and hosted images are ephemeral anyway, which is strictly better than the shared host.
- Release/ops preconditions: None. Every Apple credential this job needs is already a repository secret (cert, password, provisioning profile, ASC API key/id/issuer, `SPARKLE_PRIVATE_KEY`, `APPLE_TEAM_ID` var) — nothing to provision before merge. `blue-workspaces` and the `signing-host` label stay in place, so revert is one line if hosted notarization fails. No tag should be cut from this branch; the first hosted run should be a re-run of v0.24.0 from `main` after merge.
- Residual risk or follow-up: notarization on hosted is the open question and only a real release answers it. Follow-ups, not in this PR: `agent-executor.yml` still probes for a `lume-macos` runner and falls back to `ubuntu-latest` when absent — safe, but dead code that now always takes the fallback and silently downgrades April from macOS to Linux; and `runner-notify-complete.sh` records no job conclusion, which is how a failed v0.24.0 was read as a success in an earlier report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
