### PR TITLE
fix(release): grade the perf gate by the version being built, not the ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,8 +272,18 @@ jobs:
       # docs/performance_benchmarks.csv. Pass at 0 releases stale, warn at 1,
       # block at 2, and fail outright when the file is missing: #1238's rule is
       # that a skipped measurement must never read as a passing one.
+      #
+      # Graded against the version being built rather than the ref, because all
+      # three entry points cut the same release: a `main` dispatch rehearsing
+      # v<version>, the tester prerelease it publishes, and the v<version> tag
+      # itself. On the tag path this is the ref — "Validate app version
+      # metadata" above has already bound them.
       - name: Verify release performance benchmarks are current
-        run: ./scripts/check-perf-benchmarks.py --tag "${{ github.ref_type == 'tag' && github.ref_name || 'HEAD' }}" --format github
+        run: |
+          set -euo pipefail
+          ./scripts/check-perf-benchmarks.py \
+            --tag "$(./scripts/release-version.sh print-tag)" \
+            --format github
 
       - name: Notarize and package DMG
         env:

--- a/scripts/check-perf-benchmarks.py
+++ b/scripts/check-perf-benchmarks.py
@@ -16,6 +16,9 @@ the release being cut — pass at 0, warn at 1, fail at 2 or more. Absent or emp
 evidence fails, because #1238's rule is that a skipped measurement must never be
 indistinguishable from a passing one.
 
+--tag names the release being cut: v<version>, or the tester prerelease
+workspaces-v<version>-main.<run>, which is graded as the release it rehearses.
+
 Usage: check-perf-benchmarks.py --tag v0.25.0 [--format github]
 Exit 0 when evidence is current or one release stale, 1 when it is older or missing.
 """
@@ -24,6 +27,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -32,6 +36,25 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CSV = REPO_ROOT / "docs" / "performance_benchmarks.csv"
 BLOCK_AFTER = 2
 RELEASE_TAG_GLOB = "v*"
+VERSION = r"\d+\.\d+\.\d+(?:[-.][A-Za-z0-9.]+)?"
+RELEASE_TAG_RE = re.compile(rf"^v{VERSION}$")
+PRERELEASE_TAG_RE = re.compile(rf"^workspaces-(v{VERSION})-main\.\d+$")
+
+
+def release_tag(raw: str) -> str:
+    """The release a ref cuts.
+
+    A tester prerelease (`workspaces-v0.24.0-main.7`) rehearses the release it is
+    named for, so it is graded as that release. Anything else — a branch, `HEAD`,
+    a bare commit — holds no position in a sequence of releases, and measuring a
+    distance to it yields a confident number rather than an answer.
+    """
+    prerelease = PRERELEASE_TAG_RE.match(raw)
+    if prerelease:
+        return prerelease.group(1)
+    if RELEASE_TAG_RE.match(raw):
+        return raw
+    raise ValueError(raw)
 
 
 def release_tags(repo_root: Path) -> list[str]:
@@ -97,6 +120,19 @@ def main() -> int:
     parser.add_argument("--format", choices=("plain", "github"), default="plain")
     args = parser.parse_args()
 
+    try:
+        tag = release_tag(args.tag)
+    except ValueError:
+        emit(
+            "error",
+            f"{args.tag} is not a release tag, so its distance from the newest benchmarked "
+            "release is not a number worth reporting. Pass v<version>, or the tester "
+            "prerelease workspaces-v<version>-main.<run>. The release workflow reads it "
+            "from ./scripts/release-version.sh print-tag.",
+            args.format,
+        )
+        return 1
+
     benchmarked = benchmarked_tags(args.csv)
     if not benchmarked:
         emit(
@@ -108,17 +144,17 @@ def main() -> int:
         )
         return 1
 
-    gap = releases_since(release_tags(args.repo_root), set(benchmarked), args.tag)
+    gap = releases_since(release_tags(args.repo_root), set(benchmarked), tag)
     newest = benchmarked[-1]
 
     if gap == 0:
-        print(f"ok: {args.tag} has committed performance benchmarks")
+        print(f"ok: {tag} has committed performance benchmarks")
         return 0
 
     if gap < BLOCK_AFTER:
         emit(
             "warning",
-            f"No performance benchmarks for {args.tag}; newest is {newest} "
+            f"No performance benchmarks for {tag}; newest is {newest} "
             f"({gap} release behind). Release proceeds, but the next one is blocked "
             "unless benchmarks are updated. See docs/performance_benchmarks.md.",
             args.format,
@@ -127,7 +163,7 @@ def main() -> int:
 
     emit(
         "error",
-        f"Performance benchmarks are {gap} releases stale (newest: {newest}, releasing: {args.tag}). "
+        f"Performance benchmarks are {gap} releases stale (newest: {newest}, releasing: {tag}). "
         f"Release blocked at {BLOCK_AFTER}. Run ./scripts/perf-runner.sh on a laptop and add a row "
         "to docs/performance_benchmarks.csv — see docs/performance_benchmarks.md.",
         args.format,

--- a/scripts/tests/test_check_perf_benchmarks.py
+++ b/scripts/tests/test_check_perf_benchmarks.py
@@ -64,6 +64,27 @@ class StalenessTests(unittest.TestCase):
         self.assertGreaterEqual(gate.releases_since([], {"v0.23.0"}, "v0.25.0"), gate.BLOCK_AFTER)
 
 
+class ReleaseTagTests(unittest.TestCase):
+    """What counts as "the release being cut"."""
+
+    def test_release_tag_is_itself(self) -> None:
+        self.assertEqual(gate.release_tag("v0.25.0"), "v0.25.0")
+
+    def test_prerelease_grades_as_the_release_it_rehearses(self) -> None:
+        # The tester prerelease consumes no release slot and never earns a row,
+        # so grading it as its own release charges it for the tag it de-risks.
+        self.assertEqual(gate.release_tag("workspaces-v0.25.0-main.7"), "v0.25.0")
+
+    def test_prerelease_of_a_prerelease_version_keeps_the_version(self) -> None:
+        self.assertEqual(gate.release_tag("workspaces-v1.0.0-beta.1-main.12"), "v1.0.0-beta.1")
+
+    def test_refs_that_cut_no_release_are_rejected(self) -> None:
+        for raw in ("HEAD", "main", "refs/heads/main", "", "v0.25", "0.25.0"):
+            with self.subTest(raw=raw):
+                with self.assertRaises(ValueError):
+                    gate.release_tag(raw)
+
+
 class GateFixture:
     """A throwaway git repo with real release tags, plus a CSV to point at."""
 
@@ -135,6 +156,24 @@ class ExitCodeTests(GateFixture, unittest.TestCase):
         # No tags exist in this fresh repo, so v0.23.0 sits 2 behind v0.25.0.
         write_csv(self.csv, ["v0.23.0"])
         self.assertEqual(self.run_gate("v0.25.0"), 1)
+
+    def test_prerelease_is_graded_as_the_release_it_rehearses(self) -> None:
+        # The rehearsal has to be at least as easy to pass as the tag it
+        # rehearses, or nobody rehearses. Counting it as its own release put it
+        # one further behind and blocked the cheaper check.
+        write_csv(self.csv, ["v0.24.0"])
+        result = self.gate_result("workspaces-v0.25.0-main.7")
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("v0.25.0", result.stdout)
+
+    def test_a_ref_that_cuts_no_release_is_refused_rather_than_graded(self) -> None:
+        # Distance-from-benchmark is meaningless for HEAD; before, it was
+        # computed anyway and the verdict swung on where the newest row sat.
+        write_csv(self.csv, ["v0.25.0"])
+        result = self.gate_result("HEAD")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("not a release tag", result.stdout)
+        self.assertNotIn("releases stale", result.stdout)
 
 
 class GithubAnnotationTests(GateFixture, unittest.TestCase):

--- a/scripts/tests/test_release_workflow.py
+++ b/scripts/tests/test_release_workflow.py
@@ -29,6 +29,24 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertNotIn("release_channel", workflow)
         self.assertNotIn("refresh-stable-assets", workflow)
 
+    def test_perf_gate_grades_the_version_being_built(self) -> None:
+        # A dispatch from main has no tag to pass. Feeding the gate the ref
+        # meant it graded the literal string HEAD, which sits one release past
+        # the tag it rehearses — so the rehearsal blocked where the release
+        # itself passed.
+        step = self.release_step("Verify release performance benchmarks are current")
+        self.assertIn("--tag \"$(./scripts/release-version.sh print-tag)\"", step)
+        self.assertNotIn("github.ref_name", step)
+        self.assertNotIn("HEAD", step)
+
+    @staticmethod
+    def release_step(name: str) -> str:
+        """One step's YAML, so a failure prints the step and not the workflow."""
+        workflow = (REPO_ROOT / ".github/workflows/release.yml").read_text()
+        _, _, after = workflow.partition(f"- name: {name}\n")
+        assert after, f"no step named {name!r} in release.yml"
+        return after.split("      - ", 1)[0]
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`RELEASING.md` (#1304) makes a `Release` dispatch from `main` the required pre-tag rehearsal. That dispatch could not reach notarization — it failed the perf gate first, so the mandated rehearsal has never been usable.

## Mechanism

On a branch dispatch there is no tag, so the step passed the literal string `HEAD`. `releases_since()` then graded `[…v0.23.0, v0.24.0, HEAD]`, walked back to the newest benchmarked tag, and returned 2 — blocked.

The tag passed while the rehearsal for that same tag did not, which is backwards: the rehearsal is the cheaper thing you are supposed to do *first*.

It is also a mis-grade, not merely missing evidence. A rehearsal publishes `workspaces-v<version>-main.N`, a prerelease that consumes no release slot and never appears in `docs/performance_benchmarks.csv`. Counting it as the next release penalises the rehearsal for the staleness of the tag it exists to de-risk.

## Change

All three entry points cut the same version — a `main` dispatch rehearsing `v<version>`, the tester prerelease it publishes, and the `v<version>` tag — so the gate now reads the version being built via `release-version.sh print-tag`. On the tag path that *is* the ref, since `Validate app version metadata` has already bound them.

A tester prerelease is normalised to the release it rehearses. A non-release ref now fails with a message naming the correct invocation instead of silently grading as stale.

## Validation

![evidence](https://evidence.cloudcompute.com/workspaces/pr-1324/20260814-200547-perf-gate-rehearsal.png)

The gate run three ways, exit codes captured directly rather than through a pipe:

| `--tag` | exit | result |
|---|---|---|
| `HEAD` | 1 | rejected, with a message naming `release-version.sh print-tag` |
| `v0.24.0` | 0 | warning, 1 release behind, proceeds |
| `workspaces-v0.24.0-main.42` | 0 | normalised to `v0.24.0`, identical verdict |

That third row is the point of the PR: the rehearsal now grades exactly as the release it rehearses.

- `test_check_perf_benchmarks.py` — 23 tests, OK
- `test_release_workflow.py` — 2 tests, OK
- `actionlint` — 2 findings, same as base (pre-existing SC2129 in unrelated steps)
- `validate-release-changes.py` — passed, YAML parse OK

## Mergeability

- **Surface:** release lane — `.github/workflows/release.yml` (one step's invocation) and `scripts/check-perf-benchmarks.py` (tag normalisation), plus tests for both.
- **User-facing behavior changed:** No. No change to artifacts, signing, notarization, or what gets published.
- **Non-happy paths considered:** All three tag shapes exercised above, including the non-release ref that previously mis-graded silently and now fails loudly. Staleness thresholds are untouched — pass at 0, warn at 1, block at 2 — so a genuinely stale release is still blocked; #1238's rule that a skipped measurement must never read as passing is preserved, and `HEAD` moves from silently-wrong to explicitly-rejected.
- **Release/ops preconditions:** None. No secret, variable, or environment change. The gate reads committed evidence in `docs/performance_benchmarks.csv` and needs no new inputs. Note that `v0.24.0` currently has no benchmark row, so the next release warns at 1 behind and the one after that blocks — pre-existing and unchanged by this PR, but it is the reason to record a v0.24.0 measurement before cutting v0.25.0.
- **Residual risk or follow-up:** The release lane only executes on a tag push or dispatch, so this step is unverified-in-CI until one of those runs — mitigated by executing the gate directly in all three shapes rather than reasoning about it. The first real exercise is the next pre-tag rehearsal, which is precisely what this unblocks.

Closes #1315

🤖 Generated with [Claude Code](https://claude.com/claude-code)