### PR TITLE
fix(runners): stop a finished job from reading as a passing one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,11 @@ the API — so the hook records the run id and `runners.py` resolves the verdict
 when it renders. Anything GitHub has not confirmed reads `? unknown` rather than
 as a pass, and lines predating the run id stay that way permanently.
 
+A concluded attempt never revises its verdict, so answers are kept in
+`~/.local/share/runner-activity-outcomes.json` and only unseen lines cost an API
+call — which is also what lets `--offline` show real outcomes for jobs already
+looked up. Delete that file to re-fetch everything.
+
 It supersedes `runner-status.sh`, which reads a hardcoded list of three runner
 directories and never asks GitHub anything. On a machine with twelve runner
 directories that meant nine were invisible, and a runner whose registration had

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ brew install --cask swiftbar
 
 - Menu bar shows `CI` with a status icon (gray checkmark = idle, orange hammer = running)
 - Click to expand: per-runner status, recent activity log
-- Hooks log every job start/complete to `~/.local/share/runner-activity.log`
+- Hooks log every job start/end to `~/.local/share/runner-activity.log`
 
 **CLI status check** (no SwiftBar needed):
 
@@ -181,6 +181,12 @@ registration deleted server-side while launchd still lists the job shows up as
 `dead` rather than merely quiet. Exit status is 1 when any runner is dead, which
 makes it usable as a gate.
 
+The recent-jobs block reports what each finished job actually did. The
+completed-job hook cannot know that — job status reaches a runner only through
+the API — so the hook records the run id and `runners.py` resolves the verdict
+when it renders. Anything GitHub has not confirmed reads `? unknown` rather than
+as a pass, and lines predating the run id stay that way permanently.
+
 It supersedes `runner-status.sh`, which reads a hardcoded list of three runner
 directories and never asks GitHub anything. On a machine with twelve runner
 directories that meant nine were invisible, and a runner whose registration had
@@ -195,7 +201,7 @@ been deleted was indistinguishable from one that was merely offline.
 | `runner-ci-menubar.5s.sh` | SwiftBar plugin (installed into plugin folder) |
 | `install-runner-ci-menubar.sh` | Installs the SwiftBar plugin as a durable local copy |
 | `runner-notify-start.sh` | Runner hook: logs job start to activity log |
-| `runner-notify-complete.sh` | Runner hook: logs job completion to activity log |
+| `runner-notify-complete.sh` | Runner hook: logs that a job ended, plus the run id to resolve its outcome against |
 | `install-runner-hooks.sh` | Installs hooks on all runners (copies scripts, updates .env) |
 
 Parked, revival intended (owner decision 2026-08-02): kept despite low day-to-day use while the primary CI lane is GitHub-hosted/Lume-backed — do not re-flag as dead code in future cleanup passes.

--- a/scripts/runner-notify-complete.sh
+++ b/scripts/runner-notify-complete.sh
@@ -2,6 +2,14 @@
 # GitHub Actions runner hook: called when a job completes.
 # Set ACTIONS_RUNNER_HOOK_JOB_COMPLETED to point at an installed copy of this script.
 #
+# The hook cannot know whether the job passed. Job status reaches a runner only
+# through the API — it is absent from the hook environment, by design:
+# https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts
+# So this line records the job's identity, not its outcome: END (the job
+# stopped) plus the run id and attempt, which scripts/runners.py resolves
+# against GitHub when it renders. The word here used to be DONE, and a failed
+# v0.24.0 release was read as a passing one because of it.
+#
 # SAFETY: This script must NEVER exit non-zero — a failing hook fails the CI job.
 # All work is wrapped in a subshell with || true, and we exit 0 unconditionally.
 
@@ -14,9 +22,17 @@
     ref="$(sanitize "${GITHUB_REF_NAME:-?}")"
     ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 
+    # Identity of the run to ask about later. Attempt is recorded only when it
+    # is a re-run: the run-level conclusion reports the newest attempt, so an
+    # older attempt's line would otherwise inherit a verdict it never earned.
+    run=""
+    [[ "${GITHUB_RUN_ID:-}" =~ ^[0-9]+$ ]] && run="  run=${GITHUB_RUN_ID}"
+    [[ -n "$run" && "${GITHUB_RUN_ATTEMPT:-1}" =~ ^[0-9]+$ && "${GITHUB_RUN_ATTEMPT:-1}" -gt 1 ]] &&
+        run="${run}  attempt=${GITHUB_RUN_ATTEMPT}"
+
     log="$HOME/.local/share/runner-activity.log"
     mkdir -p "$(dirname "$log")"
-    printf '%s  DONE   %-14s  %s/%s  %s\n' "$ts" "$repo" "$workflow" "$job" "$ref" >> "$log"
+    printf '%s  END    %-14s  %s/%s  %s%s\n' "$ts" "$repo" "$workflow" "$job" "$ref" "$run" >> "$log"
 ) >/dev/null 2>&1 || true
 
 exit 0

--- a/scripts/runners.py
+++ b/scripts/runners.py
@@ -254,7 +254,7 @@ JOB_LINE = re.compile(
     r"(?:\s+run=(?P<run>\d+))?(?:\s+attempt=(?P<attempt>\d+))?\s*$"
 )
 
-OUTCOME: dict[str, tuple[str, str]] = {
+OUTCOME_GLYPH: dict[str, tuple[str, str]] = {
     "success": ("✓", "32"),
     "failure": ("✗", "31"),
     "cancelled": ("⊘", "33"),
@@ -363,7 +363,7 @@ def outcome(line: str, found: dict[JobRef, str]) -> str:
         return ""
     ref = job_ref(line)
     verdict = found.get(ref, "") if ref else ""
-    glyph, code = OUTCOME.get(verdict, ("?", "90"))
+    glyph, code = OUTCOME_GLYPH.get(verdict, ("?", "90"))
     return "  " + paint(f"{glyph} {verdict or 'unknown'}", code)
 
 

--- a/scripts/runners.py
+++ b/scripts/runners.py
@@ -263,6 +263,14 @@ OUTCOME: dict[str, tuple[str, str]] = {
 }
 
 
+OUTCOME_CACHE = HOME / ".local/share/runner-activity-outcomes.json"
+
+# Each unresolved line costs one `gh api` call (~1s). Past this many, the
+# oldest stay unresolved and render as unknown — degrading toward "I don't
+# know" is safe; degrading toward "it passed" is the bug being fixed.
+RESOLVE_LIMIT = 16
+
+
 @dataclass(frozen=True)
 class JobRef:
     """The GitHub run a completed-job line points at."""
@@ -274,6 +282,27 @@ class JobRef:
     def api_path(self, full_repo: str) -> str:
         base = f"repos/{full_repo}/actions/runs/{self.run}"
         return base if self.attempt <= 1 else f"{base}/attempts/{self.attempt}"
+
+    def key(self, full_repo: str) -> str:
+        return f"{full_repo}#{self.run}#{self.attempt}"
+
+
+def cached_outcomes() -> dict[str, str]:
+    """Verdicts already fetched. A concluded attempt never changes its mind,
+    so this is a permanent record, not a staleness risk."""
+    try:
+        stored = json.loads(OUTCOME_CACHE.read_text())
+        return stored if isinstance(stored, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def remember_outcomes(verdicts: dict[str, str]) -> None:
+    try:
+        OUTCOME_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        OUTCOME_CACHE.write_text(json.dumps(verdicts, sort_keys=True, indent=0))
+    except OSError:
+        pass
 
 
 def job_ref(line: str) -> JobRef | None:
@@ -289,28 +318,37 @@ def job_ref(line: str) -> JobRef | None:
 
 
 def conclusions(lines: Iterable[str], runners: list[Runner], offline: bool) -> dict[JobRef, str]:
-    """Ask GitHub how each logged run actually ended.
+    """How each logged run actually ended, per GitHub.
 
     The completed-job hook has no access to job status — it is API-only, per
     docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts
-    — so the log records identity and the verdict is fetched here.
+    — so the log records identity and the verdict is fetched here, then kept.
+    Only lines never seen before cost a call, which is why a log that grows by
+    a job a week does not turn into a per-invocation tax.
     """
-    if offline:
-        return {}
     full = {r.repo.split("/")[-1]: r.repo for r in runners if "/" in r.repo}
     refs = sorted(
         {ref for ref in map(job_ref, lines) if ref and ref.repo in full},
-        key=lambda r: (r.repo, r.run, r.attempt),
+        key=lambda r: (r.repo, int(r.run), r.attempt),
     )
     if not refs:
         return {}
 
-    def fetch(ref: JobRef) -> tuple[JobRef, str]:
-        payload = gh_json(ref.api_path(full[ref.repo]))
-        return ref, payload.get("conclusion") or ""
+    stored = cached_outcomes()
+    found = {ref: stored[ref.key(full[ref.repo])] for ref in refs if ref.key(full[ref.repo]) in stored}
+    pending = [ref for ref in refs if ref not in found][-RESOLVE_LIMIT:]
+    if offline or not pending:
+        return found
 
-    with cf.ThreadPoolExecutor(max_workers=min(8, len(refs))) as pool:
-        return {ref: verdict for ref, verdict in pool.map(fetch, refs) if verdict}
+    def fetch(ref: JobRef) -> tuple[JobRef, str]:
+        return ref, gh_json(ref.api_path(full[ref.repo])).get("conclusion") or ""
+
+    with cf.ThreadPoolExecutor(max_workers=min(8, len(pending))) as pool:
+        fresh = {ref: verdict for ref, verdict in pool.map(fetch, pending) if verdict}
+    if fresh:
+        # Runs still in flight resolve to "" and are deliberately not stored.
+        remember_outcomes(stored | {ref.key(full[ref.repo]): v for ref, v in fresh.items()})
+    return found | fresh
 
 
 def outcome(line: str, found: dict[JobRef, str]) -> str:

--- a/scripts/runners.py
+++ b/scripts/runners.py
@@ -248,6 +248,87 @@ def last_logged_job() -> float | None:
     return None
 
 
+JOB_LINE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)\s+(?P<kind>START|END|DONE)\s+"
+    r"(?P<repo>\S+)\s+(?P<job>\S+)\s+(?P<ref>\S+)"
+    r"(?:\s+run=(?P<run>\d+))?(?:\s+attempt=(?P<attempt>\d+))?\s*$"
+)
+
+OUTCOME: dict[str, tuple[str, str]] = {
+    "success": ("✓", "32"),
+    "failure": ("✗", "31"),
+    "cancelled": ("⊘", "33"),
+    "timed_out": ("⊘", "33"),
+    "startup_failure": ("✗", "31"),
+}
+
+
+@dataclass(frozen=True)
+class JobRef:
+    """The GitHub run a completed-job line points at."""
+
+    repo: str          # basename, as the hook logs it
+    run: str
+    attempt: int = 1
+
+    def api_path(self, full_repo: str) -> str:
+        base = f"repos/{full_repo}/actions/runs/{self.run}"
+        return base if self.attempt <= 1 else f"{base}/attempts/{self.attempt}"
+
+
+def job_ref(line: str) -> JobRef | None:
+    """The run an END line identifies, or None when the line identifies none.
+
+    START lines describe a job that had not finished, and the legacy DONE
+    format predates run ids, so neither can be resolved to an outcome.
+    """
+    found = JOB_LINE.match(line)
+    if not found or found.group("kind") != "END" or not found.group("run"):
+        return None
+    return JobRef(found.group("repo"), found.group("run"), int(found.group("attempt") or 1))
+
+
+def conclusions(lines: Iterable[str], runners: list[Runner], offline: bool) -> dict[JobRef, str]:
+    """Ask GitHub how each logged run actually ended.
+
+    The completed-job hook has no access to job status — it is API-only, per
+    docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts
+    — so the log records identity and the verdict is fetched here.
+    """
+    if offline:
+        return {}
+    full = {r.repo.split("/")[-1]: r.repo for r in runners if "/" in r.repo}
+    refs = sorted(
+        {ref for ref in map(job_ref, lines) if ref and ref.repo in full},
+        key=lambda r: (r.repo, r.run, r.attempt),
+    )
+    if not refs:
+        return {}
+
+    def fetch(ref: JobRef) -> tuple[JobRef, str]:
+        payload = gh_json(ref.api_path(full[ref.repo]))
+        return ref, payload.get("conclusion") or ""
+
+    with cf.ThreadPoolExecutor(max_workers=min(8, len(refs))) as pool:
+        return {ref: verdict for ref, verdict in pool.map(fetch, refs) if verdict}
+
+
+def outcome(line: str, found: dict[JobRef, str]) -> str:
+    """Suffix stating what a finished job did — never inferred from the line.
+
+    A hook line records only that the job stopped. Anything GitHub has not
+    confirmed renders as unknown; keeping that ambiguity visible is the point,
+    since reading "it ended" as "it passed" is what hid a failed release.
+    """
+    parsed = JOB_LINE.match(line)
+    if not parsed or parsed.group("kind") == "START":
+        return ""
+    ref = job_ref(line)
+    verdict = found.get(ref, "") if ref else ""
+    glyph, code = OUTCOME.get(verdict, ("?", "90"))
+    return "  " + paint(f"{glyph} {verdict or 'unknown'}", code)
+
+
 ENTRY = re.compile(r"^===== (\S+) =====$", re.M)
 IN_FLIGHT = re.compile(r"--- CI job processes in flight ---\n(.*?)(?=\n--- |\Z)", re.S)
 
@@ -355,8 +436,9 @@ def render(runners: list[Runner], repos: dict[str, RepoState], args) -> None:
     print()
     print(paint("RECENT JOBS", "1") + dim(f"  {ACTIVITY_LOG}"))
     if log_lines:
+        found = conclusions(log_lines, runners, args.offline)
         for line in log_lines:
-            print(f"  {line}")
+            print(f"  {line}{outcome(line, found)}")
         newest = last_logged_job()
         note = f"  newest entry {ago(newest)}"
         print(dim(note) if newest and time.time() - newest < 7 * 86400

--- a/scripts/tests/test_runners.py
+++ b/scripts/tests/test_runners.py
@@ -175,6 +175,15 @@ class JobOutcomeTests(unittest.TestCase):
     LEGACY = "2026-08-10T02:04:48Z  DONE   workspaces      Release/build  v0.24.0"
     START = "2026-08-10T01:59:00Z  START  workspaces      Release/build  v0.24.0"
 
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.original = runners.OUTCOME_CACHE
+        runners.OUTCOME_CACHE = Path(self.tmp.name) / "outcomes.json"
+
+    def tearDown(self) -> None:
+        runners.OUTCOME_CACHE = self.original
+        self.tmp.cleanup()
+
     def test_failed_run_reads_as_failure_not_as_completion(self) -> None:
         ref = runners.job_ref(self.END)
         assert ref is not None
@@ -226,6 +235,76 @@ class JobOutcomeTests(unittest.TestCase):
     def test_a_repo_with_no_local_runner_is_not_queried(self) -> None:
         # Nothing maps "workspaces" to an owner, so there is no URL to ask.
         self.assertEqual(runners.conclusions([self.END], [], offline=False), {})
+
+
+class OutcomeResolutionTests(unittest.TestCase):
+    """Asking GitHub is the only way to know, so ask once and keep the answer.
+
+    A concluded attempt never changes its verdict, which makes the answer
+    cacheable forever and keeps the cost proportional to new jobs rather than
+    to how often the tool is run.
+    """
+
+    LINE = "2026-08-10T02:04:48Z  END    workspaces  Release/build  v0.24.0  run=31345686688"
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.original_cache = runners.OUTCOME_CACHE
+        self.original_gh = runners.gh_json
+        runners.OUTCOME_CACHE = Path(self.tmp.name) / "outcomes.json"
+        self.calls: list[str] = []
+        self.runners = [make(repo="fairchild/workspaces")]
+
+    def tearDown(self) -> None:
+        runners.OUTCOME_CACHE = self.original_cache
+        runners.gh_json = self.original_gh
+        self.tmp.cleanup()
+
+    def answer(self, conclusion: str | None) -> None:
+        def fake(path: str) -> dict:
+            self.calls.append(path)
+            return {"conclusion": conclusion}
+
+        runners.gh_json = fake
+
+    def resolve(self, lines: list[str] | None = None, offline: bool = False) -> dict:
+        return runners.conclusions(lines or [self.LINE], self.runners, offline=offline)
+
+    def test_a_verdict_is_fetched_once_and_then_remembered(self) -> None:
+        self.answer("failure")
+        self.assertEqual(list(self.resolve().values()), ["failure"])
+        self.assertEqual(len(self.calls), 1)
+
+        self.answer(None)  # a second fetch would now return nothing
+        self.assertEqual(list(self.resolve().values()), ["failure"])
+        self.assertEqual(len(self.calls), 1, "cached verdict was re-fetched")
+
+    def test_a_run_still_in_flight_is_not_remembered_as_a_verdict(self) -> None:
+        self.answer(None)
+        self.assertEqual(self.resolve(), {})
+        self.answer("success")
+        self.assertEqual(list(self.resolve().values()), ["success"])
+
+    def test_offline_still_reports_what_is_already_known(self) -> None:
+        self.answer("failure")
+        self.resolve()
+        self.assertEqual(list(self.resolve(offline=True).values()), ["failure"])
+
+    def test_offline_with_nothing_known_resolves_nothing(self) -> None:
+        self.answer("failure")
+        self.assertEqual(self.resolve(offline=True), {})
+        self.assertEqual(self.calls, [])
+
+    def test_a_long_log_resolves_its_newest_lines_and_leaves_the_rest_unknown(self) -> None:
+        self.answer("success")
+        lines = [
+            f"2026-08-10T02:04:48Z  END    workspaces  CI/build  main  run={31000000000 + n}"
+            for n in range(runners.RESOLVE_LIMIT + 4)
+        ]
+        found = self.resolve(lines)
+        self.assertEqual(len(self.calls), runners.RESOLVE_LIMIT)
+        self.assertIn("unknown", runners.outcome(lines[0], found))
+        self.assertIn("success", runners.outcome(lines[-1], found))
 
 
 class CompletedHookTests(unittest.TestCase):

--- a/scripts/tests/test_runners.py
+++ b/scripts/tests/test_runners.py
@@ -6,10 +6,10 @@
 """Tests for scripts/runners.py — the self-hosted runner status view.
 
 Intent: the tool exists because dead runners were invisible for weeks, so the
-behaviour worth locking is that it never reports a dead signal as healthy. Two
+behaviour worth locking is that it never reports a dead signal as healthy. Three
 classes of test: the verdict a runner gets when its three sources of truth
-disagree, and the freshness of the activity log being read from log *content*
-rather than file mtime.
+disagree, the freshness of the activity log being read from log *content* rather
+than file mtime, and a finished job never reading as a passing one.
 """
 
 from __future__ import annotations
@@ -17,6 +17,7 @@ from __future__ import annotations
 import calendar
 import importlib.util
 import os
+import subprocess
 import sys
 import tempfile
 import time
@@ -25,6 +26,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "runners.py"
+COMPLETE_HOOK = REPO_ROOT / "scripts" / "runner-notify-complete.sh"
 
 spec = importlib.util.spec_from_file_location("runners", SCRIPT_PATH)
 assert spec and spec.loader
@@ -158,6 +160,148 @@ class GitconfigCorrelationTests(unittest.TestCase):
 
     def test_absent_watcher_yields_nothing_rather_than_a_false_all_clear(self) -> None:
         self.assertEqual(runners.gitconfig_writes(), [])
+
+
+class JobOutcomeTests(unittest.TestCase):
+    """"The job ended" is not "the job passed", and the log line cannot say which.
+
+    A failed v0.24.0 release was read as a successful one because the completed
+    hook wrote DONE the moment the job stopped. Job status is API-only, so the
+    outcome shown here comes from GitHub or is reported as unknown.
+    """
+
+    END = "2026-08-10T02:04:48Z  END    workspaces      Release/build  v0.24.0  run=31345686688"
+    RERUN = END + "  attempt=2"
+    LEGACY = "2026-08-10T02:04:48Z  DONE   workspaces      Release/build  v0.24.0"
+    START = "2026-08-10T01:59:00Z  START  workspaces      Release/build  v0.24.0"
+
+    def test_failed_run_reads_as_failure_not_as_completion(self) -> None:
+        ref = runners.job_ref(self.END)
+        assert ref is not None
+        rendered = runners.outcome(self.END, {ref: "failure"})
+        self.assertIn("failure", rendered)
+        self.assertNotIn("success", rendered)
+
+    def test_confirmed_success_says_so(self) -> None:
+        ref = runners.job_ref(self.END)
+        assert ref is not None
+        self.assertIn("success", runners.outcome(self.END, {ref: "success"}))
+
+    def test_unresolved_run_is_unknown_rather_than_a_pass(self) -> None:
+        # GitHub unreachable, --offline, or a run since deleted.
+        self.assertIn("unknown", runners.outcome(self.END, {}))
+        self.assertNotIn("success", runners.outcome(self.END, {}))
+
+    def test_legacy_done_lines_claim_nothing(self) -> None:
+        # Seven months of history predate run ids; they must stay unresolvable
+        # rather than borrow a verdict from a neighbouring line.
+        self.assertIsNone(runners.job_ref(self.LEGACY))
+        self.assertIn("unknown", runners.outcome(self.LEGACY, {}))
+
+    def test_start_lines_carry_no_outcome_at_all(self) -> None:
+        self.assertEqual(runners.outcome(self.START, {}), "")
+
+    def test_a_rerun_does_not_inherit_the_first_attempts_verdict(self) -> None:
+        first, again = runners.job_ref(self.END), runners.job_ref(self.RERUN)
+        assert first is not None and again is not None
+        self.assertNotEqual(first, again)
+        self.assertIn("unknown", runners.outcome(self.RERUN, {first: "success"}))
+
+    def test_attempts_resolve_against_the_attempt_endpoint(self) -> None:
+        first, again = runners.job_ref(self.END), runners.job_ref(self.RERUN)
+        assert first is not None and again is not None
+        self.assertEqual(
+            first.api_path("fairchild/workspaces"),
+            "repos/fairchild/workspaces/actions/runs/31345686688",
+        )
+        self.assertEqual(
+            again.api_path("fairchild/workspaces"),
+            "repos/fairchild/workspaces/actions/runs/31345686688/attempts/2",
+        )
+
+    def test_offline_resolves_nothing_instead_of_guessing(self) -> None:
+        runner = make(repo="fairchild/workspaces")
+        self.assertEqual(runners.conclusions([self.END], [runner], offline=True), {})
+
+    def test_a_repo_with_no_local_runner_is_not_queried(self) -> None:
+        # Nothing maps "workspaces" to an owner, so there is no URL to ask.
+        self.assertEqual(runners.conclusions([self.END], [], offline=False), {})
+
+
+class CompletedHookTests(unittest.TestCase):
+    """The hook records identity and never fails the job it is reporting on."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self.tmp.name)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def fire(self, **env: str) -> str:
+        result = subprocess.run(
+            ["bash", str(COMPLETE_HOOK)],
+            capture_output=True,
+            text=True,
+            env={"HOME": str(self.home), "PATH": os.environ.get("PATH", ""), **env},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        log = self.home / ".local/share/runner-activity.log"
+        return log.read_text() if log.is_file() else ""
+
+    def test_logs_the_end_of_the_job_and_the_run_to_ask_about(self) -> None:
+        line = self.fire(
+            GITHUB_REPOSITORY="fairchild/workspaces",
+            GITHUB_JOB="build-sign-notarize-release",
+            GITHUB_WORKFLOW="Release",
+            GITHUB_REF_NAME="v0.24.0",
+            GITHUB_RUN_ID="31345686688",
+        ).strip()
+        self.assertIn("END", line)
+        self.assertNotIn("DONE", line)
+        self.assertEqual(runners.job_ref(line), runners.JobRef("workspaces", "31345686688", 1))
+
+    def test_a_rerun_records_which_attempt_it_was(self) -> None:
+        line = self.fire(
+            GITHUB_REPOSITORY="fairchild/workspaces",
+            GITHUB_JOB="build",
+            GITHUB_WORKFLOW="Release",
+            GITHUB_REF_NAME="v0.24.0",
+            GITHUB_RUN_ID="31345686688",
+            GITHUB_RUN_ATTEMPT="2",
+        ).strip()
+        ref = runners.job_ref(line)
+        assert ref is not None
+        self.assertEqual(ref.attempt, 2)
+
+    def test_first_attempt_stays_unadorned(self) -> None:
+        line = self.fire(
+            GITHUB_REPOSITORY="fairchild/workspaces",
+            GITHUB_JOB="build",
+            GITHUB_WORKFLOW="Release",
+            GITHUB_REF_NAME="main",
+            GITHUB_RUN_ID="1",
+            GITHUB_RUN_ATTEMPT="1",
+        )
+        self.assertNotIn("attempt=", line)
+
+    def test_a_job_with_no_run_id_still_logs_and_still_exits_clean(self) -> None:
+        # A hook that exits non-zero fails the CI job it is only observing, so
+        # missing environment degrades the line rather than the run.
+        line = self.fire().strip()
+        self.assertIn("END", line)
+        self.assertIsNone(runners.job_ref(line))
+
+    def test_line_stays_parseable_when_the_ref_is_hostile(self) -> None:
+        line = self.fire(
+            GITHUB_REPOSITORY="fairchild/workspaces",
+            GITHUB_JOB="build",
+            GITHUB_WORKFLOW="Release",
+            GITHUB_REF_NAME='we|ird"ref',
+            GITHUB_RUN_ID="99",
+        ).strip()
+        self.assertNotIn("|", line)
+        self.assertEqual(runners.job_ref(line), runners.JobRef("workspaces", "99", 1))
 
 
 class FormattingTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- `runner-activity.log` said `DONE` the moment a job stopped. During the v0.24.0 arc that line was read as a successful release; the run had failed and never published. The log wasn't wrong, it was mute — mute in a shape that looks like good news.
- The hook can't fix that by knowing more: job status reaches a runner only through the API and is deliberately absent from the hook environment ([docs](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts), [community #28644](https://github.com/orgs/community/discussions/28644)). So the hook now records *identity* — `END`, plus the run id — and `runners.py` resolves the verdict against GitHub when it renders.
- Attempt is recorded on re-runs, because the run-level conclusion reports the newest attempt only. Without it an earlier attempt's line inherits a verdict it never earned — the same bug one layer down.
- A concluded attempt never revises its verdict, so answers are kept in `~/.local/share/runner-activity-outcomes.json`. Cost tracks new jobs, not invocations: measured ~1s per unresolved line, and zero once seen. That also gives `--offline` real outcomes for anything already looked up.

Rendered against the real run ids, including the three failed v0.24.0 attempts:

```
RECENT JOBS
  2026-07-11T23:45:48Z  END    workspaces  Release/build-sign-notarize-release  v0.23.0  run=29139329947  ✓ success
  2026-08-10T02:04:48Z  END    workspaces  Release/build-sign-notarize-release  v0.24.0  run=31345686688  ✗ failure
  2026-08-12T01:08:31Z  END    workspaces  Release/build-sign-notarize-release  v0.24.0  run=31552428291  ✗ failure
  2026-08-13T04:11:35Z  END    workspaces  Release/build-sign-notarize-release  v0.24.0  run=31665961504  ✗ failure
  2026-08-13T04:00:00Z  START  workspaces  Release/build-sign-notarize-release  v0.24.0
  2026-07-11T04:18:39Z  DONE   workspaces  Release/build-sign-notarize-release  v0.23.0  ? unknown
```

Closes the top follow-up from the 2026-08-09 self-hosted CI cleanup session.

## Mergeability

- Surface: infra — self-hosted runner observability (`scripts/runners.py`, the completed-job hook). No product code.
- User-facing behavior changed: No. `runners.py` gains an outcome column on its recent-jobs block; the hook writes `END` where it wrote `DONE`.
- Non-happy paths considered: `--offline`, unreachable/slow API, a run since deleted, a run still in flight, a repo with no local runner, a cold cache on a long `--activity N` (capped at 16 live lookups), and seven months of legacy `DONE` lines — all render `? unknown` rather than a pass. The hook still exits 0 with no environment at all, since a non-zero hook fails the CI job it is only observing; a hostile `GITHUB_REF_NAME` stays sanitized and parseable. A corrupt or unwritable cache file degrades to re-fetching, never to a crash.
- Release/ops preconditions: None. No release-sensitive path changes. The new format only reaches the log after `./scripts/install-runner-hooks.sh` re-copies the hook onto `blue-workspaces`; until then lines keep the legacy shape and read `? unknown`, which is the pre-existing behavior stated honestly.
- Residual risk or follow-up: The SwiftBar plugin prints log lines verbatim, so it shows `END` without an outcome — resolving there would need the same lookup on a 5s refresh, which is what the cache would make affordable. `--json` still reports runners only, not recent jobs. The cache file is new state on the machine; deleting it re-fetches.

## Validation

- [x] `uv run scripts/tests/test_runners.py` — **34 tests passed** (was 16; 18 new)
- [x] `bash -n scripts/runner-notify-complete.sh`
- [x] Ran `./scripts/runners.py` and `--offline` against the live log on `blue.local`
- [x] Resolved real run ids through the live API (output above); cold ~1.7s for 4 lines, 0 calls warm
- [ ] `swift build` / `swift test` — not applicable, no Swift touched

New tests cover the behavior, not the plumbing: a failed run reads as failure and never as success; unresolved runs and legacy lines read unknown; a re-run does not inherit the first attempt's verdict; attempts resolve against the attempt endpoint; `START` lines get no outcome; a verdict is fetched once and then remembered; a run still in flight is not remembered; `--offline` reports what is known and nothing more; a long log resolves its newest lines and leaves the rest unknown; and the hook itself logs `END` + run id, records attempt only on re-runs, sanitizes a hostile ref, and exits 0 with an empty environment.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (test output, command above)

Command and result:

```
$ uv run --quiet scripts/tests/test_runners.py
..................................
Ran 34 tests in 0.896s

OK
```

## Blockers

- [x] None
