### PR TITLE
ci: provision build-and-test the way release.yml does

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
       - "Tests/**"
       - "scripts/build-ghosttykit.sh"
       - "scripts/build-release.sh"
+      - "scripts/check-perf-benchmarks.py"
       - "scripts/check-release-harness-absence.sh"
       - "scripts/check-subprocess-timeouts.py"
       - "scripts/generate-sparkle-appcast.sh"
@@ -50,6 +51,7 @@ on:
       - "Tests/**"
       - "scripts/build-ghosttykit.sh"
       - "scripts/build-release.sh"
+      - "scripts/check-perf-benchmarks.py"
       - "scripts/check-release-harness-absence.sh"
       - "scripts/check-subprocess-timeouts.py"
       - "scripts/generate-sparkle-appcast.sh"
@@ -80,13 +82,22 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
+      # Provisioning below mirrors release.yml step for step, and must keep
+      # doing so. release.yml only ever executes on a tag push, so an
+      # environmental assumption that holds nowhere else is discovered by a
+      # failed release — v0.24.0 burned four of them that way. This job runs on
+      # the same macos-15 image, so matching the provisioning here is what makes
+      # a PR able to fail instead.
       - name: Ensure mise
-        run: |
-          if command -v mise >/dev/null 2>&1; then
-            mise --version
-          else
-            brew install mise
-          fi
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          version: 2026.8.4
+          install: true
+          cache: true
+
+      # check-perf-benchmarks.py is a UV script and .mise.toml does not provide
+      # uv. release.yml learned this the hard way (#1298).
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Build GhosttyKit
         run: ./scripts/build-ghosttykit.sh
@@ -108,8 +119,42 @@ jobs:
       - name: Build (debug)
         run: swift build
 
-      - name: Build (release)
-        run: swift build -c release
+      # The release lane's own build path, minus signing. It runs
+      # `swift build -c release` itself and reuses .build, so the marginal cost
+      # over the bare release build this replaces is roughly bundling time —
+      # and in exchange the bundling, Sparkle linkage, and resource-copy steps
+      # that only ever ran during a release now run on every PR.
+      - name: Build (release, unsigned bundle)
+        run: ./scripts/build-release.sh --no-sign
+
+      # Can-it-run only. Whether benchmarks are *fresh* is release policy, not
+      # PR policy: 0 (current) and 1 (stale or missing) are both fine here. What
+      # must not reach a tag is the gate being unable to execute at all — absent
+      # uv exited 127 during v0.24.0 and the release, not a PR, is where that
+      # surfaced.
+      #
+      # Plain format, not --format github: the release lane wants ::error::
+      # annotations because there staleness blocks, but emitting them from a
+      # step that passes on staleness by design would paint every PR run with a
+      # failure the run does not have.
+      - name: Release perf gate is runnable
+        run: |
+          set +e
+          output="$(./scripts/check-perf-benchmarks.py --tag HEAD 2>&1)"
+          status=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$status" -gt 1 ]; then
+            echo "::error::check-perf-benchmarks.py exited $status (expected 0 or 1); the release perf gate cannot execute on this runner"
+            exit 1
+          fi
+          case "$output" in
+            *"Traceback (most recent call last)"*)
+              echo "::error::check-perf-benchmarks.py crashed; an exit 1 from a traceback is not a policy verdict"
+              exit 1
+              ;;
+          esac
+          echo "runnable (exit $status)"
 
       - name: Check release harness absence
         run: ./scripts/check-release-harness-absence.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - ".github/workflows/ci-fallback.yml"
       - ".github/workflows/release.yml"
       - ".swift-format"
+      # Direct inputs to this job's provisioning: mise-action reads both to
+      # resolve and lock the Zig that builds GhosttyKit.
+      - ".mise.toml"
+      - "mise.lock"
       - "WorkSpacesCloudCI.xcodeproj/**"
       - "Package.swift"
       - "Package.resolved"
@@ -41,6 +45,10 @@ on:
       - ".github/workflows/ci-fallback.yml"
       - ".github/workflows/release.yml"
       - ".swift-format"
+      # Direct inputs to this job's provisioning: mise-action reads both to
+      # resolve and lock the Zig that builds GhosttyKit.
+      - ".mise.toml"
+      - "mise.lock"
       - "WorkSpacesCloudCI.xcodeproj/**"
       - "Package.swift"
       - "Package.resolved"
@@ -80,7 +88,14 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 90
     steps:
+      # Same checkout shape as release.yml. fetch-depth: 0 is not incidental —
+      # check-perf-benchmarks.py orders releases with `git tag --list`, and the
+      # default single-commit checkout carries no tags at all, so the gate would
+      # take a degenerate path here and the real one during a release.
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       # Provisioning below mirrors release.yml step for step, and must keep
       # doing so. release.yml only ever executes on a tag push, so an
@@ -127,34 +142,28 @@ jobs:
       - name: Build (release, unsigned bundle)
         run: ./scripts/build-release.sh --no-sign
 
-      # Can-it-run only. Whether benchmarks are *fresh* is release policy, not
-      # PR policy: 0 (current) and 1 (stale or missing) are both fine here. What
-      # must not reach a tag is the gate being unable to execute at all — absent
-      # uv exited 127 during v0.24.0 and the release, not a PR, is where that
+      # Proves the release perf gate can execute on this runner. Absent uv made
+      # it exit 127 during v0.24.0, and a release rather than a PR is where that
       # surfaced.
       #
-      # Plain format, not --format github: the release lane wants ::error::
-      # annotations because there staleness blocks, but emitting them from a
-      # step that passes on staleness by design would paint every PR run with a
-      # failure the run does not have.
+      # Positive proof, not tolerance: the probe runs against a fixture whose
+      # only row matches the tag being asked about, so a working script has
+      # exactly one answer — gap 0, "ok", exit 0. Inferring health from "exited
+      # 0 or 1" instead would pass a script that is merely broken in a way that
+      # exits 1, which a SyntaxError, a failed uv bootstrap, and a stray
+      # sys.exit(1) all are.
+      #
+      # Freshness of the real benchmarks stays release policy and is not
+      # asserted here. --format github coverage lives in
+      # scripts/tests/test_check_perf_benchmarks.py, which runs on the cheap
+      # Ubuntu lane rather than costing macOS minutes.
       - name: Release perf gate is runnable
         run: |
-          set +e
-          output="$(./scripts/check-perf-benchmarks.py --tag HEAD 2>&1)"
-          status=$?
-          set -e
-          printf '%s\n' "$output"
-          if [ "$status" -gt 1 ]; then
-            echo "::error::check-perf-benchmarks.py exited $status (expected 0 or 1); the release perf gate cannot execute on this runner"
-            exit 1
-          fi
-          case "$output" in
-            *"Traceback (most recent call last)"*)
-              echo "::error::check-perf-benchmarks.py crashed; an exit 1 from a traceback is not a policy verdict"
-              exit 1
-              ;;
-          esac
-          echo "runnable (exit $status)"
+          set -euo pipefail
+          fixture="$RUNNER_TEMP/perf-benchmarks-probe.csv"
+          head -1 docs/performance_benchmarks.csv > "$fixture"
+          echo "v0.0.0-probe,0000000,2026-01-01T00:00:00Z,probe,installed,probe,,,,,,,,runnability probe" >> "$fixture"
+          ./scripts/check-perf-benchmarks.py --tag v0.0.0-probe --csv "$fixture"
 
       - name: Check release harness absence
         run: ./scripts/check-release-harness-absence.sh

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -147,6 +147,9 @@ is_ci_relevant_path() {
             WorkspaceManager.entitlements | \
             scripts/build-ghosttykit.sh | \
             scripts/build-release.sh | \
+            scripts/check-perf-benchmarks.py | \
+            scripts/check-release-harness-absence.sh | \
+            scripts/check-subprocess-timeouts.py | \
             scripts/generate-sparkle-appcast.sh | \
             scripts/install-local.sh | \
             scripts/notarize.sh | \

--- a/scripts/tests/test_check_perf_benchmarks.py
+++ b/scripts/tests/test_check_perf_benchmarks.py
@@ -64,8 +64,8 @@ class StalenessTests(unittest.TestCase):
         self.assertGreaterEqual(gate.releases_since([], {"v0.23.0"}, "v0.25.0"), gate.BLOCK_AFTER)
 
 
-class ExitCodeTests(unittest.TestCase):
-    """The gate's contract with the release workflow is its exit code."""
+class GateFixture:
+    """A throwaway git repo with real release tags, plus a CSV to point at."""
 
     def setUp(self) -> None:
         self.tmp = tempfile.TemporaryDirectory()
@@ -86,13 +86,30 @@ class ExitCodeTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.tmp.cleanup()
 
-    def run_gate(self, tag: str) -> int:
+    def gate_result(self, tag: str, *extra: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
-            [sys.executable, str(SCRIPT_PATH), "--tag", tag, "--csv", str(self.csv), "--repo-root", str(self.root)],
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--tag",
+                tag,
+                "--csv",
+                str(self.csv),
+                "--repo-root",
+                str(self.root),
+                *extra,
+            ],
             capture_output=True,
             text=True,
             timeout=60,
-        ).returncode
+        )
+
+    def run_gate(self, tag: str) -> int:
+        return self.gate_result(tag).returncode
+
+
+class ExitCodeTests(GateFixture, unittest.TestCase):
+    """The gate's contract with the release workflow is its exit code."""
 
     def test_missing_file_blocks_rather_than_passes(self) -> None:
         # The whole point: no evidence must not read as good evidence.
@@ -118,6 +135,33 @@ class ExitCodeTests(unittest.TestCase):
         # No tags exist in this fresh repo, so v0.23.0 sits 2 behind v0.25.0.
         write_csv(self.csv, ["v0.23.0"])
         self.assertEqual(self.run_gate("v0.25.0"), 1)
+
+
+class GithubAnnotationTests(GateFixture, unittest.TestCase):
+    """`--format github` is reachable only from release.yml.
+
+    CI runs the gate in plain format, so without these the annotation branch in
+    emit() executes for the first time during a release — and a typo confined to
+    that branch fails the release rather than the PR that wrote it.
+    """
+
+    def test_blocking_gate_annotates_as_an_error(self) -> None:
+        result = self.gate_result("v0.25.0", "--format", "github")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("::error::", result.stdout)
+
+    def test_one_release_stale_annotates_as_a_warning_without_blocking(self) -> None:
+        write_csv(self.csv, ["v0.24.0"])
+        result = self.gate_result("v0.25.0", "--format", "github")
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("::warning::", result.stdout)
+
+    def test_plain_format_stays_free_of_annotations(self) -> None:
+        write_csv(self.csv, ["v0.24.0"])
+        result = self.gate_result("v0.25.0")
+        self.assertEqual(result.returncode, 0)
+        self.assertNotIn("::warning::", result.stdout)
+        self.assertNotIn("::error::", result.stdout)
 
 
 class CommittedDataTests(unittest.TestCase):

--- a/scripts/tests/test_release_preflight.py
+++ b/scripts/tests/test_release_preflight.py
@@ -13,6 +13,7 @@ published, especially when GitHub check-runs spill past the first API page.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -23,6 +24,52 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "release-preflight.sh"
+CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def ci_workflow_script_paths() -> set[str]:
+    """The scripts/ entries in ci.yml's push path filter."""
+    return set(re.findall(r'^\s+- "(scripts/[^"*]+)"$', CI_WORKFLOW_PATH.read_text(), re.M))
+
+
+def preflight_relevant_script_paths() -> set[str]:
+    """The scripts/ entries in release-preflight.sh's is_ci_relevant_path case."""
+    body = SCRIPT_PATH.read_text()
+    block = body[body.index("is_ci_relevant_path()") :]
+    block = block[: block.index("return 1")]
+    return set(re.findall(r"(scripts/[A-Za-z0-9_.-]+)", block))
+
+
+class CiRelevantPathParityTests(unittest.TestCase):
+    """release-preflight.sh hand-duplicates ci.yml's path filter.
+
+    The two lists decide the same thing from opposite ends: which changes oblige
+    a build-and-test run. When they disagree, preflight can read a commit as
+    having no CI-relevant changes and wave a release through on a file CI was
+    watching. Nothing coupled them, so this does.
+    """
+
+    def test_every_ci_watched_script_is_release_relevant(self) -> None:
+        missing = ci_workflow_script_paths() - preflight_relevant_script_paths()
+        self.assertEqual(
+            missing,
+            set(),
+            "ci.yml triggers build-and-test for these scripts but "
+            "release-preflight.sh's is_ci_relevant_path does not list them, so a "
+            "release can skip waiting for the CI they gate: "
+            f"{sorted(missing)}",
+        )
+
+    def test_every_release_relevant_script_is_ci_watched(self) -> None:
+        missing = preflight_relevant_script_paths() - ci_workflow_script_paths()
+        self.assertEqual(
+            missing,
+            set(),
+            "release-preflight.sh waits for build-and-test on these scripts but "
+            "ci.yml never runs it for them, so preflight waits for a check that "
+            "will not arrive: "
+            f"{sorted(missing)}",
+        )
 
 
 class ReleasePreflightTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

`.github/workflows/release.yml` is the only consumer of its runner environment and only runs on a tag push, so every environmental assumption in it is validated by a failed release. v0.24.0 burned four attempts that way — two of them (#1297, #1298) tracing to a single PR that shipped a uv-based release gate, a mise pin at an already-pruned version, and a hosted-runner migration together.

`ci.yml` already path-triggers on `release.yml` and the release scripts, and already runs on `macos-15`, the same runner class release now uses. It just provisioned differently, so none of that was reachable from a PR. This brings the two into line:

- Ensure mise via the same SHA-pinned `jdx/mise-action` step release.yml uses, replacing an unpinned `brew install mise`.
- Provision uv, which `check-perf-benchmarks.py` needs and `.mise.toml` does not supply — the #1298 failure exactly.
- Match release.yml's checkout shape (`fetch-depth: 0`, `persist-credentials: false`).
- Build through `./scripts/build-release.sh --no-sign` instead of a bare `swift build -c release`.
- Prove the release perf gate can execute, against a fixture with a determinate answer.
- Add `scripts/check-perf-benchmarks.py`, `.mise.toml`, and `mise.lock` to the path filters.
- Add the new script to `release-preflight.sh`'s relevant-path list, and couple that list to ci.yml's filter with a test.

Had this existed, #1293 would have failed on its own PR instead of on four releases.

**Build-step cost.** `build-release.sh` runs `swift build -c release` itself and reuses `.build`. A warm re-run measures **6.14s**, so the marginal cost over the step it replaces is bundling — and in exchange the bundling, Sparkle-linkage, and resource-copy paths that only ever ran during a release now run per PR.

## Review loop

Directed codex review (gpt-5.6-sol, xhigh) — **request changes**. Five findings, four acted on in `f121f57f`.

| # | Severity | Finding | Disposition |
|---|---|---|---|
| 1 | High (introduced) | `exit 1` is not a reliable policy verdict — the traceback heuristic passes a checker that can't execute | **Fixed.** Replaced with positive proof. |
| 2 | High | CI never exercises the release path: no tags under default checkout, and `--format github` is release-only | **Fixed.** `fetch-depth: 0`; `--format github` covered by tests. |
| 3 | Medium (pre-existing) | `build-release.sh` is fail-open on resource paths; `verify-release-bundle.sh`'s structural assertions need no secrets | **Deferred, with reason** — see below. |
| 4 | Medium | `.mise.toml` / `mise.lock` are direct inputs, absent from path filters | **Fixed.** |
| 5 | Medium (introduced) | `release-preflight.sh`'s duplicated path list omits the new script | **Fixed, and coupled.** |

**On #1 — the one that mattered.** The first version accepted exit 0 or 1 unless the output carried a `Traceback (most recent call last)` header, on the theory that a crash always prints one. It does not: a `SyntaxError`, a failed uv bootstrap, and a bare `sys.exit(1)` all exit 1 silently. Codex reproduced a syntax-errored checker being certified `runnable (exit 1)`; so did I. Inference was the wrong shape. The step now runs the checker against a fixture whose one row matches the tag it asks about — where a working script has exactly one answer, gap 0 and exit 0 — and demands it. A checker that cannot execute cannot produce that.

**On #5 — the test found more than the bug.** Nothing tied `release-preflight.sh`'s hand-duplicated relevant-path list to ci.yml's filter. `test_release_preflight.py` now asserts they agree in both directions, and failed on its first run with two drifts beyond the one this PR introduced: `check-release-harness-absence.sh` and `check-subprocess-timeouts.py`, both watched by CI and both absent from preflight — meaning a release could skip waiting for the CI they gate. Both are now listed.

**On #3 — why it is not here.** The finding is correct: `build-release.sh` suppresses SPM resource-copy failures, warns past missing Ghostty resources, and relabels `actool` failures as warnings, while `verify-release-bundle.sh` later hard-requires those resources — so a resource-layout change can pass CI's unsigned build and fail release immediately after. Codex is also right that the structural assertions need no secrets and needn't be release-only. But teaching a release-signing verifier a new mode is an independent change from making ci.yml provision like release.yml, and bundling independent risky changes into one release-sensitive PR is precisely what #1293 did to produce these four failed releases. It gets its own PR rather than a ride on this one.

## Mergeability

- Surface: infra (CI)
- User-facing behavior changed: none. No product code path is touched; this changes what CI provisions and asserts.
- Non-happy paths considered: the perf probe is positive-proof, so a checker that cannot execute — missing uv (127), `SyntaxError` (1), unexecutable path (126) — fails the step rather than being read as a policy verdict; verified against all three. `build-release.sh` fails closed on build failure through the `while read` filter (`set -o pipefail`; codex reproduced an upstream exit 42 propagating). It leaves `.build/release/WorkspaceManager` in place, so the following `check-release-harness-absence.sh` and `swift test` are unaffected — confirmed locally. `fetch-depth: 0` costs clone time on every CI run; that is the price of the gate seeing the tag list release sees.
- Release/ops preconditions: none. No secrets, no self-hosted lane.
- Residual risk or follow-up: signing, notarization, appcast, and manifest steps remain release-only and unreachable from a PR — inherent, they need repo secrets. The pre-tag rehearsal (separate PR against `RELEASING.md`) is the mitigation for those. `ci.yml`'s mise-action pin duplicates release.yml's `2026.8.4` byte for byte here; a follow-up PR brings both under `scripts/mise-pin-refresh.py`. Follow-up issue filed for #3.

## Validation

- [ ] `swift build`
- [x] `swift test` — not re-run for this diff; no Swift source changes. The release build path is exercised directly instead (below).
- [x] Other checks run:
  - `actionlint .github/workflows/ci.yml` — clean.
  - `./scripts/build-release.sh --no-sign` — exit 0, 56M bundle produced; warm re-run 6.14s.
  - `./scripts/check-release-harness-absence.sh` against the tree that leaves — passes.
  - `uv run --script scripts/tests/test_check_perf_benchmarks.py` — 17/17 (3 new `--format github` cases).
  - `uv run --script scripts/tests/test_release_preflight.py` — 4/4 (2 new parity cases).
  - `uv run --script scripts/validate-release-changes.py` over `scripts/release-preflight.sh` — passed.
  - Old-vs-new perf-step comparison on a syntax-errored checker, a healthy checker, and exit 127.

## Performance

- [x] Not a performance-sensitive change

Not product performance. CI wall-clock cost is named above: ~6s bundling plus full-history checkout.

## Evidence

- [x] Test evidence attached (Playwright report, test output, or equivalent)

https://evidence.cloudcompute.com/workspaces/pr-1303/20260813-054011-ci-release-provisioning-parity.txt

actionlint, the unsigned release build and its bundle, the warm-rerun timing, the harness-absence check, the old-vs-new gate comparison, the probe as CI runs it, both test suites, and the release-change validator.

## Blockers

None.
