### PR TITLE
fix(release): bump the orphaned mise pin so the signing lane can install it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,11 @@ jobs:
       - name: Ensure mise
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
-          version: 2026.1.10
+          # Not covered by scripts/mise-pin-refresh.py (see its PIN_SITES), so
+          # this one is bumped by hand. Upstream prunes release assets from old
+          # versions, which fails this step on a cache miss rather than at pin
+          # time — keep it recent.
+          version: 2026.8.4
           install: true
           cache: true
 


### PR DESCRIPTION
The v0.24.0 release ([run 31552428291](https://github.com/fairchild/workspaces/actions/runs/31552428291)) failed at `Ensure mise`, before signing:

```
curl -fsSL https://github.com/jdx/mise/releases/download/v2026.1.10/mise-v2026.1.10-macos-arm64.tar.zst
curl: (56) The requested URL returned error: 404
```

## Root cause

`v2026.1.10` still exists upstream but carries **0 release assets** — they were pruned. Naming is unchanged on current releases (`v2026.8.4` ships the exact `mise-v2026.8.4-macos-arm64.tar.zst` this step asks for), so the pinned version was simply un-downloadable.

```
v2026.1.10 assets: 0
v2026.5.0  assets: 46
v2026.6.0  assets: 46
v2026.7.18 assets: 46
```

## Why it went unnoticed for ~7 months

`scripts/mise-pin-refresh.py` keeps the sandbox pin fresh weekly, but its `PIN_SITES` are:

```python
PIN_SITES = (
    "scripts/verify-mise-security.sh",
    "web/src/lib/agent-runtime/vercel-sandbox.ts",
    "scripts/tests/test_security_hardening.py",
)
```

`.github/workflows/release.yml` isn't among them, so this pin drifted outside the refresh loop — managed pin is at `v2026.7.1` today while this one sat at `2026.1.10`.

Two things then hid the breakage: the step only runs during a release, and the previous release attempt restored mise from cache rather than downloading. The failure needed a release *and* a cache miss on the same run.

## Fix

Bump to `2026.8.4` and leave a comment at the pin site saying it's hand-maintained and why staleness fails late.

![release-mise-pin-404](https://evidence.cloudcompute.com/workspaces/pr-1297/20260812-011451-release-mise-pin-404.png)

## Validation

`scripts/validate-release-changes.py` — the check CI runs for release-sensitive files:

```
$ uv run --script scripts/validate-release-changes.py --changed-files changed.json
Release-sensitive files changed:
- .github/workflows/release.yml
YAML parse OK
Release change validation passed.          (exit 0)
```

`actionlint` 1.7.12 — workflow syntax and schema, which plain YAML parsing does not cover:

```
$ actionlint .github/workflows/release.yml
release.yml:126:9: shellcheck SC2129:style ... [shellcheck]
release.yml:277:9: shellcheck SC2129:style ... [shellcheck]
```

Both are pre-existing style warnings in unrelated `run:` blocks — this PR changes line ~110. Confirmed against a baseline rather than asserted:

```
$ actionlint <origin/main copy of release.yml>   → 2 findings
$ actionlint <this branch>                        → 2 findings
```

Same count, same two locations: **zero new findings introduced**. I left them alone rather than fold an unrelated style cleanup into a release-blocking fix.

Asset availability, checked before pinning:

```
$ curl -o /dev/null -s -w "%{http_code}" -L .../v2026.8.4/mise-v2026.8.4-macos-arm64.tar.zst
200
```

## Mergeability

- Surface: infra / release workflow. One pinned version string plus a comment.
- User-facing behavior changed: No.
- Non-happy paths considered: The failure mode being fixed is a cache miss forcing a download of a pruned asset — a cache *hit* masks it, which is exactly how this survived. Bumping does not remove that fragility; any pinned version eventually gets pruned. It does buy runway, since assets survive at least back to `v2026.5.0`. The signing lane now runs a newer mise than it did in July; the toolchain it provisions comes from `.mise.toml`, which is unchanged, so the exposure is mise's own behavior rather than tool versions.
- Residual risk or follow-up: The real fix is bringing this pin under `mise-pin-refresh.py`. It can't just be appended to `PIN_SITES` — that script does a literal `text.replace(old_version, new_version)` and `sys.exit`s if a site has no match, and this file uses a bare `2026.8.4` where the managed sites use `v`-prefixed strings. Worth a follow-up that either normalizes the format or teaches the script both. Filing that rather than folding it into a release-blocking fix.
- Release/ops preconditions: After merge, `v0.24.0` must be re-pointed at the new head — a tag-triggered run checks out the tag's own tree, so the tag has to contain this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
