### PR TITLE
fix(tests): prove wait MainActor-liveness by ordering, not a sampled tick tally

### DIFF
--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -104,11 +104,13 @@ struct AutomationControllerTests {
 
     /// Polls a MainActor condition until it holds. The ceiling bounds failure only — a healthy run
     /// returns the moment the state lands — so a slow machine pays latency instead of a verdict.
-    /// Sized well past the worst main-actor starvation seen on a hosted runner (~20s for a single
-    /// test's turns) rather than past any particular hop's nominal delay.
+    /// Sized past the worst main-actor starvation measured in a full parallel run (a 120ms hop
+    /// inside a test that took 34s of wall clock), not past any particular hop's nominal delay.
+    /// A generous ceiling costs nothing on a healthy machine and everything it costs is paid by a
+    /// run that was going to fail anyway.
     @discardableResult
     private func waitForMainActorState(
-        ceiling: Duration = .seconds(30),
+        ceiling: Duration = .seconds(60),
         _ condition: () -> Bool
     ) async -> Bool {
         let deadline = ContinuousClock.now.advanced(by: ceiling)

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -95,8 +95,28 @@ struct AutomationControllerTests {
         #expect(result.createdSurfaceID == split.id.uuidString)
         #expect(fixture.store.splitLayout(for: fixture.primary.id)?.axis == .topBottom)
 
-        try await Task.sleep(for: .milliseconds(180))
+        // Focus for a new split lands on a delayed main-queue hop. Wait for the delivery itself:
+        // a sleep sized just past the nominal delay fails whenever the hop is queued behind other
+        // main-actor work, which is the normal condition on a loaded runner.
+        await waitForMainActorState { fixture.focusedSessionIDs == [split.id] }
         #expect(fixture.focusedSessionIDs == [split.id])
+    }
+
+    /// Polls a MainActor condition until it holds. The ceiling bounds failure only — a healthy run
+    /// returns the moment the state lands — so a slow machine pays latency instead of a verdict.
+    /// Sized well past the worst main-actor starvation seen on a hosted runner (~20s for a single
+    /// test's turns) rather than past any particular hop's nominal delay.
+    @discardableResult
+    private func waitForMainActorState(
+        ceiling: Duration = .seconds(30),
+        _ condition: () -> Bool
+    ) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: ceiling)
+        while ContinuousClock.now < deadline {
+            if condition() { return true }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return condition()
     }
 
     @Test("Split grows an existing split tree from the primary tile")
@@ -982,7 +1002,7 @@ struct AutomationControllerTests {
         #expect(textReads == 2)
     }
 
-    @Test("wait surface_text_matches times out typed on a catastrophic pattern, MainActor still live")
+    @Test("wait surface_text_matches times out typed on a catastrophic pattern")
     func waitSurfaceTextMatchesCatastrophicPatternTimesOut() async throws {
         let store = TileTreeStore()
         let session = store.activateSession(
@@ -993,6 +1013,9 @@ struct AutomationControllerTests {
         let operatorEntry = registry.registerOperator(appScopeID: "workspaces.local")
         // Real time, not the virtual clock: the property under test is that a pathological
         // pattern spends the wait's budget and stops, which only means anything on a real clock.
+        // That the match spends that budget off this actor is the mechanism's own property,
+        // proven against a blocked MainActor in `AutomationAPITests` — an ordering there rather
+        // than a responsiveness measurement here, which no shared runner can be asked for.
         let controller = AutomationController(
             handleRegistry: registry,
             tileTreeStore: store,
@@ -1009,41 +1032,17 @@ struct AutomationControllerTests {
             effectiveTimeoutMS: ceilingMS
         )
 
-        // A MainActor heartbeat: if the regex ran on this actor, it could not tick while the
-        // wait is in flight. Baseline it first so the count is strictly ticks during the wait.
-        let heartbeat = MainActorHeartbeat()
-        let ticker = Task { @MainActor in
-            while !Task.isCancelled {
-                heartbeat.tick()
-                try? await Task.sleep(for: .milliseconds(20))
-            }
-        }
-        defer { ticker.cancel() }
-        try await Task.sleep(for: .milliseconds(50))
-        let baselineTicks = heartbeat.count
-
-        let started = ContinuousClock.now
         let result = try await controller.automationWait(for: operatorEntry.handle, plan: plan)
-        let elapsed = ContinuousClock.now - started
-        let ticksDuringWait = heartbeat.count - baselineTicks
 
         #expect(result.outcome == .timedOut)
         #expect(result.effectiveTimeoutMS == ceilingMS)
         // `textMatched` is absent, not false: the tick abandoned its match rather than deciding it.
         #expect(result.observed.textMatched == nil)
         #expect(result.observed.surfaceLive == true)
-        // Loose bound — the claim is that the wait terminates at all, and left unbounded this
-        // match outlives the process.
-        #expect(elapsed < .seconds(30))
-        #expect(ticksDuringWait >= 2)
-    }
-
-    /// Counts MainActor turns taken while something else is awaited. A plain counter is enough:
-    /// every mutation and read happens on the MainActor.
-    @MainActor
-    private final class MainActorHeartbeat {
-        private(set) var count = 0
-        func tick() { count += 1 }
+        // No assertion on `waitedMS`: the tick's budget is whatever is left of the wait when the
+        // probe finally runs, so a runner that delays the first tick past the ceiling legitimately
+        // produces a short, still-abandoned wait. That the match spends a budget it is given is
+        // the pattern's property, asserted directly in `AutomationAPITests`.
     }
 
     @Test("wait prompt_ready times out typed when the readiness signal never arrives")

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -2454,7 +2454,9 @@ struct AutomationAPITests {
         let (match, released) = await MainActor.run { () -> (Task<Bool?, Never>, DispatchTimeoutResult) in
             // Started with this actor already held, so the match cannot have run before the block:
             // starting it outside would let a contended runner finish it first and pass vacuously.
-            let match = Task.detached { () -> Bool? in
+            // `.userInitiated` because the pool has to schedule it while the main thread is held —
+            // the one way this test can fail spuriously is a pool with no worker free to start it.
+            let match = Task.detached(priority: .userInitiated) { () -> Bool? in
                 defer { matchFinished.signal() }
                 // Small budget: this burns a core, and it burns it while the MainActor is held.
                 return await pattern.firstMatchExists(in: text, budgetMS: 120)

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -2440,6 +2440,36 @@ struct AutomationAPITests {
         #expect(elapsed < .seconds(30))
     }
 
+    @Test("A catastrophic match runs to its budget with the MainActor blocked — it never needs it")
+    func waitPatternMatchesWithoutTheMainActor() async throws {
+        // Why the app stays drawable through a pathological wait: the match never asks for the
+        // MainActor. Proven by holding that actor for the match's whole life and letting only the
+        // match's completion release it, so the claim is an ordering rather than a measurement of
+        // how responsive a shared runner felt — the shape that made the tick-tally version of this
+        // check flaky enough to abort a release (#1300).
+        let pattern = try AutomationWaitPattern("(a+)+$")
+        let text = String(repeating: "a", count: 64) + "b"
+        let matchFinished = DispatchSemaphore(value: 0)
+
+        let (match, released) = await MainActor.run { () -> (Task<Bool?, Never>, DispatchTimeoutResult) in
+            // Started with this actor already held, so the match cannot have run before the block:
+            // starting it outside would let a contended runner finish it first and pass vacuously.
+            let match = Task.detached { () -> Bool? in
+                defer { matchFinished.signal() }
+                // Small budget: this burns a core, and it burns it while the MainActor is held.
+                return await pattern.firstMatchExists(in: text, budgetMS: 120)
+            }
+            // Blocking, not suspending: a suspension would hand the actor back and prove nothing.
+            // The timeout is the failure path, never the pass path — a match that needs this actor
+            // makes the wait expire and the test fail instead of hanging the suite.
+            return (match, matchFinished.wait(timeout: .now() + 30))
+        }
+
+        #expect(released == .success)
+        // Abandoned at the budget, off-actor, while nothing could run on the MainActor.
+        #expect(await match.value == nil)
+    }
+
     // MARK: - Wait engine (virtual time — no sleeps)
 
     /// Virtual clock for the wait engine: `sleepMS` advances the counter instantly, so the


### PR DESCRIPTION
Closes #1300.

`waitSurfaceTextMatchesCatastrophicPatternTimesOut` proved that `automationWait` leaves the MainActor
live by counting 20ms heartbeat ticks inside the wait's 400ms window. On a hosted runner whose
MainActor is held by sibling tests for seconds at a time, the tally comes back `1`. It failed on
`main` @ `105d1008` ([31363515819](https://github.com/fairchild/workspaces/actions/runs/31363515819))
and again on `main` @ `040a5253`
([31560996895](https://github.com/fairchild/workspaces/actions/runs/31560996895) attempt 1), where it
turned `main` red and aborted the v0.24.0 release at `Release preflight — verify CI passed`
([31665961504](https://github.com/fairchild/workspaces/actions/runs/31665961504)). Both failing runs
report the test taking 15–20s of wall clock for a 400ms wait — the tally was measuring the runner.

## What changed

**The liveness property moved to where it can be proven by ordering.** `AutomationAPITests` now
starts the pathological match with the MainActor *already held* and lets only the match's completion
release it. A match that needed that actor cannot finish; the semaphore's 30s timeout is the failure
path, never the pass path. Nothing is sampled, so runner load costs latency instead of a verdict.

**The controller test keeps the half that was always deterministic:** a typed `timed_out` whose
`textMatched` is *absent* because the tick abandoned its match rather than deciding it. It no longer
claims anything about liveness, and it no longer asserts `elapsed < .seconds(30)` — that bound could
never catch the unbounded case (which hangs), so all it did was measure scheduling.

**Sibling in the same file:** `splitUsesHostTerminalState` slept 180ms for a 120ms `asyncAfter` focus
hop, then asserted. It now waits on the delivery itself, with a failure-only ceiling.

An ordering-based liveness check *inside* the controller test was tried first and discarded: it
passed under the mutation, because main-actor jobs run in enqueue order, so forcing the match onto
that actor delays every job equally and never reorders them. Liveness is only observable from
outside the actor — which is why the proof lives at the mechanism level now.

## Verification

Mutation binding (`Tests/AGENTS.md`), each reverted after measuring:

| Mutation | Result |
|---|---|
| Match forced onto the MainActor (`@MainActor` + inline execution) | new test fails: `(released → .timedOut) == .success`, 30.1s |
| Abandoned match reported as `false` (`?? false` in the probe) | controller test fails: `(textMatched → false) == nil` |
| Delayed split focus never delivered | split test fails at its ceiling |

Local reproduction of the CI signature, and the fix under the same condition — a temporary harness
holding the MainActor in 1s chunks (deleted, not committed):

- **before:** 2 of 4 runs failed with `Expectation failed: (ticksDuringWait → 1) >= 2` — the CI
  signature, same observed value
- **after:** 6 of 6 passed

Full `swift test` (1678 tests) ran twice; the touched tests passed in both, including under heavy
starvation (57.5s and 34.6s for tests that take 0.4s and 0.16s alone). Both runs also hit unrelated
failures, neither in this diff and both passing in isolation: `DesktopUISmokeAutomationTests`
(that is #1281) and `ClaudeIntegrationLifecycleTests` `install() is called exactly once on launch`
(filed as #1306). Stability: 10 consecutive runs of the touched suites, all green.
`mise run lint` clean.

### Evidence

**Mutation binding** — each mutation applied to production code, measured, reverted; includes the
discarded design the mutation rejected.
![mutation-binding](https://evidence.cloudcompute.com/workspaces/pr-1307/20260813-060317-mutation-binding.png)

**CI signature reproduced locally, and the fix under the same starvation** — 2/4 failures before,
6/6 passes after.
![starvation-before-after](https://evidence.cloudcompute.com/workspaces/pr-1307/20260813-060325-starvation-before-after.png)

**Suite runs, stability, lint** — 10 consecutive green runs of the touched suites, two full
`swift test` runs with their unrelated failures named.
![suite-runs-and-lint](https://evidence.cloudcompute.com/workspaces/pr-1307/20260813-060326-suite-runs-and-lint.png)

## Relation to #1281

Separate, and this fix does not generalise to it. #1281 is five fixed wall-clock *deadlines*
(`.seconds(5)`, `.seconds(15)`) in `DesktopUISmokeAutomationTests` that should scale from
`Helpers/LaunchBudget.swift`; this was a fixed *sampling window*, and scaling it would have kept the
bet at longer odds. What does carry over is the shape: where the property is observable, replacing
the sample with a causally sequenced observation beats any budget. #1281's test failed in both full
local runs here (passing 3/3 in isolation), which is fresh evidence for its diagnosis, not a fix.

## Review loop

Directed codex review (`gpt-5.6-sol`, xhigh) after self-reflection. Reflection itself caught one
defect before codex saw it: an added `waitedMS >= ceilingMS` assertion was load-dependent — a runner
that delays the first probe past the wait's deadline legitimately produces a short, still-abandoned
wait — so it was dropped rather than shipped.

| Finding | Disposition |
|---|---|
| No false-negative remains in the final shape; the detached task is created inside the held block, so completion is proof rather than a vacuous pass | Confirmed, no change |
| False-failure risk: a cooperative pool with no free worker to start the match while the main thread is held (cycle via the two `runOnMainSync` tests' `DispatchQueue.main.sync`) | Mitigated in 9b9e618a — match scheduled `.userInitiated`. Margin, not a fix: three CPUs against two known blockers leave one worker spare, and a genuine cycle still surfaces as a 30s failure rather than a hang. Named in residual risk below |
| `textMatched == nil` is not *formally* guaranteed: abandonment depends on `NSRegularExpression` firing a `.reportProgress` callback, which Foundation promises only "periodically" | Accepted, unchanged. The same assumption already carries `waitPatternAbandonsCatastrophicMatchAtBudget`; without a progress callback the pattern would not abort at all, which is a hang, not a `false`. Starvation makes `nil` more likely, not less |
| Split poll no longer catches a *duplicate* second focus delivery that the 180ms sleep might have | Declined. Production schedules exactly one callback; asserting the absence of a second is precisely the window bet this PR removes |
| Inventory of remaining wall-clock samples: the WebKit (800ms) and window-snapshot (400ms) paint waits, and the listener smoke's 250ms sleep | Out of scope, all pre-existing and all in front of *conditional* assertions except the listener smoke; recorded on #1300 as follow-up |
| Recent merges do not change this diff's assumptions (`AutomationWait.swift` untouched since #1265; #1296–#1298 changed only the release lane) | Confirmed, rebased on `origin/main` |

## Mergeability

- **Surface:** tests only — `Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift`,
  `Tests/WorkspaceManagerTests/AutomationAPITests.swift`. No production code changed.
- **User-facing behavior changed:** none. The behaviour the tests describe — a pathological
  `surface_text_matches` pattern burns its budget off the MainActor and returns a typed `timed_out` —
  is unchanged and now asserted more strictly.
- **Non-happy paths considered:** match forced onto the MainActor (caught, 30s deterministic
  failure); abandoned match reported as a decision (caught); delayed focus never delivered (caught);
  first probe delayed past the wait's own deadline (no longer asserted against); a starved runner
  (measured — passes at 57s of scheduling delay).
- **Residual risk or follow-up:** the new test blocks the main thread for the match's 120ms budget.
  If every cooperative-pool worker were simultaneously blocked in `DispatchQueue.main.sync`, the
  match could not start and the test would fail at 30s rather than hang; on `macos-15`'s three CPUs
  the two `runOnMainSync` tests leave a worker spare, so this needs a third concurrent blocker to
  bite. If it ever fires the signature is `(released → .timedOut) == .success` and the analysis is
  here. Follow-ups tracked on #1300 (remaining fixed sleeps in these files) and #1281 (LaunchBudget
  scaling in the smoke suite).
