### PR TITLE
feat(config): manage deployment environments as code

### DIFF
--- a/.github/workflows/repo-settings-drift.yml
+++ b/.github/workflows/repo-settings-drift.yml
@@ -1,5 +1,7 @@
-# Drift gate for config/github/ — verifies live GitHub repo settings (rulesets)
-# still match the committed desired state. Read-only: applying changes is a
+# Drift gate for config/github/ — verifies live GitHub repo settings (rulesets
+# and deployment environments) still match the committed desired state. The
+# environments carry the release path's approval gate and branch policies, so a
+# UI edit that weakens them surfaces here. Read-only: applying changes is a
 # deliberate local act via `scripts/github-settings.py apply` (repo admin).
 name: Repo Settings Drift
 

--- a/config/github/README.md
+++ b/config/github/README.md
@@ -23,6 +23,32 @@ default Actions token (rulesets are visible to anyone with read access);
 To manage an additional ruleset, create `rulesets/<name>.json` containing
 `{"name": "<live-name>"}` and run `snapshot`.
 
+## Environments (`environments/`)
+
+`environments/<name>.json` holds one deployment environment each: its protection
+rules (`reviewers`, `wait_timer`, `prevent_self_review`) and its deployment
+branch policy, including the exact list of allowed branches and tags. Same
+workflow as rulesets — edit the JSON in a PR, `apply` after merge, and the drift
+run catches a change made in the UI. Add one with `{"name": "<live-name>"}` and
+`snapshot`.
+
+These gate the release path, so drift here is worth catching: `release` requires
+a human approval and admits only `main` plus `v*` / `workspaces-v*` tags, and
+`xcode-cloud-logs` admits only `main` and `ci/xcode-cloud-logs`. Weakening either
+in the UI is invisible without this check.
+
+Two deliberate choices:
+
+- **Reviewers are stored by login, not id.** Numeric ids make diffs unreadable;
+  `apply` resolves the login back to an id. `apply` always sends the reviewer
+  list, because the environments `PUT` *clears* reviewers when the field is
+  omitted — which would silently remove the approval gate on `release`.
+- **Secret names live in `scripts/audit-security-posture.py`, not here.** That
+  script already checks which names exist in which scope, and duplicating the
+  list would create the second source of truth this directory exists to prevent.
+  Secret *values* appear in neither. The two tools are complementary: this one
+  owns protection rules, that one owns secret placement.
+
 ## App manifests (`apps/`)
 
 `apps/<slug>.manifest.json` holds the [GitHub App manifest](https://docs.github.com/en/apps/sharing-github-apps/registering-a-github-app-from-a-manifest)

--- a/config/github/README.md
+++ b/config/github/README.md
@@ -13,6 +13,13 @@ uv run --script scripts/github-settings.py apply      # push files to GitHub (ne
 uv run --script scripts/github-settings.py snapshot   # overwrite files from live state
 ```
 
+**`bypass_actors` is not managed here.** A read-only token cannot see it, so
+tracking it would make every CI check disagree with every admin check. `check`
+normalises it to `[]` on both sides, and `apply` carries the live value across
+untouched — otherwise applying an unrelated rule change would strip the
+repository-admin bypass as a side effect. Bypass-actor changes are made in the
+UI and are not drift-checked.
+
 Changing a setting is a PR that edits the JSON, then `apply` after merge.
 `.github/workflows/repo-settings-drift.yml` runs `check` on a schedule and on
 PRs touching these files, so a settings change made in the GitHub UI without a

--- a/config/github/environments/release.json
+++ b/config/github/environments/release.json
@@ -1,0 +1,29 @@
+{
+  "branch_policies": [
+    {
+      "name": "main",
+      "type": "branch"
+    },
+    {
+      "name": "v*",
+      "type": "tag"
+    },
+    {
+      "name": "workspaces-v*",
+      "type": "tag"
+    }
+  ],
+  "deployment_branch_policy": {
+    "custom_branch_policies": true,
+    "protected_branches": false
+  },
+  "name": "release",
+  "prevent_self_review": false,
+  "reviewers": [
+    {
+      "login": "fairchild",
+      "type": "User"
+    }
+  ],
+  "wait_timer": 0
+}

--- a/config/github/environments/xcode-cloud-logs.json
+++ b/config/github/environments/xcode-cloud-logs.json
@@ -1,0 +1,20 @@
+{
+  "branch_policies": [
+    {
+      "name": "ci/xcode-cloud-logs",
+      "type": "branch"
+    },
+    {
+      "name": "main",
+      "type": "branch"
+    }
+  ],
+  "deployment_branch_policy": {
+    "custom_branch_policies": true,
+    "protected_branches": false
+  },
+  "name": "xcode-cloud-logs",
+  "prevent_self_review": false,
+  "reviewers": [],
+  "wait_timer": 0
+}

--- a/scripts/github-settings.py
+++ b/scripts/github-settings.py
@@ -54,10 +54,13 @@ def repo_slug() -> str:
 
 def render(ruleset: dict) -> str:
     desired = {key: ruleset[key] for key in WRITABLE_FIELDS if key in ruleset}
-    # Read-only tokens (e.g. the Actions token in the drift workflow) get the
-    # ruleset without bypass_actors; treat absent as empty so they compare
-    # cleanly. Actual bypass-actor drift is still caught by admin-side checks.
-    desired.setdefault("bypass_actors", [])
+    # bypass_actors is deliberately not managed here: a read-only token (the
+    # Actions token in the drift workflow) cannot see it, so tracking it would
+    # make every CI check disagree with every admin check. Normalising to []
+    # on both sides keeps the comparison honest about what this file covers.
+    # apply() carries the live value across so the field is never rewritten
+    # from this empty placeholder — see apply_ruleset.
+    desired["bypass_actors"] = []
     return json.dumps(desired, indent=2, sort_keys=True) + "\n"
 
 
@@ -256,17 +259,26 @@ def check(repo: str) -> int:
     return max(drift, check_environments(repo))
 
 
+def apply_ruleset(repo: str, path: Path, live_ids: dict[str, int]) -> None:
+    desired = json.loads(render(json.loads(path.read_text())))
+    name = desired["name"]
+    if name not in live_ids:
+        gh_api(f"repos/{repo}/rulesets", "POST", desired)
+        print(f"created: ruleset '{name}' <- {path.name}")
+        return
+    # Carry the live bypass_actors across rather than sending render()'s empty
+    # placeholder, which would strip the repository-admin bypass as a silent
+    # side effect of applying an unrelated rule change.
+    live = gh_api(f"repos/{repo}/rulesets/{live_ids[name]}")
+    desired["bypass_actors"] = live.get("bypass_actors", []) if isinstance(live, dict) else []
+    gh_api(f"repos/{repo}/rulesets/{live_ids[name]}", "PUT", desired)
+    print(f"applied: ruleset '{name}' <- {path.name} (bypass_actors left as-is)")
+
+
 def apply(repo: str) -> int:
     live_ids = live_ids_by_name(repo)
     for path in desired_files():
-        desired = json.loads(render(json.loads(path.read_text())))
-        name = desired["name"]
-        if name in live_ids:
-            gh_api(f"repos/{repo}/rulesets/{live_ids[name]}", "PUT", desired)
-            print(f"applied: ruleset '{name}' <- {path.name}")
-        else:
-            gh_api(f"repos/{repo}/rulesets", "POST", desired)
-            print(f"created: ruleset '{name}' <- {path.name}")
+        apply_ruleset(repo, path, live_ids)
     for path in environment_files():
         apply_environment(repo, path)
     return 0

--- a/scripts/github-settings.py
+++ b/scripts/github-settings.py
@@ -3,12 +3,17 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Config-as-code for GitHub repo settings (currently: repository rulesets).
+"""Config-as-code for GitHub repo settings: repository rulesets and environments.
 
-Desired state lives in config/github/rulesets/<name>.json, matched to live
-rulesets by their "name" field. `check` exits 1 with a diff when live settings
-drift from the files; `apply` pushes the files to GitHub (admin token);
-`snapshot` overwrites the files from live state. Auth via `gh` / GH_TOKEN.
+Desired state lives in config/github/rulesets/<name>.json and
+config/github/environments/<name>.json, each matched to live settings by its
+"name" field. `check` exits 1 with a diff when live settings drift from the
+files; `apply` pushes the files to GitHub (admin token); `snapshot` overwrites
+the files from live state. Auth via `gh` / GH_TOKEN.
+
+Environments carry protection rules and deployment branch policies only. Secret
+*names* are audited separately by scripts/audit-security-posture.py, which stays
+the single source of truth for them; secret values never appear here.
 """
 
 import argparse
@@ -18,7 +23,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-RULESETS_DIR = Path(__file__).resolve().parent.parent / "config" / "github" / "rulesets"
+CONFIG_DIR = Path(__file__).resolve().parent.parent / "config" / "github"
+RULESETS_DIR = CONFIG_DIR / "rulesets"
+ENVIRONMENTS_DIR = CONFIG_DIR / "environments"
 WRITABLE_FIELDS = ("name", "target", "enforcement", "bypass_actors", "conditions", "rules")
 
 
@@ -32,7 +39,7 @@ def gh_api(path: str, method: str = "GET", body: dict | None = None) -> dict | l
         result = subprocess.run(cmd, input=stdin, capture_output=True, check=True)
     except subprocess.CalledProcessError as err:
         sys.exit(f"gh api {method} {path} failed: {err.stderr.decode().strip()}")
-    return json.loads(result.stdout)
+    return json.loads(result.stdout or b"{}")
 
 
 def repo_slug() -> str:
@@ -65,6 +72,162 @@ def live_ids_by_name(repo: str) -> dict[str, int]:
     return {r["name"]: r["id"] for r in gh_api(f"repos/{repo}/rulesets")}
 
 
+# --- environments ------------------------------------------------------------
+#
+# Reviewers are stored by login rather than numeric id: the id is an
+# implementation detail that makes diffs unreadable, and `apply` resolves it
+# back. Reviewers are always written on apply — the environments PUT clears
+# them when the field is omitted, which would silently drop the human approval
+# gate on `release`.
+
+
+def environment_files() -> list[Path]:
+    return sorted(ENVIRONMENTS_DIR.glob("*.json")) if ENVIRONMENTS_DIR.is_dir() else []
+
+
+def render_environment(name: str, live: dict, branch_policies: list[dict]) -> str:
+    rules = live.get("protection_rules") or []
+    by_type = {rule.get("type"): rule for rule in rules}
+    reviewer_rule = by_type.get("required_reviewers", {})
+    wait_rule = by_type.get("wait_timer", {})
+    desired = {
+        "name": name,
+        "wait_timer": wait_rule.get("wait_timer", 0),
+        "prevent_self_review": reviewer_rule.get("prevent_self_review", False),
+        "reviewers": sorted(
+            (
+                {
+                    "type": entry.get("type"),
+                    "login": (entry.get("reviewer") or {}).get("login")
+                    or (entry.get("reviewer") or {}).get("slug"),
+                }
+                for entry in reviewer_rule.get("reviewers", [])
+            ),
+            key=lambda item: (item["type"] or "", item["login"] or ""),
+        ),
+        "deployment_branch_policy": live.get("deployment_branch_policy"),
+        "branch_policies": sorted(
+            ({"type": policy["type"], "name": policy["name"]} for policy in branch_policies),
+            key=lambda item: (item["type"], item["name"]),
+        ),
+    }
+    return json.dumps(desired, indent=2, sort_keys=True) + "\n"
+
+
+def gh_api_optional(path: str) -> dict | None:
+    """GET that distinguishes "absent" from "could not read".
+
+    A 404 returns None; anything else still exits, so a permissions failure is
+    never reported as a missing environment.
+    """
+    result = subprocess.run(
+        ["gh", "api", path], capture_output=True, text=True
+    )
+    if result.returncode == 0:
+        return json.loads(result.stdout or "{}")
+    if "HTTP 404" in result.stderr or "Not Found" in result.stderr:
+        return None
+    sys.exit(f"gh api GET {path} failed: {result.stderr.strip()}")
+
+
+def live_environment(repo: str, name: str) -> str | None:
+    live = gh_api_optional(f"repos/{repo}/environments/{name}")
+    if live is None:
+        return None
+    policies: list[dict] = []
+    if (live.get("deployment_branch_policy") or {}).get("custom_branch_policies"):
+        payload = gh_api(f"repos/{repo}/environments/{name}/deployment-branch-policies")
+        policies = payload.get("branch_policies", []) if isinstance(payload, dict) else []
+    return render_environment(name, live, policies)
+
+
+def normalise_environment_file(path: Path) -> tuple[str, str]:
+    desired = json.loads(path.read_text())
+    name = desired["name"]
+    desired.setdefault("wait_timer", 0)
+    desired.setdefault("prevent_self_review", False)
+    desired.setdefault("reviewers", [])
+    desired.setdefault("deployment_branch_policy", None)
+    desired.setdefault("branch_policies", [])
+    desired["reviewers"] = sorted(
+        desired["reviewers"], key=lambda item: (item.get("type", ""), item.get("login", ""))
+    )
+    desired["branch_policies"] = sorted(
+        desired["branch_policies"], key=lambda item: (item.get("type", ""), item.get("name", ""))
+    )
+    return name, json.dumps(desired, indent=2, sort_keys=True) + "\n"
+
+
+def reviewer_id(login: str, kind: str) -> int:
+    path = f"orgs/{login}" if kind == "Team" else f"users/{login}"
+    return int(gh_api(path)["id"])
+
+
+def apply_environment(repo: str, path: Path) -> None:
+    name, rendered = normalise_environment_file(path)
+    desired = json.loads(rendered)
+    body = {
+        "wait_timer": desired["wait_timer"],
+        "prevent_self_review": desired["prevent_self_review"],
+        "reviewers": [
+            {"type": entry["type"], "id": reviewer_id(entry["login"], entry["type"])}
+            for entry in desired["reviewers"]
+        ],
+        "deployment_branch_policy": desired["deployment_branch_policy"],
+    }
+    gh_api(f"repos/{repo}/environments/{name}", "PUT", body)
+
+    if not (desired["deployment_branch_policy"] or {}).get("custom_branch_policies"):
+        print(f"applied: environment '{name}' <- {path.name}")
+        return
+
+    payload = gh_api(f"repos/{repo}/environments/{name}/deployment-branch-policies")
+    existing = payload.get("branch_policies", []) if isinstance(payload, dict) else []
+    live_keys = {(policy["type"], policy["name"]): policy["id"] for policy in existing}
+    wanted_keys = {(policy["type"], policy["name"]) for policy in desired["branch_policies"]}
+    for key in sorted(wanted_keys - set(live_keys)):
+        gh_api(
+            f"repos/{repo}/environments/{name}/deployment-branch-policies",
+            "POST",
+            {"type": key[0], "name": key[1]},
+        )
+    for key, policy_id in sorted(live_keys.items()):
+        if key not in wanted_keys:
+            gh_api(
+                f"repos/{repo}/environments/{name}/deployment-branch-policies/{policy_id}",
+                "DELETE",
+            )
+    print(f"applied: environment '{name}' <- {path.name}")
+
+
+def check_environments(repo: str) -> int:
+    drift = 0
+    for path in environment_files():
+        name, wanted = normalise_environment_file(path)
+        live = live_environment(repo, name)
+        if live is None:
+            print(f"DRIFT: environment '{name}' ({path.name}) does not exist on {repo}")
+            drift = 1
+            continue
+        if live == wanted:
+            print(f"OK: environment '{name}' matches {path.name}")
+        else:
+            print(f"DRIFT: environment '{name}' differs from {path.name}:")
+            sys.stdout.writelines(
+                difflib.unified_diff(
+                    live.splitlines(keepends=True),
+                    wanted.splitlines(keepends=True),
+                    fromfile=f"live/{name}",
+                    tofile=f"config/github/environments/{path.name}",
+                )
+            )
+            drift = 1
+    return drift
+
+
+# --- commands ----------------------------------------------------------------
+
+
 def check(repo: str) -> int:
     live_ids = live_ids_by_name(repo)
     drift = 0
@@ -90,7 +253,7 @@ def check(repo: str) -> int:
                 )
             )
             drift = 1
-    return drift
+    return max(drift, check_environments(repo))
 
 
 def apply(repo: str) -> int:
@@ -104,6 +267,8 @@ def apply(repo: str) -> int:
         else:
             gh_api(f"repos/{repo}/rulesets", "POST", desired)
             print(f"created: ruleset '{name}' <- {path.name}")
+    for path in environment_files():
+        apply_environment(repo, path)
     return 0
 
 
@@ -115,6 +280,13 @@ def snapshot(repo: str) -> int:
             sys.exit(f"ruleset '{name}' ({path.name}) does not exist on {repo}")
         path.write_text(render(gh_api(f"repos/{repo}/rulesets/{live_ids[name]}")))
         print(f"snapshot: {path.name} <- live ruleset '{name}'")
+    for path in environment_files():
+        name = json.loads(path.read_text())["name"]
+        live = live_environment(repo, name)
+        if live is None:
+            sys.exit(f"environment '{name}' ({path.name}) does not exist on {repo}")
+        path.write_text(live)
+        print(f"snapshot: {path.name} <- live environment '{name}'")
     return 0
 
 


### PR DESCRIPTION
`config/github/` versioned rulesets and repo variables but not environments, so the protection rules gating the release path could be weakened in the GitHub UI with nothing catching it. That gap matters more after this week's secrets work: `release` now holds every signing credential behind a human approval, and `xcode-cloud-logs` holds an Admin-scoped App Store Connect key behind a branch policy. Both are UI-editable state that nothing verified.

## What is managed

`environments/<name>.json` holds protection rules (`reviewers`, `wait_timer`, `prevent_self_review`) and the deployment branch policy, including the exact allowed branches and tags. `check` / `apply` / `snapshot` behave as they already do for rulesets, and `repo-settings-drift.yml` picks environments up through its existing `config/github/**` trigger — no workflow plumbing needed.

Two deliberate boundaries:

**Secret names stay in `audit-security-posture.py`.** That script already owns which names exist in which scope. Duplicating the list here would create the second source of truth this directory exists to prevent. This file owns protection rules; that one owns secret placement; neither holds values.

**Reviewers are stored by login, not numeric id.** Ids make diffs unreadable, and `apply` resolves the login back. `apply` always sends the reviewer list, because the environments `PUT` *clears* reviewers when the field is omitted — that would silently remove the approval gate on `release`.

## A live foot-gun this found, and defused

Second commit, and the reason this PR is two commits rather than one.

`apply` from a clean checkout **stripped the repository-admin bypass from `main-merge`**. The committed ruleset file carries `bypass_actors: []` because the read-only Actions token cannot see bypass actors, and `apply` wrote that placeholder back as if it were desired state.

I hit it twice in one session. The first time was masked — `snapshot` had already written the real actors into the file, so `apply` sent them back. The second time, generating evidence for this PR, it cleared the bypass for real. I restored it immediately, and the evidence below shows the restored state surviving a subsequent `apply`.

I had planned to file this separately, per the release-lane bundling lesson. That was the wrong call here: this PR's own README instructs people to run `apply`, so shipping the feature while leaving the foot-gun armed would be handing someone a loaded tool.

`bypass_actors` is now explicitly unmanaged — `render` normalises it to `[]` on both sides so admin and CI checks agree, and `apply` carries the live value across untouched. A side effect worth having: **a local `check` as an admin is clean for the first time**. It always reported drift on `main-merge` before, which is the kind of permanently-red check people learn to ignore.

## Validation

![evidence](https://evidence.cloudcompute.com/workspaces/pr-1327/20260816-061252-environments-as-code-v3.png)

- `check` clean as admin across ruleset and both environments, exit 0.
- **Drift detected — required reviewer removed:** diff shows the `fairchild` reviewer, exit 1. This is the weakening that matters most, since it is the release approval gate.
- **Drift detected — allowed branch removed:** diff shows `main` dropping out of `branch_policies`.
- **`apply` preserves what it does not manage:** `bypass_actors` still `RepositoryRole 5 always` afterwards, `release` still has its reviewer, all three allowed refs, and all 7 environment secrets.
- Clean again after `apply`.

The two environment files were produced by `snapshot` against live state, so they describe what is actually configured rather than what I believe is configured.

## Mergeability

- **Surface:** config-as-code — `scripts/github-settings.py`, two new `config/github/environments/*.json`, README, and a comment in the drift workflow.
- **User-facing behavior changed:** No. No product code. GitHub-side state is unchanged by merging; the files describe what already exists.
- **Non-happy paths considered:** Both drift cases driven to failure (above). `gh_api_optional` distinguishes 404 from a permissions failure, so an unreadable environment reports an error rather than silently claiming the environment does not exist — which would otherwise read as drift and invite someone to "fix" it by recreating a protection rule. `apply` on a branch-policy set reconciles both directions (adds missing, removes extra) rather than only adding.
- **Release/ops preconditions:** None. Nothing needs applying — live state already matches the committed files, which is what the evidence shows. The next `apply` is a no-op.
- **Residual risk or follow-up:** The drift job runs with the read-only Actions token; environment reads are exercised for the first time by this PR's own drift run, so if that token cannot read environments it surfaces here as a red check rather than in a scheduled run later. `bypass_actors` is now documented as unmanaged, which is honest but does mean a bypass-actor change made in the UI is still undetected — narrower than before, when it was undetected *and* silently reverted by `apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)