### PR TITLE
fix(tests): wait on the smoke scenario's milestones instead of a 5s poll deadline

### DIFF
--- a/Tests/WorkspaceManagerAppTests/DesktopUISmokeAutomationTests.swift
+++ b/Tests/WorkspaceManagerAppTests/DesktopUISmokeAutomationTests.swift
@@ -328,9 +328,11 @@ struct DesktopUISmokeAutomationTests {
             .appendingPathComponent("desktop-ui-smoke-\(UUID().uuidString).jsonl")
     }
 
-    /// Reads what is already on disk. Every milestone these tests assert on is emitted inside an
-    /// awaited `note…` call, and the writer actor finishes the write before that call returns, so
-    /// there is nothing to settle for: the events are there or the code is wrong.
+    /// Reads what is already on disk. Every milestone read this way is emitted inside an awaited
+    /// controller call — a `note…`, or `waitForSurfaceFocus`'s own timeout and not-applicable
+    /// paths — and the writer actor finishes the write before that call returns, so there is
+    /// nothing to settle for: the events are there or the code is wrong. The one milestone with an
+    /// unawaited producer, `scenario_complete`, is waited for through `awaitEvents` instead.
     private static func readEvents(at url: URL) throws -> [[String: Any]] {
         try parseEvents(at: url)
     }

--- a/Tests/WorkspaceManagerAppTests/DesktopUISmokeAutomationTests.swift
+++ b/Tests/WorkspaceManagerAppTests/DesktopUISmokeAutomationTests.swift
@@ -4,8 +4,17 @@ import WorkspaceManagerCore
 
 @testable import WorkspaceManager
 
+/// Every deadline in this suite is a failure-only ceiling, never a sampling window: each test
+/// waits on the event it asserts on and continues the moment that event lands, so a healthy run
+/// never spends the number and a loaded runner pays latency instead of a verdict. The controller
+/// under test is in-process — no child launches — so `LaunchBudget`'s unit (a spawn-to-answer
+/// round trip, and a different test target) does not describe what these waits are waiting for:
+/// main-actor scheduling. The ceiling is sized past the worst starvation measured in a full
+/// parallel run, where tests whose own work is sub-second took 20s (hosted CI) and 57s (laptop).
 @Suite("DesktopUISmokeAutomation")
 struct DesktopUISmokeAutomationTests {
+    private static let observationCeiling: Duration = .seconds(60)
+
     @Test("Configuration parses desktop UI smoke environment")
     func configurationParsesEnvironment() {
         let environment = [
@@ -83,8 +92,10 @@ struct DesktopUISmokeAutomationTests {
         )
 
         let baseline = controller.surfaceFocusCount
+        // The focus below is what ends this wait; the timeout only decides how long a broken
+        // signal takes to report, so it is sized to be unreachable rather than tuned.
         let waiter = Task { @MainActor in
-            await controller.waitForSurfaceFocus(after: baseline, timeout: .seconds(5))
+            await controller.waitForSurfaceFocus(after: baseline, timeout: Self.observationCeiling)
         }
 
         await controller.noteSurfaceFocused(sessionID: UUID())
@@ -103,12 +114,17 @@ struct DesktopUISmokeAutomationTests {
             environment: Self.environment(eventsURL: eventsURL)
         )
 
+        // Short on purpose, and the one place a number is the property: the wait is supposed to
+        // expire, and nothing in this test can ever end it early. Load delays the expiry; it
+        // cannot turn it into a focus.
         let focused = await controller.waitForSurfaceFocus(
             after: controller.surfaceFocusCount,
             timeout: .milliseconds(150)
         )
         #expect(!focused)
 
+        // The timeout milestone is emitted inside the awaited call above, so it is already on
+        // disk — no settling, no polling.
         let events = try Self.readEventTypes(at: eventsURL)
         #expect(events.contains("surface_focus_timed_out"))
     }
@@ -126,13 +142,17 @@ struct DesktopUISmokeAutomationTests {
             )
         )
 
+        // Neither wait consults its timeout: suppressed activation makes focus impossible, so the
+        // call returns on the not-applicable path. Passing the same unreachable ceiling as
+        // everywhere else keeps that visible — were the short-circuit to regress, these would run
+        // long and `surface_focus_timed_out` below would name the regression.
         let firstWait = await controller.waitForSurfaceFocus(
             after: controller.surfaceFocusCount,
-            timeout: .seconds(15)
+            timeout: Self.observationCeiling
         )
         let secondWait = await controller.waitForSurfaceFocus(
             after: controller.surfaceFocusCount,
-            timeout: .seconds(15)
+            timeout: Self.observationCeiling
         )
         #expect(!firstWait)
         #expect(!secondWait)
@@ -171,15 +191,11 @@ struct DesktopUISmokeAutomationTests {
             scopePath: "/tmp/repo-workspace"
         )
 
-        // The completion task runs on the main actor; suspend (not block) while
-        // waiting so it can be scheduled.
-        var events: [String] = []
-        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
-        while ContinuousClock.now < deadline {
-            events = try Self.readEventTypes(at: eventsURL)
-            if events.contains("scenario_complete") { break }
-            try await Task.sleep(for: .milliseconds(20))
-        }
+        // `scenario_complete` comes from the completion task, which needs main-actor turns the
+        // test cannot schedule for it. Wait for that event rather than for a duration: five
+        // seconds was long enough on an idle machine and not on a loaded runner, which is how
+        // this assertion failed twice on main (#1281).
+        let events = try await Self.awaitEventTypes(at: eventsURL, containing: "scenario_complete")
 
         #expect(events.contains("surface_focus_not_applicable"))
         #expect(!events.contains("surface_focused"))
@@ -197,8 +213,10 @@ struct DesktopUISmokeAutomationTests {
         )
 
         let baseline = controller.terminalAttachCount
+        // Ended by the attach below, not by the clock — unreachable ceiling for the same reason
+        // as the focus wait above.
         let waiter = Task { @MainActor in
-            await controller.waitForTerminalAttach(after: baseline, timeout: .seconds(5))
+            await controller.waitForTerminalAttach(after: baseline, timeout: Self.observationCeiling)
         }
         await controller.noteTerminalSessionAttached(
             kind: .workspace,
@@ -207,6 +225,8 @@ struct DesktopUISmokeAutomationTests {
         )
         #expect(await waiter.value)
 
+        // The other half of the pair, where expiring is the property: no attach follows, so this
+        // wait can only end one way and load can only postpone it.
         let timedOut = await controller.waitForTerminalAttach(
             after: controller.terminalAttachCount,
             timeout: .milliseconds(150)
@@ -283,7 +303,9 @@ struct DesktopUISmokeAutomationTests {
         )
         await controller.noteSurfaceFocused(sessionID: sessionID)
 
-        let events = try Self.readEventTypes(at: eventsURL, waitingFor: "scenario_complete")
+        // Same detached completion task as the suppressed-activation case, reached by a real focus
+        // instead of the not-applicable path.
+        let events = try await Self.awaitEventTypes(at: eventsURL, containing: "scenario_complete")
         #expect(events.contains("awaiting_api_select"))
         #expect(events.contains("terminal_session_attached"))
         #expect(events.contains("surface_focused"))
@@ -306,20 +328,29 @@ struct DesktopUISmokeAutomationTests {
             .appendingPathComponent("desktop-ui-smoke-\(UUID().uuidString).jsonl")
     }
 
-    private static func readEvents(at url: URL, waitingFor eventType: String? = nil) throws -> [[String: Any]] {
-        // Events are written by a background actor; allow a brief settle.
-        let deadline = Date().addingTimeInterval(2)
-        while Date() < deadline {
-            if let events = try? parseEvents(at: url), !events.isEmpty {
-                if let eventType, !events.contains(where: { $0["type"] as? String == eventType }) {
-                    Thread.sleep(forTimeInterval: 0.02)
-                    continue
-                }
-                break
-            }
-            Thread.sleep(forTimeInterval: 0.02)
-        }
+    /// Reads what is already on disk. Every milestone these tests assert on is emitted inside an
+    /// awaited `note…` call, and the writer actor finishes the write before that call returns, so
+    /// there is nothing to settle for: the events are there or the code is wrong.
+    private static func readEvents(at url: URL) throws -> [[String: Any]] {
+        try parseEvents(at: url)
+    }
 
+    /// Waits for a milestone that a detached task emits, suspending between reads. Blocking here
+    /// would be self-defeating rather than merely slow: these tests run on the main actor, and the
+    /// task that emits `scenario_complete` needs that actor to run at all — a blocking wait holds
+    /// the thing it is waiting for. Returns as soon as the event lands; `ceiling` only bounds how
+    /// long a genuinely missing event takes to report.
+    private static func awaitEvents(
+        at url: URL,
+        containing eventType: String,
+        ceiling: Duration = observationCeiling
+    ) async throws -> [[String: Any]] {
+        let deadline = ContinuousClock.now.advanced(by: ceiling)
+        while ContinuousClock.now < deadline {
+            let events = try parseEvents(at: url)
+            if events.contains(where: { $0["type"] as? String == eventType }) { return events }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
         return try parseEvents(at: url)
     }
 
@@ -334,7 +365,16 @@ struct DesktopUISmokeAutomationTests {
             }
     }
 
-    private static func readEventTypes(at url: URL, waitingFor eventType: String? = nil) throws -> [String] {
-        try readEvents(at: url, waitingFor: eventType).compactMap { $0["type"] as? String }
+    private static func readEventTypes(at url: URL) throws -> [String] {
+        try readEvents(at: url).compactMap { $0["type"] as? String }
+    }
+
+    private static func awaitEventTypes(
+        at url: URL,
+        containing eventType: String,
+        ceiling: Duration = observationCeiling
+    ) async throws -> [String] {
+        try await awaitEvents(at: url, containing: eventType, ceiling: ceiling)
+            .compactMap { $0["type"] as? String }
     }
 }


### PR DESCRIPTION
Closes #1281. Second half of the pair that made `main`'s CI unreliable enough to abort v0.24.0 — the
first half merged as #1307 (`c098bef6`) while this one was being written, which is why it is two PRs
and not one.

Two consecutive CI runs of the identical commit `040a5253` failed on two different wall-clock tests:
attempt 1 on the tick tally (#1300, fixed in #1307), attempt 2 on this one
([31560996895](https://github.com/fairchild/workspaces/actions/runs/31560996895)), so re-running CI
just alternated between them.

## What was wrong

`apiSelectHandoffCompletesWithoutActivation` polled the events file for a fixed five seconds and then
asserted on whatever had arrived:

```swift
let deadline = ContinuousClock.now.advanced(by: .seconds(5))
while ContinuousClock.now < deadline { … }
#expect(events.last == "scenario_complete")
```

`scenario_complete` comes from a detached `Task { @MainActor }`. On a loaded runner that task does
not get a turn inside five seconds, so the assertion reported an *unfinished* scenario as a *wrong*
one — the failure prints `events.last → "terminal_session_attached"`, a scenario that had not
reached its last step rather than one that took a wrong step.

## What changed

**Both api-select tests wait for the milestone they assert on** and continue the moment it lands.
The ceiling behind that wait is failure-only: a healthy run never spends it, so load buys latency
instead of a verdict.

**The reader helpers stop blocking the main actor.** `readEvents` slept the main thread in 20ms
slices for up to two seconds, waiting for milestones whose producer needs that same actor — a wait
that prevents what it waits for. Every milestone read synchronously has an awaited controller call
behind it (the writer actor completes the file write before the call returns), so the settle loop
was buying nothing; the one milestone with an unawaited producer gets the suspending wait instead.

**The other three deadlines are sized from what they are for.** Waits that a later signal ends
(`waitForSurfaceFocus` before a focus, `waitForTerminalAttach` before an attach, and the two
suppressed-activation waits that never consult their timeout) carry the same unreachable ceiling, so
only a broken signal spends it. The two waits whose property *is* expiry keep their 150ms timeouts
with the reason named — nothing in those tests can ever end them early, so load can postpone the
expiry but not invert it. That is the whole set of five wall-clock timeouts #1281 counted, plus the
poll deadline and the blocking settle it did not.

**Why not `LaunchBudget`:** it measures a spawn-to-answer round trip for tests that supervise child
processes. This controller is in-process, so that unit does not describe what these waits wait for
(main-actor scheduling), and it lives in the other test target, which SwiftPM cannot share without a
new support target. Waiting on the observable event needs no budget at all.

## Verification

Mutation binding (`Tests/AGENTS.md`), each applied to the production controller, measured, reverted:

| Mutation | Result |
|---|---|
| Completion task never emits `scenario_complete` | both api-select tests fail (60s, the ceiling) |
| `surface_focus_not_applicable` never emitted | two tests fail — in 0.4s, because the awaited event still lands and the ceiling is never spent |
| `noteSurfaceFocused` stops advancing the counter | `surfaceFocusWaitResolvesOnFocus` fails (60s) |

Four full `swift test` runs (1678 tests) on the same machine, before and after:

| Run | | Result |
|---|---|---|
| 1 | before | ✘ `DesktopUISmokeAutomationTests.swift:186` |
| 2 | before | ✘ `:184` and `:186` |
| 3 | after | ✔ both api-select tests, at **51.5s** and **51.9s** of scheduling delay |
| 4 | after | ✔ **1678 tests passed** — first green full local run of this session |

51.9s of delay on tests whose own work is ~0.2s is the condition that failed these assertions on CI;
none of the new assertions can be moved by it. Isolated stability: 8 consecutive runs of the suite,
all green. `mise run lint` clean.

### Evidence

**Mutation binding and the four full-suite runs** — the three mutations with their measured
failures, and the before/after across four `swift test` runs on the same machine.
![smoke-mutation-and-suite-runs](https://evidence.cloudcompute.com/workspaces/pr-1317/20260813-071907-smoke-mutation-and-suite-runs.png)

The first half of this pair carries its own evidence on #1307: [mutation binding](https://evidence.cloudcompute.com/workspaces/pr-1307/20260813-060317-mutation-binding.png),
[starvation before/after](https://evidence.cloudcompute.com/workspaces/pr-1307/20260813-060325-starvation-before-after.png),
[suite runs and lint](https://evidence.cloudcompute.com/workspaces/pr-1307/20260813-060326-suite-runs-and-lint.png).

## Review loop

Directed codex review (`gpt-5.6-sol`, xhigh). Verdict: no blocking in-scope correctness finding.

| Finding | Disposition |
|---|---|
| Traced every direct `readEvents` call site against its emit path: none now races an unawaited producer | Confirmed, no change |
| The comment justifying the direct reads was literally inaccurate — two milestones come from awaited `waitForSurfaceFocus` paths, not `note…` calls | Fixed in a07e206a |
| A regressed short-circuit in `surfaceFocusWaitSkippedWithoutActivation` now takes ~120s to fail instead of ~30s | Accepted. It still fails, on the assertion that names the regression (`surface_focus_not_applicable` count, and no `surface_focus_timed_out`); a wait that ignored its timeout entirely would hang under either number |
| `events.last == "scenario_complete"` is stable here: the completion emit is one-shot, each test owns a UUID-named events file | Confirmed, no change |
| Torn reads are possible in principle (append is two writes, read is unsynchronised); the new code handles them no worse — a partial record is dropped and re-read 20ms later, and direct reads never overlap an append | Accepted, no change |
| Three assertions still flip if scheduling exceeds the 60s ceiling | Accepted and named below. Every ceiling has this property; the alternative to a ceiling is a hang |
| **Production, out of scope:** `apiSelectCompletionTask?.cancel()` neither stops nor joins the old task, and `waitForSurfaceFocus` never observes cancellation — a superseded task can still emit `scenario_complete` against newer state | Filed as #1316 rather than fixed here; single-handoff runs do not exercise it |

## Mergeability

- **Surface:** one test file — `Tests/WorkspaceManagerAppTests/DesktopUISmokeAutomationTests.swift`.
  No production code changed.
- **User-facing behavior changed:** none. The scenario the suite describes — API select hands off,
  focus is skipped when activation is suppressed, `scenario_complete` is the final milestone — is
  unchanged and now asserted after waiting for it rather than around it.
- **Non-happy paths considered:** completion milestone never emitted (caught at the ceiling);
  not-applicable milestone dropped (caught in 0.4s); focus signal that never advances (caught);
  short-circuit regression (caught, slower); torn reads mid-append (dropped and re-read); a starved
  runner (measured — passes at 51.9s of delay where it previously failed at 5s).
- **Residual risk or follow-up:** the 60s ceiling is a bound, not a proof — scheduling delay beyond
  it turns the three completion assertions red, and the mutation evidence shows what they bind to,
  not that 60s is unreachable on every host. If it ever fires, the signature is a missing
  `scenario_complete` after a full minute, which is worth investigating rather than re-running.
  Follow-ups: #1316 (production cancellation), #1306 (`ClaudeIntegrationLifecycleTests`, same family,
  different file), and #1300's closing comment lists the fixed sleeps left in the automation test
  files.
