### PR TITLE
fix(perf): bound the installed lane's teardown and sweep for survivors

### DIFF
--- a/scripts/launch-installed-diagnostics.sh
+++ b/scripts/launch-installed-diagnostics.sh
@@ -3,6 +3,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/perf-process.sh"
+
 usage() {
     cat <<'EOF'
 Usage:
@@ -144,11 +147,19 @@ CAPTURE_START="$(date '+%Y-%m-%d %H:%M:%S')"
 
 if [[ "$CAPTURE_SECONDS" -gt 0 ]]; then
     echo "  capture_seconds: $CAPTURE_SECONDS"
+    perf_assert_no_instance "$APP_PATH" "$(basename "$0")"
     env "${ENV_VARS[@]}" "$APP_PATH" "${APP_ARGS[@]}" > >(tee "$LOG_FILE") 2>&1 &
     APP_PID=$!
     sleep "$CAPTURE_SECONDS"
-    kill "$APP_PID" 2>/dev/null || true
+    perf_stop_launched_app "$APP_PID" || {
+        echo "the launched app survived SIGKILL (pid $APP_PID)" >&2
+        exit 1
+    }
+    # `wait` only after the pid is confirmed gone: against an app that ignores
+    # SIGTERM it blocks forever, and the interrupt that ends that wait is what
+    # leaves the instance behind.
     wait "$APP_PID" 2>/dev/null || true
+    perf_assert_clean_exit "$APP_PATH" "$(basename "$0")"
     append_unified_log "$CAPTURE_START"
 else
     env "${ENV_VARS[@]}" "$APP_PATH" "${APP_ARGS[@]}" 2>&1 | tee "$LOG_FILE"

--- a/scripts/lib/perf-process.sh
+++ b/scripts/lib/perf-process.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Teardown contract shared by the perf lanes. A harness that leaves its subject
+# running measures a loaded machine on the next lane rather than a launch, which
+# is how the first #1251 measurement pass was invalidated (#1277).
+#
+# Two rules hold everywhere: signals go only to a pid this run launched, never to
+# whatever a pattern matches; and a lane reports success only after the process
+# table is observably clear.
+
+# `pgrep -f` matches a regex against whole command lines, and binary paths are
+# full of `.` metacharacters that would otherwise match anything.
+perf_escape_pattern() {
+    printf '%s' "$1" | sed 's/[][\\.*^$(){}?+|]/\\&/g'
+}
+
+# Pids actually *running* the named binary.
+#
+# Anchored, because these lanes take the binary as `--app <path>`: an unanchored
+# search finds the very string in the harness's own argv and every script in the
+# chain reports itself as a survivor. A process running the app has the binary at
+# the *start* of its command line; a harness mentioning it never does.
+#
+# Matching on the command line rather than `ps -o comm=` is deliberate — on macOS
+# `comm` reports argv[0], so a process is free to present any name it likes there.
+perf_instance_pids() {
+    pgrep -f -- "^$(perf_escape_pattern "$1")" 2>/dev/null || true
+}
+
+# Read-only on purpose: an instance this run did not start belongs to someone
+# else — a `launch-dev.sh` app, a concurrent capture — so the lane refuses to
+# measure beside it rather than killing something it does not own.
+perf_assert_no_instance() {
+    local binary="$1" label="$2" pids
+    pids="$(perf_instance_pids "$binary")"
+    [[ -z "$pids" ]] && return 0
+    echo "  [$label] a WorkspaceManager matching this lane's binary is already running: $(echo "$pids" | tr '\n' ' ')" >&2
+    echo "  [$label] refusing to measure beside it — stop it and re-run." >&2
+    return 1
+}
+
+# TERM, then KILL on a deadline, and only ever the pid this invocation launched.
+# Bounded on purpose: a plain `kill` followed by `wait` blocks forever against an
+# app that does not act on SIGTERM, and whatever interrupts that wait leaves the
+# instance behind.
+perf_stop_launched_app() {
+    local pid="$1" attempt
+    kill "$pid" 2>/dev/null || true
+    for attempt in $(seq 1 40); do
+        kill -0 "$pid" 2>/dev/null || return 0
+        sleep 0.25
+    done
+    echo "  escalating to SIGKILL for launched pid $pid" >&2
+    kill -9 "$pid" 2>/dev/null || true
+    for attempt in $(seq 1 20); do
+        kill -0 "$pid" 2>/dev/null || return 0
+        sleep 0.25
+    done
+    return 1
+}
+
+# The post-condition. Loud on purpose: a survivor that only shows up as a slower
+# number in the next lane is the failure this whole file exists to prevent.
+perf_assert_clean_exit() {
+    local binary="$1" label="$2" pids
+    pids="$(perf_instance_pids "$binary")"
+    [[ -z "$pids" ]] && return 0
+    echo "  [$label] a WorkspaceManager survived teardown: $(echo "$pids" | tr '\n' ' ')" >&2
+    echo "  [$label] later lanes would measure a loaded machine — failing rather than reporting a number." >&2
+    return 1
+}

--- a/scripts/perf-runner.sh
+++ b/scripts/perf-runner.sh
@@ -38,6 +38,7 @@ EOF
 }
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$ROOT_DIR/scripts/lib/perf-process.sh"
 SCENARIO=""
 APP_PATH="/Applications/WorkSpaces.app/Contents/MacOS/WorkspaceManager"
 RUNS=5
@@ -268,6 +269,23 @@ run_channel() {
     fi
     UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/workspaces-uv-cache}" "${cmd[@]}"
 }
+
+# Whole-run sweep. Each lane already gates its own teardown, but a scenario that
+# exits early — an unsupported flag, a failed summarizer, an interrupt — skips
+# that gate, and the survivor only reappears as a slower number in whatever runs
+# next. Checked for both build kinds because a run can be pointed at either.
+sweep_survivors() {
+    local status=$?
+    local label="perf-runner sweep"
+    local binary
+    for binary in \
+        "$(normalize_installed_app_path "$APP_PATH")" \
+        "$ROOT_DIR/.build/debug/WorkspaceManager"; do
+        perf_assert_clean_exit "$binary" "$label" || status=1
+    done
+    return "$status"
+}
+trap 'sweep_survivors || exit 1' EXIT
 
 case "$SCENARIO" in
     debug_no_activate)


### PR DESCRIPTION
Closes #1277.

**The debug half of #1277 already shipped.** `perf-baseline.sh` gained `assert_no_debug_instance`, `stop_launched_app` (TERM→KILL), and a post-teardown gate in #1286 (`d98e019f`) — its comments cite this issue by number. Re-running `debug_no_activate` today does not leak. The issue stayed open over the **installed** lane, which never got that treatment.

## The defect

`launch-installed-diagnostics.sh` sent one SIGTERM and then waited:

```bash
kill "$APP_PID" 2>/dev/null || true
wait "$APP_PID" 2>/dev/null || true
```

An `NSApplication` mid-launch installs its own SIGTERM handler, so the signal is not guaranteed to land. When it doesn't, `wait` blocks **forever** — the lane does not leak quietly, it hangs, and whatever interrupts that hang is what leaves the instance running. Reproduced with a stand-in that traps TERM: the harness ran past a 15s ceiling without `wait` ever returning, and the process outlived it (section A of the evidence).

That is the same defect class as the debug lane, one layer over: a harness that cannot guarantee its subject is gone measures a loaded machine on the next lane.

## What changed

`scripts/lib/perf-process.sh` carries the contract — refuse to measure beside a foreign instance, stop a launched pid on a deadline, gate on the table being clear. `launch-installed-diagnostics.sh` uses it, and `wait` now runs only after the pid is confirmed gone. `perf-runner.sh` gains the whole-run sweep #1277 asked for: a scenario that exits early — bad flag, failed summarizer, interrupt — skips its lane's own gate, and the survivor resurfaces only as a slower number in whatever runs next.

**Matching is anchored at the start of the command line.** These lanes take the binary as `--app <path>`, so an unanchored `pgrep -f` finds that string in the harness's own argv and every script in the chain reports itself as a survivor — exactly the trap #1277 named. I hit it: the first version of this patch flagged the launcher as its own leak. Anchoring also beats matching on `ps -o comm=`, which on macOS reports argv[0] and can therefore be presented as anything (section C3 demonstrates a decoy that defeats a `comm` check and not this one).

## Validation

| What | Result |
|---|---|
| `bash -n` on all three scripts | OK |
| TERM-ignoring process | escalates to SIGKILL, dies, `rc=0` in 13s |
| Well-behaved process | exits on TERM in 0s, no escalation noise |
| Harness argv contains the path, no app | reports clean — does **not** flag itself |
| App actually running | detected, exit 1 |
| argv[0]-spoofing decoy beside the app | app reported, decoy excluded |
| `perf-runner.sh`, no survivor | sweep silent |
| `perf-runner.sh`, survivor planted | fails loudly, exit 1 |

Stand-in note: the app is simulated by a symlink to a signed system binary. A *copied* binary loses its signature and is killed on exec by macOS, and a shell script reports `comm=/bin/bash` — both make useless stand-ins here, which is worth recording because the second one briefly made this check look like it detected nothing.

Not exercised: a real `installed_clean_shell` run. That needs the installed app and a display, and would launch the app on the owner's desktop; the teardown path is covered by the stand-in cases above rather than by a live capture.

## Evidence

![perf-teardown-verification](https://evidence.cloudcompute.com/workspaces/pr-1314/20260813-070518-perf-teardown-verification.png)

## Review loop

Skipped codex per the skill's scope gate — this is a small, fully-verified shell change whose failure modes were reproduced directly rather than argued. Reflection did the work that matters here: it caught the self-matching bug described above, which is the defect this PR most easily could have shipped.

## Mergeability

- **Surface:** perf measurement harness (`scripts/`). No product code, no CI workflow, no release path.
- **Behavior changed:** the installed lane refuses to start beside a live instance, escalates TERM→KILL on a deadline instead of waiting indefinitely, and fails if anything survives. `perf-runner.sh` fails a run that leaves a survivor behind, for any scenario.
- **Non-happy paths:** a foreign instance the run did not start is reported and refused, never killed; a survivor after SIGKILL exits non-zero rather than reporting a number; an early-exiting scenario still gets swept because the sweep is an `EXIT` trap.
- **Residual risk:** `perf-baseline.sh` keeps its own inline copy of this contract rather than sourcing the lib. Its pattern is built internally so the unanchored form is safe there, and it is a working lane I cannot exercise without a debug build — but two implementations of one contract is the drift this repo keeps paying for, so consolidating it is a follow-up worth filing.
- **Release/ops preconditions:** none. Perf lanes are laptop-local and opt-in per `docs/decisions/perf-measurement-laptop-optin.md`; nothing here runs in CI.
