### PR TITLE
fix(release): name the scope when release config resolves empty

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,8 +100,8 @@ jobs:
             # same name even when the environment copy is empty, which presents
             # as a missing credential while a working repository value sits
             # underneath it.
-            echo "::error::Release config resolved empty: ${missing[*]}"
-            echo "Each name above is unset, or set to an empty value, in the scope this job reads."
+            echo "::error::Release config resolved empty in this job's scope: ${missing[*]}"
+            echo "Each name above is either unset or set to an empty value."
             echo "Secrets resolve environment-first: a value on the 'release' environment wins over"
             echo "the repository secret of the same name, including when it is empty. Check both scopes:"
             echo "  gh secret list --env release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,18 @@ jobs:
           [[ -n "$SPARKLE_PRIVATE_KEY" ]] || missing+=("SPARKLE_PRIVATE_KEY")
 
           if (( ${#missing[@]} > 0 )); then
-            echo "::error::Missing required repository release config: ${missing[*]}"
+            # Empty and unset are the same value here, so the message names both
+            # causes. An environment secret shadows the repository secret of the
+            # same name even when the environment copy is empty, which presents
+            # as a missing credential while a working repository value sits
+            # underneath it.
+            echo "::error::Release config resolved empty: ${missing[*]}"
+            echo "Each name above is unset, or set to an empty value, in the scope this job reads."
+            echo "Secrets resolve environment-first: a value on the 'release' environment wins over"
+            echo "the repository secret of the same name, including when it is empty. Check both scopes:"
+            echo "  gh secret list --env release"
+            echo "  gh secret list"
+            echo "APPLE_TEAM_ID is a repository variable, not a secret: gh variable list"
             exit 1
           fi
 


### PR DESCRIPTION
The fifth v0.24.0 release attempt failed `Validate release secrets` with:

```
::error::Missing required repository release config: APPLE_API_KEY_ID APPLE_API_ISSUER_ID
```

Nothing was missing. Both names were set on the `release` environment as **empty strings**, and an environment secret shadows the repository secret of the same name — so two empty values hid two working repository values underneath. The message sent diagnosis to the wrong scope.

## Why the message, and not a detection check

The first instinct was an audit check that flags a zero-length secret. That is not implementable: GitHub's secrets API returns only `name`, `created_at`, `updated_at`, for both repository and environment scopes.

```
$ gh api repos/fairchild/workspaces/environments/release/secrets --jq '.secrets[0]'
{"created_at":"2026-08-14T17:15:36Z","name":"APPLE_API_ISSUER_ID","updated_at":"2026-08-14T17:15:36Z"}
```

No value, no length — an empty secret is indistinguishable from a healthy one from outside. Bash has the same blind spot in-workflow, since unset and empty both arrive as `""`. So neither the audit script nor this step can *detect* the condition; the honest fix is for the existing check, which already failed correctly, to describe both causes and point at both scopes.

## Change

One step's failure branch. The assertions are untouched — same names, same conditions, same exit code.

## Validation

![evidence](https://evidence.cloudcompute.com/workspaces/pr-1323/20260814-172557-release-secret-scope-message-v2.png)

Re-captured at `aec66d32` after the review wording change, so the image shows the message as it now ships. ([first capture, superseded](https://evidence.cloudcompute.com/workspaces/pr-1323/20260814-172028-release-secret-scope-message.png))

- `actionlint` — 2 findings on base, 2 on branch: pre-existing SC2129 style hits in unrelated steps (lines 143/294). No new findings.
- `scripts/validate-release-changes.py` — `Release change validation passed`, YAML parse OK.
- **Failure path executed**, reproducing the attempt-5 shape with both IDs empty: emits the new message, `exit=1`.
- **Happy path executed** with all values present: `exit=0`, silent.

Paths 3 and 4 run the step body extracted from the workflow itself, not a transcription of it.

## Mergeability

- **Surface:** CI — `.github/workflows/release.yml`, the `Validate release secrets` step's failure branch only.
- **User-facing behavior changed:** No. Release artifacts, signing, and notarization are untouched; this alters only what a failing release job prints.
- **Non-happy paths considered:** Both branches executed locally (evidence above). The pass path stays silent and returns 0, so a green release is unaffected. The message names `APPLE_TEAM_ID` separately because it is a repository *variable*, not a secret, and would otherwise send a reader to `gh secret list` for a name that will never appear there.
- **Release/ops preconditions:** None. No secret, variable, or environment change is required to merge or to run this — the step reads the same names in the same order as before. The edited branch executes only when a release job is already failing, so merging cannot affect a green release; it first runs for real on the next tag push, and both of its branches were executed locally (evidence above) rather than left for that push to discover.
- **Residual risk or follow-up:** The release lane only executes on a tag push, so this exact step runs unverified-in-CI until the next release — mitigated by executing both branches directly rather than reasoning about them. Follow-up, separable: `audit-security-posture.py` could flag names present in *both* scopes, which is API-detectable and would have surfaced the shadowing even though emptiness cannot be seen; it is deliberately not bundled here, per the release-lane bundling lesson in #1310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


