### PR TITLE
fix(perf): capture os.Logger output so the release gate sees its metrics

### DIFF
--- a/scripts/launch-installed-diagnostics.sh
+++ b/scripts/launch-installed-diagnostics.sh
@@ -127,6 +127,21 @@ echo "  app_args:"
 for entry in "${APP_ARGS[@]}"; do
     echo "    $entry"
 done
+# App logging is os.Logger, which writes to the unified log rather than
+# stdout/stderr — including the `[Perf]` metric lines summarize_perf_log.py
+# reads. Appending the subsystem's entries keeps the captured log complete for
+# consumers that only see this file.
+append_unified_log() {
+    local since="$1"
+    log show \
+        --info \
+        --start "$since" \
+        --predicate 'subsystem == "com.cloudcompute.workspaces"' \
+        --style compact >>"$LOG_FILE" 2>/dev/null || true
+}
+
+CAPTURE_START="$(date '+%Y-%m-%d %H:%M:%S')"
+
 if [[ "$CAPTURE_SECONDS" -gt 0 ]]; then
     echo "  capture_seconds: $CAPTURE_SECONDS"
     env "${ENV_VARS[@]}" "$APP_PATH" "${APP_ARGS[@]}" > >(tee "$LOG_FILE") 2>&1 &
@@ -134,6 +149,8 @@ if [[ "$CAPTURE_SECONDS" -gt 0 ]]; then
     sleep "$CAPTURE_SECONDS"
     kill "$APP_PID" 2>/dev/null || true
     wait "$APP_PID" 2>/dev/null || true
+    append_unified_log "$CAPTURE_START"
 else
     env "${ENV_VARS[@]}" "$APP_PATH" "${APP_ARGS[@]}" 2>&1 | tee "$LOG_FILE"
+    append_unified_log "$CAPTURE_START"
 fi


### PR DESCRIPTION
The v0.24.0 release ([run 31345686688](https://github.com/fairchild/workspaces/actions/runs/31345686688)) built, signed, and notarized successfully, then failed its final gate:

```
missing installed perf metrics: terminal_first_output, first_prompt_ready
```

## Root cause

#1173 (`3d69def3`, Aug 5) migrated 146 NSLog call sites to `os.Logger`. One of them was `defaultEmitMetric` in `Sources/WorkspaceManager/Diagnostics/TerminalReadinessDiagnostics.swift:118`:

```diff
-        NSLog("%@", components.joined(separator: " "))
+        log.info("\(components.joined(separator: " "), privacy: .public)")
```

`NSLog` writes to stderr, which `launch-installed-diagnostics.sh` captures. `os.Logger` writes to the unified log, which it does not. The `[Perf]` lines never stopped firing — the capture went blind to them.

No CI lane caught this because no release ran between #1173 and the v0.24.0 tag. The gate is release-only.

## Fix

Append the subsystem's unified-log entries to the captured log after the capture window. This lives in `launch-installed-diagnostics.sh` rather than `verify-installed-perf.sh` so every consumer of that log is repaired, not just the release gate.

Two details worth stating, since both are silent-failure traps:

- **`--info` is required.** `log.info` sits below `log show`'s default level, so without it the command succeeds and returns nothing.
- **The timestamp prefix is safe.** `summarize_perf_log.py:29` uses `PERF_PATTERN.search()`, not `.match()`, so `log show`'s line prefix doesn't break parsing.

`log show` after the fact rather than `log stream` during: a stream takes time to attach and would race the app's earliest metrics, which are exactly the ones the gate needs.

## Verification

Built from current `main` (so the `os.Logger` path is live — note `/Applications/WorkSpaces.app` is v0.23.0 and still uses NSLog, so it cannot exercise this), captured 12s, then ran the gate check verbatim.

![perf-gate-unified-log](https://evidence.cloudcompute.com/workspaces/pr-1296/20260811-085630-perf-gate-unified-log.png)

```
[Perf] lines in captured log: 12
metric=terminal_first_output duration_ms=1071.76
metric=first_prompt_ready duration_ms=1071.76

GATE: PASS - both metrics present
metrics parsed: ['first_prompt_ready', 'launch_to_first_prompt',
                 'terminal_first_output', 'terminal_investigation',
                 'workspace_orphan_scan']
```

The captured line proves the source is the unified-log append rather than stdout — `I` is the info-level marker and the subsystem tag is `log show --style compact` formatting:

```
2026-08-11 01:55:07.697 I  WorkspaceManager[4313:431941f] [com.cloudcompute.workspaces:PerformanceSignposts] [Perf] metric=terminal_first_output …
```

`shellcheck` clean, `bash -n` OK.

## Mergeability

- Surface: infra / release verification tooling. One shell script; no app code, no workflow changes.
- User-facing behavior changed: No. This changes what a diagnostics capture records, not what the app does.
- Non-happy paths considered: `log show` failures are swallowed (`|| true`) so a unified-log problem degrades to today's behavior rather than failing the capture outright. Stdout capture is unchanged, so pre-#1173 builds and any non-`os.Logger` output still land as before — the two sources are additive. If the unified log has rolled or the predicate matches nothing, the gate fails exactly as it does now, with the same message.
- Residual risk or follow-up: The real gap is that a release-only gate has no CI coverage — this class of break can only surface during a release. Worth a follow-up on running the installed-perf capture against a built bundle in a scheduled lane so the next logging change fails early instead of at signing time.
- Release/ops preconditions: None to merge. After merge, re-dispatch `Release` on the existing `v0.24.0` tag — the tag is valid and needs no re-cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
