### PR TITLE
fix(security): scope the App Store Connect key to an environment

### DIFF
--- a/.github/workflows/xcode-cloud-logs.yml
+++ b/.github/workflows/xcode-cloud-logs.yml
@@ -24,6 +24,12 @@ concurrency:
 jobs:
   fetch:
     runs-on: ubuntu-latest
+    # The App Store Connect key this reads is Admin-scoped, so it lives on an
+    # environment rather than at repository scope, where any workflow on any
+    # branch could read it. The environment's branch policy allows only `main`
+    # and `ci/xcode-cloud-logs` — matching this workflow's triggers — so
+    # declaring the environment is not by itself enough to reach the key.
+    environment: xcode-cloud-logs
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -194,7 +194,8 @@ Notes:
 - Add `--non-interactive` for CI-friendly usage.
 - Add `--run-release --watch` to dispatch the release workflow from `main` immediately after setup and stream the result.
 
-If you prefer to configure GitHub manually, add these **secrets** to your GitHub repository (Settings > Secrets and variables > Actions > Secrets):
+If you prefer to configure GitHub manually, add these to the **`release` environment**, not to
+repository secrets (Settings > Environments > release > Environment secrets):
 
 | Secret | Description |
 |--------|-------------|
@@ -204,6 +205,22 @@ If you prefer to configure GitHub manually, add these **secrets** to your GitHub
 | `APPLE_API_KEY_BASE64` | Base64-encoded App Store Connect API `.p8` key |
 | `APPLE_API_KEY_ID` | App Store Connect API key ID |
 | `APPLE_API_ISSUER_ID` | App Store Connect issuer ID |
+| `SPARKLE_PRIVATE_KEY` | Sparkle EdDSA private key, matching `SUPublicEDKey` |
+
+**Why the environment and not repository scope.** A repository secret is readable by any workflow
+on any branch. Scoping these to `release` means a job must declare `environment: release` and clear
+its human approval before it can read them at all — so the credentials are protected by
+construction rather than by everyone remembering not to reference them. This will surprise anyone
+adding a workflow that needs signing: the secret resolves empty until the job declares the
+environment.
+
+`xcode-cloud-logs.yml` needs the same three App Store Connect values and holds its own copies on the
+`xcode-cloud-logs` environment, which gates on a branch policy (`main` and `ci/xcode-cloud-logs`)
+rather than approval, since fetching build logs should not need a human.
+
+One scope per name matters: an environment secret shadows a repository secret of the same name
+**including when the environment copy is empty**, which reads as a missing credential while a
+working value sits underneath it.
 
 Add these **variables** to your GitHub repository (Settings > Secrets and variables > Actions > Variables):
 

--- a/docs/development/security-critical-path.md
+++ b/docs/development/security-critical-path.md
@@ -28,9 +28,19 @@ not a broad public security stance.
 ## Release And Update Chain
 
 - Release signing runs on hosted `macos-15` behind the protected `release`
-  environment. Every credential comes from repository secrets and the
-  certificate is imported into a temporary keychain the job creates and
-  destroys, so no signing material persists on the runner.
+  environment. Every credential is scoped to that environment rather than to the
+  repository, so a job must declare `environment: release` and clear its human
+  approval to read any of them — the gate covers what a job can read, not only
+  when it runs. The certificate is imported into a temporary keychain the job
+  creates and destroys, so no signing material persists on the runner.
+- `xcode-cloud-logs.yml` reads an Admin-scoped App Store Connect key, so it holds
+  its own copies on the `xcode-cloud-logs` environment. That one gates on a
+  deployment branch policy (`main` and `ci/xcode-cloud-logs`) instead of
+  approval: log fetching should not need a human, but the key should not be
+  reachable from an arbitrary branch. `scripts/audit-security-posture.py` checks
+  both environments and warns on any name present in both an environment and
+  repository scope, since the environment copy wins silently — including when it
+  is empty.
 - The signing job has read-only repository permissions; publication is isolated
   in a separate `contents: write` job.
 - Host tooling comes from SHA-pinned actions at pinned versions — `mise` via

--- a/scripts/audit-security-posture.py
+++ b/scripts/audit-security-posture.py
@@ -32,14 +32,8 @@ RETIRED_RUNNER_LABELS = {"lume-macos", "signing-host", "tart-ui"}
 # OS and architecture qualifiers, not lanes: they narrow which self-hosted
 # machine takes the job, they do not name a purpose.
 RUNNER_QUALIFIER_LABELS = {"self-hosted", "macos", "linux", "windows", "arm64", "x64", "x86"}
-EXPECTED_ENVIRONMENTS = {"release"}
+EXPECTED_ENVIRONMENTS = {"release", "xcode-cloud-logs"}
 EXPECTED_REPO_SECRETS = {
-    # The three App Store Connect names stay repository-scoped because
-    # xcode-cloud-logs.yml reads them and declares no environment. They are also
-    # on the release environment, which is why DUAL_SCOPE_EXPECTED lists them.
-    "APPLE_API_ISSUER_ID",
-    "APPLE_API_KEY_BASE64",
-    "APPLE_API_KEY_ID",
     "CLAUDE_CODE_OAUTH_TOKEN",
     "CLOUDFLARE_ACCOUNT_ID",
     "CLOUDFLARE_API_TOKEN",
@@ -52,6 +46,15 @@ LEGACY_REPO_SECRETS = {"APPLE_APP_PASSWORD"}
 # Signing credentials live only on the release environment, so a job must declare
 # `environment: release` — and clear its human approval — to read them at all.
 EXPECTED_ENVIRONMENT_SECRETS = {
+    # Both environments hold the App Store Connect triple. They are separate
+    # copies, not a shared one: release gates on human approval, while
+    # xcode-cloud-logs gates only on a branch policy, because fetching build
+    # logs should not need an approval.
+    "xcode-cloud-logs": {
+        "APPLE_API_ISSUER_ID",
+        "APPLE_API_KEY_BASE64",
+        "APPLE_API_KEY_ID",
+    },
     "release": {
         "APPLE_API_ISSUER_ID",
         "APPLE_API_KEY_BASE64",
@@ -66,13 +69,9 @@ EXPECTED_ENVIRONMENT_SECRETS = {
 # when the environment copy is empty — that is how two empty values hid two
 # working ones during the v0.24.0 arc. Emptiness is invisible from outside (the
 # API exposes only name and timestamps), so the reachable signal is the shadowing
-# itself. These names are dual-scoped on purpose until xcode-cloud-logs.yml gets
-# its own environment; anything else in both scopes is unintended.
-DUAL_SCOPE_EXPECTED = {
-    "APPLE_API_ISSUER_ID",
-    "APPLE_API_KEY_BASE64",
-    "APPLE_API_KEY_ID",
-}
+# itself. No name is dual-scoped by design any more; every credential the
+# release and log lanes use lives on an environment only.
+DUAL_SCOPE_EXPECTED: set[str] = set()
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
`xcode-cloud-logs.yml` read the App Store Connect key from **repository secrets** — where any workflow, on any branch, could reach it with no approval. That is the same exposure the release migration closed for the signing certificate and the Sparkle key, on the credential with the broader reach: key `2C24D6F2FW` is **Admin**-scoped, so it is not limited to downloading build logs.

It is also the last thing standing between the current state and a finished migration. `DUAL_SCOPE_EXPECTED` in `audit-security-posture.py` existed solely to allowlist these three names; this empties it.

## The branch policy is the control, not the environment

Worth being plain about, because it would be easy to overstate what this buys. Declaring `environment:` is something any workflow can do — an environment with no protection rules would be close to theatre. The `xcode-cloud-logs` environment therefore carries a **deployment branch policy** allowing only `main` and `ci/xcode-cloud-logs`, matching this workflow's own triggers. Agent-authored PRs run on feature branches, so that policy is what actually denies them the key.

Approval would be a stronger gate, and `release` uses one. Log fetching should not need a human, so this trades that for a branch restriction deliberately.

## Change

`jobs.fetch` declares the environment. The audit gains `xcode-cloud-logs` in `EXPECTED_ENVIRONMENTS` and `EXPECTED_ENVIRONMENT_SECRETS`; the three names come out of `EXPECTED_REPO_SECRETS`; `DUAL_SCOPE_EXPECTED` becomes empty. `RELEASING.md` and `security-critical-path.md` now say environment rather than repository scope, and say why — including that the secret resolves empty until a job declares the environment, which will surprise the next person adding a signing workflow.

The two environments hold **separate copies** of the same three values, not a shared one. That is inherent to environment scoping and worth knowing when rotating the key: both copies must be updated.

## Validation

![evidence](https://evidence.cloudcompute.com/workspaces/pr-1326/20260816-050848-xcode-cloud-logs-environment.png)

- Environment exists with `branch_policy` protection; allowed branches are exactly `main` and `ci/xcode-cloud-logs`.
- All three secrets present on it. Set with a non-empty guard, and the key material verified at 344 chars — the check that would have prevented the v0.24.0 attempt-5 failure.
- `jobs.fetch.environment` parses as `xcode-cloud-logs`; `actionlint` clean on the file.
- Audit run against live state: both environments pass, all expected names present.

**The two WARNs in the evidence are expected and correct.** The repository copies are deliberately still there — deleting them before this merges would break the workflow in the window between. They clear on deletion, which is the last step, after a dispatch proves the environment resolves.

## Mergeability

- **Surface:** CI + security tooling — `.github/workflows/xcode-cloud-logs.yml` (one job declaration), `scripts/audit-security-posture.py` (expectations), and two docs.
- **User-facing behavior changed:** No. No product code, no release artifacts, no signing path. `release.yml` is untouched.
- **Non-happy paths considered:** If the environment or its secrets were wrong, the fetch job fails closed — it cannot read a value and the ASC call errors, rather than silently fetching nothing. A dispatch from a branch outside the policy is denied the environment, which is the intended behavior and the reason the policy exists. The audit's environment lookup is wrapped by the existing per-collector `try`, so a permissions failure reports rather than crashes.
- **Release/ops preconditions:** The GitHub-side setup is already applied — environment, branch policy, and all three secrets exist (evidence above). Nothing to configure before merge. After merge: dispatch this workflow once with a known SHA to confirm the environment resolves, then delete the three repository copies. Until that deletion the repository values remain a working fallback, so the merge itself cannot break log fetching.
- **Residual risk or follow-up:** `config/github/` versions rulesets and variables but not environments, so these protection rules can be weakened in the UI with nothing catching it — a real drift surface, and the reason `audit-security-posture.py` checking protection rules is the compensating control for now. Extending `scripts/github-settings.py` to manage environments is the durable fix, filed separately rather than bundled here. Higher-leverage alternative worth considering independently: this key is Admin-scoped and neither notarization nor log fetching needs that, so a narrower key would shrink the blast radius by more than scoping does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)