### PR TITLE
docs(release): make the pre-tag rehearsal part of the ritual

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -251,10 +251,53 @@ There are two normal lanes:
 Both lanes use the same protected signing, notarization, appcast, manifest,
 artifact upload, and published-asset validation workflow.
 
+### Rehearse from `main` before tagging
+
+A manual `Release` dispatch from `main` runs the whole signing, notarization,
+appcast, manifest, and published-asset path and publishes the result as
+`workspaces-v<version>-main.<run_number>`, a prerelease that leaves the stable
+channel and the Sparkle feed untouched. It is the only way to exercise the
+release environment without spending a version number to find out whether it
+works.
+
+That environment is worth exercising deliberately because `release.yml` is its
+only consumer and only runs on a tag push, so an assumption that holds nowhere
+else in CI is discovered when a release breaks. v0.24.0 found four in a row that
+way: a perf gate reading a log stream that no longer carried the metrics
+(#1296), a mise pin whose upstream release assets had been pruned (#1297), a uv
+the workflow never installed (#1298), and a red `main`.
+
+The rehearsal was routine through v0.23.0 — dispatched 2026-06-26, 06-28, 06-30,
+and 07-07, green every time — and was skipped ahead of v0.24.0. It also covers
+more ground now than it did then: #1293 moved signing and notarization from the
+self-hosted `signing-host` runner to a hosted `macos-15` image, and as of
+2026-08-13 every hosted attempt has failed before reaching the notarization
+step, so notarization has not yet run green on the current runner.
+
+So, before Method 1:
+
+1. Dispatch `Release` from `main` (Actions > `Release` > `Run workflow` >
+   Ref: `main`) and let it finish. Mechanics and tester handoff: Method 1A.
+2. Confirm the published prerelease is real, not just listed:
+
+   ```bash
+   gh release download workspaces-v0.21.0-main.42 \
+       --repo fairchild/workspaces \
+       --pattern "WorkSpaces-0.21.0.dmg" \
+       --dir /tmp/workspaces-rehearsal \
+       --clobber
+   xcrun stapler validate /tmp/workspaces-rehearsal/WorkSpaces-0.21.0.dmg
+   ```
+
+3. Only then tag.
+
+A rehearsal that fails costs a run number. A tag that fails costs a tag, a
+changelog entry, and a version.
+
 ### Method 1: Stable Release
 
 Use this after tester signoff or when you are ready to publish directly to all
-users.
+users, and after a green rehearsal from `main` (above).
 
 1. **Open a stable release metadata PR**
 
@@ -330,7 +373,10 @@ users.
 ### Method 1A: Optional Tester Prerelease
 
 Use this when several changes have landed on `main` and you want testers to
-exercise the signed, notarized app before publishing a new stable release.
+exercise the signed, notarized app before publishing a new stable release. It is
+also the mechanism behind the pre-tag rehearsal above — the same dispatch serves
+both, so a rehearsal costs nothing extra when you were going to hand testers a
+build anyway.
 
 1. **Open a prerelease metadata PR**
 


### PR DESCRIPTION
## Summary

Dispatching `Release` from `main` publishes `workspaces-v<version>-main.<run_number>` — a full signed, notarized, appcast-and-manifest run that leaves the stable channel and the Sparkle feed untouched. It is the only way to exercise the release environment without spending a version number to find out whether it works. `RELEASING.md` described it only as an optional tester handoff (Method 1A), never as the check you run before burning a tag.

This adds it as a named step before Method 1, with the download-and-staple check that distinguishes an asset that exists from an asset that works, and notes in Method 1A that one dispatch serves both purposes.

**The habit is real, not hypothetical.** It was dispatched before v0.21.0 through v0.23.0 — 2026-06-26, 06-28, 06-30, 07-07 — green every time, and skipped ahead of v0.24.0, the release that then failed four times with each failure found mid-release.

**It also covers more ground than it used to.** #1293 (2026-08-09) moved signing and notarization from the self-hosted `signing-host` runner to a hosted `macos-15` image. Every v0.24.0 attempt postdates that, all four failed, and none reached the notarization step — the latest stopped at step 4 of 22. So notarization has not yet run green on the runner that will perform it, and the rehearsal is currently the only way to learn that before a tag depends on it.

## Mergeability

- Surface: docs (release process)
- User-facing behavior changed: none. Documentation only; no workflow, script, or product code is touched. The lane being documented already exists and already works.
- Non-happy paths considered: the added step tells the operator what a failed rehearsal costs (a run number) versus a failed tag (a tag, a changelog entry, and a version), so the guidance stays useful when the rehearsal is the thing that breaks. The verification step deliberately downloads and staples rather than trusting the release page listing — the same distinction Method 1 step 4 already draws for stable releases.
- Release/ops preconditions: none to merge. Acting on it costs one extra `Release` dispatch per stable release, which is a signed and notarized run on hosted macOS.
- Residual risk or follow-up: the paragraph naming the hosted-notarization gap is dated (`as of 2026-08-13`) and should be trimmed once a hosted release reaches notarization — it is a statement about right now, not a permanent property. The rehearsal dates and run history are facts about the past and will not go stale.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - Every factual claim verified against GitHub rather than asserted: `gh run list --workflow=release.yml` for the rehearsal dates and outcomes, `git log 105d1008` for the hosted-migration date, and `gh run view` on the latest release run for how far it got (step 4 of 22, notarization at 16 never reached).
  - No markdown links added, so `docs-link-check` has nothing new to resolve; heading structure confirmed intact.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (Playwright report, test output, or equivalent)

https://evidence.cloudcompute.com/workspaces/pr-1304/20260813-054234-releasing-pre-tag-rehearsal.txt

The release-run history the claims rest on, the hosted-migration commit date, the step-level breakdown of the latest failed run, the heading structure, and the diff.

## Blockers

None.
