### PR TITLE
chore(security): audit the release environment, not just repository scope

### DIFF
--- a/scripts/audit-security-posture.py
+++ b/scripts/audit-security-posture.py
@@ -34,22 +34,45 @@ RETIRED_RUNNER_LABELS = {"lume-macos", "signing-host", "tart-ui"}
 RUNNER_QUALIFIER_LABELS = {"self-hosted", "macos", "linux", "windows", "arm64", "x64", "x86"}
 EXPECTED_ENVIRONMENTS = {"release"}
 EXPECTED_REPO_SECRETS = {
+    # The three App Store Connect names stay repository-scoped because
+    # xcode-cloud-logs.yml reads them and declares no environment. They are also
+    # on the release environment, which is why DUAL_SCOPE_EXPECTED lists them.
     "APPLE_API_ISSUER_ID",
     "APPLE_API_KEY_BASE64",
     "APPLE_API_KEY_ID",
-    "APPLE_DEVELOPER_ID_CERT_BASE64",
-    "APPLE_DEVELOPER_ID_CERT_PASSWORD",
-    "APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64",
     "CLAUDE_CODE_OAUTH_TOKEN",
     "CLOUDFLARE_ACCOUNT_ID",
     "CLOUDFLARE_API_TOKEN",
     "EVIDENCE_UPLOAD_TOKEN",
-    "SPARKLE_PRIVATE_KEY",
     "VERCEL_ORG_ID",
     "VERCEL_PROJECT_ID",
     "VERCEL_TOKEN",
 }
 LEGACY_REPO_SECRETS = {"APPLE_APP_PASSWORD"}
+# Signing credentials live only on the release environment, so a job must declare
+# `environment: release` — and clear its human approval — to read them at all.
+EXPECTED_ENVIRONMENT_SECRETS = {
+    "release": {
+        "APPLE_API_ISSUER_ID",
+        "APPLE_API_KEY_BASE64",
+        "APPLE_API_KEY_ID",
+        "APPLE_DEVELOPER_ID_CERT_BASE64",
+        "APPLE_DEVELOPER_ID_CERT_PASSWORD",
+        "APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64",
+        "SPARKLE_PRIVATE_KEY",
+    },
+}
+# An environment secret shadows the repository secret of the same name, including
+# when the environment copy is empty — that is how two empty values hid two
+# working ones during the v0.24.0 arc. Emptiness is invisible from outside (the
+# API exposes only name and timestamps), so the reachable signal is the shadowing
+# itself. These names are dual-scoped on purpose until xcode-cloud-logs.yml gets
+# its own environment; anything else in both scopes is unintended.
+DUAL_SCOPE_EXPECTED = {
+    "APPLE_API_ISSUER_ID",
+    "APPLE_API_KEY_BASE64",
+    "APPLE_API_KEY_ID",
+}
 
 
 @dataclass(frozen=True)
@@ -303,7 +326,7 @@ def remote_secret_checks(repo: str) -> list[Check]:
     }
     missing = sorted(EXPECTED_REPO_SECRETS - secrets)
     legacy = sorted(LEGACY_REPO_SECRETS & secrets)
-    return [
+    checks = [
         Check(
             "fail" if missing else "pass",
             "expected repository secrets",
@@ -315,6 +338,38 @@ def remote_secret_checks(repo: str) -> list[Check]:
             f"remove stale names: {', '.join(legacy)}" if legacy else "none found",
         ),
     ]
+
+    for environment, expected in sorted(EXPECTED_ENVIRONMENT_SECRETS.items()):
+        env_secrets = {
+            str(item.get("name"))
+            for item in gh_json(
+                ["secret", "list", "--repo", repo, "--env", environment, "--json", "name"]
+            )
+            if isinstance(item, dict) and item.get("name")
+        }
+        env_missing = sorted(expected - env_secrets)
+        shadowed = sorted((env_secrets & secrets) - DUAL_SCOPE_EXPECTED)
+        checks.append(
+            Check(
+                "fail" if env_missing else "pass",
+                f"expected {environment} environment secrets",
+                f"missing: {', '.join(env_missing)}"
+                if env_missing
+                else "all expected names present",
+            )
+        )
+        checks.append(
+            Check(
+                "warn" if shadowed else "pass",
+                f"{environment} environment shadows repository secrets",
+                f"also at repository scope, so the environment copy wins silently: "
+                f"{', '.join(shadowed)}"
+                if shadowed
+                else "no unintended dual-scoped names",
+            )
+        )
+
+    return checks
 
 
 def remote_checks(repo: str) -> list[Check]:


### PR DESCRIPTION
The seven release credentials are now on the `release` environment, and the four release-exclusive ones have been **deleted at repository scope**. A job must declare `environment: release` — and clear its human approval — to read the signing certificate, its password, the provisioning profile, or the Sparkle private key. That was the point of the migration; until now `environment: release` gated *when* the job ran, not *what it could read*.

The audit still expected those names at repository scope, so it failed the moment they moved:

```
[FAIL] expected repository secrets: missing: APPLE_DEVELOPER_ID_CERT_BASE64,
       APPLE_DEVELOPER_ID_CERT_PASSWORD, APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64,
       SPARKLE_PRIVATE_KEY
```

## Change

Expectations follow the credentials. `EXPECTED_ENVIRONMENT_SECRETS` checks the release environment; the four moved names come out of `EXPECTED_REPO_SECRETS`.

The three App Store Connect names stay listed at repository scope on purpose — `xcode-cloud-logs.yml` reads them and declares no environment, so deleting them there would break it. Giving that workflow its own environment is separate work; this PR records the current state rather than pretending it is finished.

## The shadowing check

An environment secret wins over the repository secret of the same name **including when the environment copy is empty**. That is what broke the fifth v0.24.0 attempt: two empty environment values silently hid two working repository values, and the failure read as a missing credential.

Emptiness cannot be detected — the API returns only `name`, `created_at`, `updated_at` — so the reachable signal is the dual scoping itself. The three knowingly dual-scoped names are allowlisted in `DUAL_SCOPE_EXPECTED`; anything else warns. When `xcode-cloud-logs.yml` gets its environment, that allowlist empties and the check tightens on its own.

## Validation

![evidence](https://evidence.cloudcompute.com/workspaces/pr-1325/20260815-035020-audit-environment-scoped-secrets.png)

Run against live GitHub state after the deletion: all 11 checks pass, `--strict` exits 0.

A passing audit does not prove the new checks *can* fail, so both were driven to failure:

| Negative test | Result |
|---|---|
| An expected environment secret is absent | `[FAIL] expected release environment secrets: missing: DEFINITELY_NOT_SET_HERE` |
| A dual-scoped name is not allowlisted | `[WARN] release environment shadows repository secrets: … APPLE_API_KEY_BASE64` |

Both ran in-tree, because the script resolves `REPO_ROOT` from its own location — copies run from `/tmp` crash on a missing path and exit non-zero for the wrong reason, which is how my first attempt at this produced a false pass. The tree is clean afterwards (0 stray files).

## Mergeability

- **Surface:** operator tooling — `scripts/audit-security-posture.py`. Not wired into CI; report-only by default, `--strict` exits non-zero.
- **User-facing behavior changed:** No.
- **Non-happy paths considered:** Both new checks driven to failure (above). The environment lookup is a separate `gh secret list --env` call per environment, wrapped by the existing per-collector `try` in `remote_checks`, so a permissions failure degrades to a reported error rather than a crash. `DUAL_SCOPE_EXPECTED` is a subtraction from a warn set, so an unexpected dual-scoped name still surfaces.
- **Release/ops preconditions:** None to merge — the GitHub-side changes it audits are already applied. The state it now expects is live: 7 secrets on `release`, 4 deleted at repository scope, `APPLE_ID` and `APPLE_TEAM_ID` secret duplicates removed (both remain as repository *variables*, which is what the workflows actually read). Prior state snapshotted outside the repo before deletion.
- **Residual risk or follow-up:** The three App Store Connect names remain dual-scoped until `xcode-cloud-logs.yml` gets its own environment — tracked in the arc notes, and the allowlist is the honest record of it. Deletion is recoverable: five values from `~/.config/apple/`, the Sparkle key from the login keychain, the Issuer ID from App Store Connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)