### PR TITLE
fix(release): provision uv and stop rg absence from passing silently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,11 @@ jobs:
           install: true
           cache: true
 
+      # check-perf-benchmarks.py and summarize_perf_log.py are UV scripts, and
+      # .mise.toml does not provide uv — without this the signing host resolves
+      # it from ambient PATH, which a launchd-started runner does not inherit.
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+
       - name: Build GhosttyKit
         run: ./scripts/build-ghosttykit.sh
 

--- a/scripts/verify-installed-perf.sh
+++ b/scripts/verify-installed-perf.sh
@@ -79,6 +79,12 @@ fi
 [[ -x "$APP_BINARY" ]] || fail "App binary not found: $APP_BINARY"
 [[ -d "$APP_BUNDLE" ]] || fail "App bundle not found: $APP_BUNDLE"
 
+# The packaging checks below run rg inside `if` conditions, where a missing
+# binary is indistinguishable from "no matches" — set -e does not fire there.
+# Absent this guard, a host without rg reports a clean bundle without ever
+# looking at the log.
+command -v rg >/dev/null 2>&1 || fail "rg (ripgrep) is required but not on PATH"
+
 mkdir -p "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR/app-data"
 


### PR DESCRIPTION
The v0.24.0 release ([run 31554501804](https://github.com/fairchild/workspaces/actions/runs/31554501804)) got past mise and failed at `Verify release performance benchmarks are current`:

```
$ ./scripts/check-perf-benchmarks.py --tag v0.24.0 --format github
env: uv: No such file or directory
##[error]Process completed with exit code 127.
```

## uv was never provisioned

`check-perf-benchmarks.py` is a UV script, `.mise.toml`'s `[tools]` provides only `zig`, and `release.yml` has no `setup-uv` step — it resolved `uv` from ambient PATH (`/opt/homebrew/bin/uv`). Five other workflows already pin `astral-sh/setup-uv`: `docs-link-check`, `pr-readiness`, `ci-agents`, `agent-executor`, `factory-comment-responder`. This one was the outlier.

A launchd-started runner doesn't inherit the shell PATH that supplies Homebrew — the same class of problem #1283 documented for GUI apps.

**This affects two steps, not one.** `summarize_perf_log.py` is also a UV script, invoked from `verify-installed-perf.sh`, so the later installed-perf gate would have failed identically once this one was cleared.

## A quieter defect in the same class

`verify-installed-perf.sh` calls `rg` inside `if` conditions:

```bash
if rg -n "ghostty terminfo not found|no resources dir set..." "$LOG_FILE" >/dev/null; then
    fail "Detected Ghostty resource packaging warnings"
fi
```

A missing `rg` exits 127, the condition reads as false, and `set -e` is not consulted for commands in a condition. So on a host without ripgrep this gate reports a clean bundle **without ever reading the log** — it cannot fail. Now guarded with an explicit `command -v rg` check that fails loudly.

I folded this in rather than filing it because it's the same ambient-PATH root cause in the same release gate, and a check that silently cannot fail is worse than the failure it was meant to catch.

## Validation

![release-uv-provisioning](https://evidence.cloudcompute.com/workspaces/pr-1298/20260812-023712-release-uv-provisioning.png)

```
$ uv run --script scripts/validate-release-changes.py --changed-files changed.json
- .github/workflows/release.yml
- scripts/verify-installed-perf.sh
$ bash -n scripts/verify-installed-perf.sh
YAML parse OK
Release change validation passed.

$ actionlint .github/workflows/release.yml   → 2 findings (baseline on main: 2, unchanged)
$ bash -n scripts/verify-installed-perf.sh   → OK
$ shellcheck scripts/verify-installed-perf.sh → clean
```

The two actionlint findings are the same pre-existing SC2129 style warnings as on `main`; this PR adds none.

## Mergeability

- Surface: infra / release workflow and its verification script. No app code.
- User-facing behavior changed: No.
- Non-happy paths considered: `setup-uv` adds a network dependency to the signing lane — it fails loudly and early rather than mid-signing, which is the right place for it. The `rg` guard converts a silent pass into an explicit failure, so a host missing ripgrep now blocks the release instead of shipping an unverified bundle; that is a deliberate trade toward failing closed on a gate whose entire job is catching packaging defects.
- Residual risk or follow-up: This is the fourth release-only failure in this arc (perf gate, mise pin, and now uv + rg). The pattern is that `release.yml` runs on a host whose environment nothing else exercises, so every ambient dependency is discovered by a failed release. Worth a follow-up that either runs this lane's preflight in a scheduled job or asserts its tool prerequisites up front, so the next missing binary surfaces before a release rather than during one.
- Release/ops preconditions: After merge, `v0.24.0` must be re-pointed at the new head — tag-triggered runs check out the tag's own tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
