### PR TITLE
ci(agents): lint workflows with actionlint

### DIFF
--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -59,6 +59,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Net-new: nothing checked Actions schema before. The nearest thing,
+  # scripts/validate-release-changes.py, runs `YAML.load_file` on release.yml —
+  # that proves the file is YAML, not that it is a workflow GitHub will accept,
+  # so the check the PR readiness gate takes as evidence for workflow changes
+  # cannot see a misspelled key, a bad `needs:`, an undefined matrix reference,
+  # or an unknown runner label. This job can. It reads .github/actionlint.yaml,
+  # so a workflow reaching for a decommissioned self-hosted lane fails here.
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # Pinned binary verified by checksum rather than a third-party action,
+      # matching how mise-security.yml provisions its pinned tool.
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint
+          sudo install -m 755 /tmp/actionlint /usr/local/bin/actionlint
+          actionlint --version
+
+      # shellcheck at --severity=warning: actionlint shells out to it for every
+      # `run:` block, and real shell bugs should fail. Style opinions should not
+      # — plain actionlint is red on main today over two SC2129 "consider using
+      # { cmd; } >> file" notes in release.yml, and a gate that starts red
+      # teaches people to ignore it. `shellcheck --version` runs first so the
+      # job fails loudly if the image ever stops shipping it, rather than
+      # quietly linting less than it claims to.
+      - name: Lint workflows
+        run: |
+          set -euo pipefail
+          shellcheck --version
+          actionlint -shellcheck "shellcheck --severity=warning"
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

Adds an `actionlint` job to `ci-agents.yml`, which already path-triggers on `.github/workflows/*.yml` and already runs on `ubuntu-latest`.

**What this replaces: nothing — it is net-new coverage.** Nothing in the repo checked Actions schema. The nearest thing is `scripts/validate-release-changes.py`, whose entire workflow check is `YAML.load_file` on `release.yml` (lines 46–51). That proves the file is YAML, not that it is a workflow GitHub will accept. So the check the PR readiness gate accepts as evidence for a workflow change cannot see a misspelled key, a bad `needs:`, an undefined matrix or step-output reference, or an unknown runner label.

The runner-label case is the one this repo has already paid for. `.github/actionlint.yaml` names `signing-host` as the only permitted self-hosted lane and explicitly rejects retired `lume-macos` and `tart-ui` — a policy written down with nothing enforcing it. Now a workflow reaching for a decommissioned lane fails on its own PR.

## Mergeability

- Surface: infra (CI)
- User-facing behavior changed: none. New required-to-pass job on PRs that touch workflows or agent scripts; no product code path is affected.
- Non-happy paths considered: the binary is a checksum-verified pinned release (`1.7.12`, sha256 from upstream `actionlint_1.7.12_checksums.txt`), so a tampered or truncated download fails `sha256sum -c -` rather than silently linting nothing. `shellcheck --version` runs before the lint so the job fails loudly if the runner image ever stops shipping shellcheck, instead of quietly checking less than it claims. `set -euo pipefail` throughout.
- Release/ops preconditions: none. Ubuntu job, no secrets, no self-hosted dependency.
- Residual risk or follow-up: a future actionlint version could introduce a new check that turns the gate red on unrelated PRs — the version is pinned, so that only happens on a deliberate bump. Two pre-existing SC2129 style notes in `release.yml` remain unfixed by design (see below); if the signing job is ever restyled, `--severity=warning` could be dropped.

### Why `-shellcheck "shellcheck --severity=warning"`

Plain `actionlint` **exits 1 on main today** — two SC2129 (`consider using { cmd1; cmd2; } >> file`) *style* notes inside `release.yml`'s signing job. Landing a gate red teaches people to route around it, and restyling the signing job is not this change's business. At `--severity=warning`, genuine shell bugs still fail the job and style opinions do not.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `actionlint -shellcheck "shellcheck --severity=warning"` over all 31 workflow files including the new job — exit 0.
  - Negative test: a synthetic workflow with four schema errors (retired `lume-macos` label, misspelled `needs: buidl`, misspelled `ubuntu-lastest`, undefined `steps.nope.outputs.thing`). Ruby's `YAML.load_file` reports `YAML parse OK`, exit 0. actionlint catches all four, exit 1. This is the gap, demonstrated.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (Playwright report, test output, or equivalent)

https://evidence.cloudcompute.com/workspaces/pr-1302/20260813-052920-actionlint-gate.txt

Side-by-side of the Ruby parse vs actionlint on the same broken workflow, the plain-actionlint red baseline, the clean `--severity=warning` run, and the diff.

## Blockers

None.
