### PR TITLE
docs(release): correct the team ID verify-p12.sh advertises

### DIFF
--- a/scripts/verify-p12.sh
+++ b/scripts/verify-p12.sh
@@ -9,7 +9,7 @@
 #   P12=/absolute/path/to/cert.p12 P12_PASSWORD='...' ./scripts/verify-p12.sh --non-interactive
 #
 # Optional:
-#   --team-id NVSFDGS2TD     Expected Apple Team ID (default: NVSFDGS2TD)
+#   --team-id LKVN4J3C6C     Expected Apple Team ID (default: LKVN4J3C6C)
 #   --password-env NAME      Env var name for password (default: P12_PASSWORD)
 #   --non-interactive        Fail instead of prompting for password
 #   --help                   Show this help


### PR DESCRIPTION
## Summary

- `scripts/verify-p12.sh`'s header block advertised `--team-id NVSFDGS2TD  Expected Apple Team ID (default: NVSFDGS2TD)`. The actual default (line 28) is `LKVN4J3C6C`.
- `usage()` (line 44) and the default `.p12` path (line 50) already said `LKVN4J3C6C`, so the header comment was the lone dissenter — and the only occurrence of `NVSFDGS2TD` anywhere in the repo.
- Docs wrong, code right: only the comment changes.

There are two Apple identities in play, which is what lifts this above cosmetic. A reader who trusts the header passes `--team-id NVSFDGS2TD`, and the subject check at line 128 then rejects a certificate that was correct all along — a confusing failure at exactly the moment someone is setting up release signing.

## Mergeability

- Surface: infra (release tooling)
- User-facing behavior changed: none. Comment-only; no executable line is touched.
- Non-happy paths considered: none introduced. The `--team-id` flag still overrides `EXPECTED_TEAM_ID` exactly as before, and the failure path at line 128 is unchanged. Verified by diffing the executable body: the only changed line is a `#` comment.
- Release/ops preconditions: none.
- Residual risk or follow-up: none. If the signing identity ever moves to a different team, three sites now need updating together (lines 12, 28, 44) plus the default path at 50 — they were already four, this just makes them agree.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `bash -n scripts/verify-p12.sh` — clean.
  - `uv run --script scripts/validate-release-changes.py --changed-files ...` — passed. `scripts/verify-p12.sh` is in `RELEASE_PATHS`, so this PR is release-sensitive and the validator runs its `bash -n` check on it.
  - `./scripts/verify-p12.sh --help` — rendered output now matches the code default.
  - `rg NVSFDGS2TD` over the tree — no occurrences remain.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (Playwright report, test output, or equivalent)

https://evidence.cloudcompute.com/workspaces/pr-1301/20260813-052328-verify-p12-team-id-help.txt

Before/after of the three affected line ranges, the repo-wide `NVSFDGS2TD` sweep, rendered `--help`, `bash -n`, and the release-change validator run.

## Blockers

None.
