### PR TITLE
fix(tests): end the socket robustness waits on state, not on racing clocks

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift
@@ -154,6 +154,11 @@ public actor AutomationListener {
         }
     }
 
+    /// Connections currently occupying a cap slot. Exists for tests that must observe the cap
+    /// engaging — a test that sends its own request before the server has registered the
+    /// connection meant to hold the slot gets the slot itself, and hangs up the holder as busy.
+    var activeConnectionCount: Int { activeConnectionIDs.count }
+
     private func accept(connection: NWConnection) {
         guard activeConnectionIDs.count < maxConcurrentConnections else {
             rejectBusy(connection: connection)

--- a/Tests/WorkspaceManagerTests/AutomationSocketRobustnessTests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationSocketRobustnessTests.swift
@@ -130,6 +130,42 @@ private func uniqueSocketPath(_ prefix: String) -> String {
 
 @Suite("AutomationSocketRobustness", .serialized)
 struct AutomationSocketRobustnessTests {
+    /// Failure-only ceiling for everything this suite waits on. Each wait ends on the state it is
+    /// waiting for, so a healthy run never spends this and a starved one pays latency instead of a
+    /// verdict. Sized past the worst starvation measured in a full parallel run, where tests whose
+    /// own work is sub-second took ~50s of wall clock.
+    private static let observationCeiling: TimeInterval = 60
+
+    /// Polls `condition` until it holds, suspending between attempts. Returns the moment it does,
+    /// so `ceiling` is only ever spent by a run that was going to fail.
+    private static func waitUntil(
+        ceiling: TimeInterval = observationCeiling,
+        _ condition: @Sendable () async -> Bool
+    ) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(ceiling))
+        while ContinuousClock.now < deadline {
+            if await condition() { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return await condition()
+    }
+
+    /// Connects once the listener is accepting. `start()` returning does not mean the socket
+    /// accepts yet, and how long that takes is scheduling rather than a property under test.
+    private static func connectWhenAccepting(
+        to path: String,
+        receiveTimeout: TimeInterval,
+        ceiling: TimeInterval = observationCeiling
+    ) async -> Int32 {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(ceiling))
+        while ContinuousClock.now < deadline {
+            let fd = RawUnixSocket.connect(to: path, receiveTimeout: receiveTimeout)
+            if fd >= 0 { return fd }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return RawUnixSocket.connect(to: path, receiveTimeout: receiveTimeout)
+    }
+
     @Test("Listener read deadline closes a hung client connection")
     @MainActor
     func readDeadlineClosesHungClient() async throws {
@@ -142,17 +178,21 @@ struct AutomationSocketRobustnessTests {
             readDeadline: .milliseconds(200)
         )
         try await listener.start()
-        try await Task.sleep(for: .milliseconds(250))
 
-        // Connect and send nothing; the server must hang up on its own within the deadline.
-        let fd = RawUnixSocket.connect(to: socket.path, receiveTimeout: 10)
+        // Connect and send nothing; the server must hang up on its own.
+        let fd = await Self.connectWhenAccepting(
+            to: socket.path,
+            receiveTimeout: Self.observationCeiling
+        )
         defer { if fd >= 0 { close(fd) } }
         #expect(fd >= 0)
 
         var buffer = [UInt8](repeating: 0, count: 64)
         let count = Darwin.read(fd, &buffer, buffer.count)
-        // EOF (0) proves the listener cancelled the hung connection; a negative return here
-        // means the generous client-side timeout fired first, i.e. no server deadline.
+        // EOF (0) proves the listener cancelled the hung connection. The client-side timeout is
+        // sized to be unreachable rather than merely generous, so a negative return means no
+        // server deadline fired at all — where a 10s client timeout was racing the 200ms server
+        // deadline, and lost whenever the watchdog's own resumption was delayed past it.
         #expect(count == 0)
         await listener.stop()
     }
@@ -167,18 +207,30 @@ struct AutomationSocketRobustnessTests {
             socketURLOverride: socket,
             auditLogger: nil,
             maxConcurrentConnections: 1,
-            readDeadline: .seconds(30)
+            // Has to outlive the whole test: this connection's job is to hold the only slot, so a
+            // deadline the test can reach would hang it up and dissolve the precondition — which
+            // is what a 30s deadline did on a runner where this suite takes ~50s to get its turns.
+            readDeadline: .seconds(600)
         )
         try await listener.start()
-        try await Task.sleep(for: .milliseconds(250))
 
         // Occupy the single slot with a connection that never sends a request.
-        let heldFD = RawUnixSocket.connect(to: socket.path, receiveTimeout: 30)
+        let heldFD = await Self.connectWhenAccepting(
+            to: socket.path,
+            receiveTimeout: Self.observationCeiling
+        )
         defer { if heldFD >= 0 { close(heldFD) } }
         #expect(heldFD >= 0)
-        try await Task.sleep(for: .milliseconds(300))
 
-        let client = AutomationSocketClient(socketPath: socket.path, timeout: 10)
+        // Wait for the server to register that connection before sending anything else. This is
+        // the precondition, not a formality: a request that arrives first takes the only slot and
+        // the server hangs up the intended holder as busy, after which the cap can never engage.
+        // Sleeping a fixed interval here bet on registration being prompt; polling with real
+        // requests would race it outright.
+        let slotHeld = await Self.waitUntil { await listener.activeConnectionCount == 1 }
+        #expect(slotHeld)
+
+        let client = AutomationSocketClient(socketPath: socket.path, timeout: Self.observationCeiling)
         let response = try client.request(method: "GET", path: "/v1/health")
         let envelope = try AutomationJSON.decoder.decode(
             AutomationResponseEnvelope<AutomationEmptyResult>.self,
@@ -202,6 +254,8 @@ struct AutomationSocketRobustnessTests {
         #expect(serverFD >= 0)
 
         // The backlog completes the connect and buffers the request, but nothing ever responds.
+        // Short and fixed on purpose — expiring is the property here, and with no server to answer
+        // there is nothing load can do but postpone the expiry it is asserting on.
         let client = AutomationSocketClient(socketPath: path, timeout: 0.3)
         do {
             _ = try client.request(method: "GET", path: "/v1/health")


### PR DESCRIPTION
Closes #1319. Third member of the family that has been alternating failures on `main` — and the one
that turned `main` red again at `fe983710`, minutes after #1307 and #1317 fixed the other two.

**Scope note:** you scoped me to `AutomationControllerTests` and `DesktopUISmokeAutomationTests`.
This is a third file, taken because it is now what blocks the v0.24.0 preflight and it is the same
defect shape. Say the word and I'll close it.

## What failed

[Run 31678860495](https://github.com/fairchild/workspaces/actions/runs/31678860495) on `main` @
`fe983710`:

```
✘ "Listener read deadline closes a hung client connection"
   AutomationSocketRobustnessTests.swift:156: Expectation failed: (count → -1) == 0
```

`-1` is the *client's* `SO_RCVTIMEO` firing — not a wrong answer from the server. The test armed a
200ms server `readDeadline` against a 10s client receive timeout and asserted the client saw EOF, so
it was asserting a *ratio between two wall clocks*. The server's deadline is a `Task` that sleeps and
then cancels the connection, which makes its resumption precisely the thing runner starvation
delays; past 10s the client's timeout wins and the test reports "no server deadline" for a deadline
that had simply not been scheduled yet.

## What changed

**The client timeout is now unreachable**, so EOF is what ends the read and a negative return means
what the comment always claimed: no server deadline fired at all.

**`connectionCapReturnsBusy` waits for the server to register its slot holder.** That registration
is the precondition, not a formality — a request that arrives first takes the only slot, and the
server hangs up the intended holder as busy, after which the cap can never engage. Its
slot-holding `readDeadline` also has to outlive the test: at `.seconds(30)`, a suite observed taking
~50s for its turns would hang up its own precondition.

**Both connects wait for the socket to accept** rather than sleeping past an assumed startup cost.

**`clientTimeoutThrowsTypedError` keeps its 0.3s timeout**, with the reason named: expiring *is* the
property there, nothing can answer, and load can only postpone the expiry it asserts on.

**One production line:** `AutomationListener.activeConnectionCount`, an internal accessor over
existing state, because the cap's precondition is not observable from outside the actor. No
behaviour change.

## A race I introduced, and how it got caught

The first version of the cap fix replaced the 300ms sleep with polling by real requests. That races
registration outright — the probe takes the slot itself. Looping the test found it at **1 failure in
10 runs** before it left my machine; the committed version waits on the connection count and is
15/15. It is in the evidence because "replace the sleep with a poll" is the obvious move here and it
is wrong.

## Verification

| Mutation | Result |
|---|---|
| No read watchdog — hung clients never hung up | `readDeadlineClosesHungClient` fails, `(count → -1) == 0`, at the ceiling (60s) |
| Concurrency cap never engages | `connectionCapReturnsBusy` fails on all three assertions — in **0.039s**, because the registration wait still succeeds and the ceiling is never spent |

Isolated stability: 8 consecutive runs of the suite, all green (~0.57s each). Full `swift test` on
this branch: **1678 tests passed** (21.5s). `mise run lint` clean.

### Evidence

**The 1-in-10 race, the mutations, and the stability runs** — including the failing first attempt,
kept in the record because it is the obvious fix and it is wrong.
![socket-race-and-mutations](https://evidence.cloudcompute.com/workspaces/pr-1320/20260813-083512-socket-race-and-mutations.png)

## Mergeability

- **Surface:** `Tests/WorkspaceManagerTests/AutomationSocketRobustnessTests.swift`, plus one
  internal accessor on `Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift`.
- **User-facing behavior changed:** none. `activeConnectionCount` reads existing state and is not
  called by production code; the transport behaviour under test is unchanged.
- **Non-happy paths considered:** server deadline never fires (caught at the ceiling); cap never
  engages (caught in 0.039s); slot holder rejected because a probe raced it (the race that cost 1 in
  10 — now impossible, the holder is registered before anything else is sent); listener not yet
  accepting when the test connects (retried); slot holder hung up mid-test by its own deadline (now
  outlives the test).
- **Residual risk or follow-up:** the 60s ceilings are bounds, not proofs — starvation past a minute
  turns these red, and the mutations show what the assertions bind to, not that 60s is unreachable
  on every host. The accessor widens `AutomationListener`'s internal surface by one computed
  property; it is `internal`, so it stays inside the module. Open siblings in this family: #1306
  (`ClaudeIntegrationLifecycleTests`) and #1316 (production cancellation in the smoke controller,
  found while reviewing #1317).
