### PR TITLE
chore(scripts): launch-dev --coexist / --seed-store — a trial copy next to the installed app

### DIFF
--- a/scripts/launch-dev.sh
+++ b/scripts/launch-dev.sh
@@ -326,7 +326,10 @@ ensure_no_installed_app_instance() {
 stop_existing_if_requested() {
     if [[ "$COEXIST" == true ]]; then
         log "Coexist mode: leaving the installed app running; stopping any previous debug instance..."
-        pkill -f "$DEBUG_BINARY" >/dev/null 2>&1 || true
+        local pid
+        while read -r pid _; do
+            [[ -n "$pid" ]] && kill "$pid" >/dev/null 2>&1 || true
+        done <<< "$(list_instances_for_binary "$DEBUG_BINARY")"
         sleep 1
         return
     fi
@@ -363,15 +366,27 @@ configure_data_root() {
         return
     fi
 
+    [[ -n "$DATA_DIR" ]] || fail "--data-dir requires a non-empty path"
     DATA_DIR="$(expand_home_prefix "$DATA_DIR")"
     # Relative --data-dir values resolve against the repo root: the synthetic
     # fixture root derived from it must be absolute, and the app's own cwd is
-    # not a contract.
-    [[ "$DATA_DIR" == /* ]] || DATA_DIR="$REPO_ROOT/${DATA_DIR#./}"
+    # not a contract. The physical path is then checked against the checkout
+    # and the home directory so --clean-data can never rm -rf either.
+    [[ "$DATA_DIR" == /* ]] || DATA_DIR="$REPO_ROOT/$DATA_DIR"
+    mkdir -p "$DATA_DIR"
+    DATA_DIR="$(cd "$DATA_DIR" && pwd -P)"
+    local repo_physical home_physical
+    repo_physical="$(cd "$REPO_ROOT" && pwd -P)"
+    home_physical="$(cd "$HOME" && pwd -P)"
+    case "$repo_physical/" in
+        "$DATA_DIR"/*) fail "--data-dir must not be the checkout or an ancestor of it: $DATA_DIR" ;;
+    esac
+    if [[ "$DATA_DIR" == "/" || "$DATA_DIR" == "$home_physical" ]]; then
+        fail "--data-dir must not be / or the home directory: $DATA_DIR"
+    fi
     ENV_VARS+=("WORKSPACES_DATA_DIR=$DATA_DIR")
     ENV_VARS+=("WORKSPACES_APP_VARIANT=dev")
 
-    mkdir -p "$DATA_DIR"
     if [[ "$CLEAN_DATA" == true ]]; then
         log "Cleaning isolated data dir: $DATA_DIR"
         rm -rf "$DATA_DIR"
@@ -399,16 +414,27 @@ seed_store_if_requested() {
     fi
     command -v sqlite3 >/dev/null 2>&1 || fail "--seed-store requires sqlite3"
 
-    local name
+    # Everything lands in a staging dir and is published in one step, so a
+    # failure part-way never leaves a dir that later launches treat as seeded.
+    local staging="$DATA_DIR/.seed-staging"
+    rm -rf "$staging"
+    mkdir -p "$staging"
+
+    local name target
     for name in default.store local-state.sqlite; do
         [[ -f "$APP_SUPPORT_DATA_DIR/$name" ]] || continue
-        sqlite3 "$APP_SUPPORT_DATA_DIR/$name" ".backup '$DATA_DIR/$name'"
+        # VACUUM INTO is SQL, so the destination is a string literal ('' escapes
+        # a quote); sqlite3's .backup dot-command has no such escaping.
+        target="$(printf '%s' "$staging/$name" | sed "s/'/''/g")"
+        sqlite3 "$APP_SUPPORT_DATA_DIR/$name" "VACUUM INTO '$target'"
         log "Seeded $name from a snapshot of the installed app's store"
     done
-    if [[ -d "$APP_SUPPORT_DATA_DIR/ghostty" && ! -e "$DATA_DIR/ghostty" ]]; then
-        cp -R "$APP_SUPPORT_DATA_DIR/ghostty" "$DATA_DIR/ghostty"
+    if [[ -d "$APP_SUPPORT_DATA_DIR/ghostty" ]]; then
+        cp -R "$APP_SUPPORT_DATA_DIR/ghostty" "$staging/ghostty"
         log "Copied ghostty config"
     fi
+    mv "$staging"/* "$DATA_DIR"/
+    rmdir "$staging"
 }
 
 configure_fixture_mode() {
@@ -604,18 +630,20 @@ dump_recent_log_and_fail() {
 }
 
 read_window_id() {
-    swift - <<'SWIFT'
+    WORKSPACES_LAUNCH_OWNER_PID="$APP_PID" swift - <<'SWIFT'
 import CoreGraphics
 import Foundation
 
 let ownerCandidates: Set<String> = ["WorkSpaces", "WorkspaceManager"]
+let ownerPID = Int(ProcessInfo.processInfo.environment["WORKSPACES_LAUNCH_OWNER_PID"] ?? "")
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 
 for window in windows {
     let owner = window[kCGWindowOwnerName as String] as? String ?? ""
     let layer = window[kCGWindowLayer as String] as? Int ?? 1
-    guard ownerCandidates.contains(owner), layer == 0 else { continue }
+    let pid = window[kCGWindowOwnerPID as String] as? Int ?? -1
+    guard ownerCandidates.contains(owner), layer == 0, ownerPID == nil || pid == ownerPID else { continue }
 
     if let windowID = window[kCGWindowNumber as String] as? Int {
         print(windowID)
@@ -698,7 +726,7 @@ launch_background() {
     log "Verified visible window id: $WINDOW_ID"
     log "Log file: $LOG_PATH"
     if [[ "$NO_ACTIVATE_ON_LAUNCH" == true ]]; then
-        log "Shared-desktop follow-up: capture with ./scripts/capture-window.sh while leaving the app in the background."
+        log "Shared-desktop follow-up: capture with ./scripts/capture-window.sh --pid $APP_PID while leaving the app in the background."
     fi
 }
 

--- a/scripts/launch-dev.sh
+++ b/scripts/launch-dev.sh
@@ -38,6 +38,10 @@
 # - Shared-desktop mode (do not steal foreground focus at launch):
 #     ./scripts/launch-dev.sh --no-activate
 #
+# - Trial copy next to the installed app (dogfood a branch without quitting the
+#   daily driver; state seeded once from a snapshot of the live store):
+#     ./scripts/launch-dev.sh --coexist --seed-store --data-dir .dev-data/trial --no-activate
+#
 # ==========================================================================
 
 set -euo pipefail
@@ -55,9 +59,12 @@ GHOSTTYKIT_FRAMEWORK="$REPO_ROOT/Frameworks/GhosttyKit.xcframework"
 MISE_CONFIG_PATH="$REPO_ROOT/.mise.toml"
 DEFAULT_DATA_DIR="$REPO_ROOT/.dev-data/workspacemanager"
 LOG_DIR="$REPO_ROOT/.dev-data/logs"
+APP_SUPPORT_DATA_DIR="$HOME/Library/Application Support/WorkspaceManager"
 
 DO_BUILD=true
 KILL_EXISTING=true
+COEXIST=false
+SEED_STORE=false
 RUN_IN_BACKGROUND=true
 USE_APP_SUPPORT=false
 FIXTURE_MODE=false
@@ -82,6 +89,11 @@ Usage: ./scripts/launch-dev.sh [options]
 Options:
   --no-build           Skip swift build and launch existing debug binary
   --no-kill            Do not stop existing WorkspaceManager processes
+  --coexist            Leave the installed WorkSpaces.app running; only a previous
+                       debug instance is stopped
+  --seed-store         Seed an empty data dir from a snapshot of the installed app's
+                       store (SwiftData + local-state sidecar); the live files are
+                       only read
   --foreground         Run attached to current terminal (no nohup)
   --use-app-support    Do not set WORKSPACES_DATA_DIR (use platform defaults)
   --data-dir <path>    Override isolated data root (default: ./.dev-data/workspacemanager)
@@ -127,6 +139,15 @@ parse_args() {
                 ;;
             --no-kill)
                 KILL_EXISTING=false
+                shift
+                ;;
+            --coexist)
+                COEXIST=true
+                KILL_EXISTING=false
+                shift
+                ;;
+            --seed-store)
+                SEED_STORE=true
                 shift
                 ;;
             --foreground)
@@ -287,6 +308,10 @@ list_instances_for_binary() {
 }
 
 ensure_no_installed_app_instance() {
+    if [[ "$COEXIST" == true ]]; then
+        return
+    fi
+
     local installed_instances
     installed_instances="$(list_instances_for_binary "$INSTALLED_APP_BINARY")"
     if [[ -n "$installed_instances" ]]; then
@@ -299,6 +324,13 @@ ensure_no_installed_app_instance() {
 }
 
 stop_existing_if_requested() {
+    if [[ "$COEXIST" == true ]]; then
+        log "Coexist mode: leaving the installed app running; stopping any previous debug instance..."
+        pkill -f "$DEBUG_BINARY" >/dev/null 2>&1 || true
+        sleep 1
+        return
+    fi
+
     if [[ "$KILL_EXISTING" != true ]]; then
         return
     fi
@@ -340,6 +372,38 @@ configure_data_root() {
         log "Cleaning isolated data dir: $DATA_DIR"
         rm -rf "$DATA_DIR"
         mkdir -p "$DATA_DIR"
+    fi
+}
+
+# A trial copy is only useful with the user's real repos and workspaces. Snapshot
+# the installed app's store into the isolated data dir (sqlite online backup is
+# consistent with the live app running and WAL in play); the live files are
+# never written, and any schema migration a branch carries runs on the copy.
+seed_store_if_requested() {
+    if [[ "$SEED_STORE" != true ]]; then
+        return
+    fi
+    if [[ "$USE_APP_SUPPORT" == true ]]; then
+        fail "--seed-store requires an isolated data dir (drop --use-app-support)"
+    fi
+    if [[ -f "$DATA_DIR/default.store" ]]; then
+        log "Data dir already holds a store; keeping it (pass --clean-data to reseed): $DATA_DIR"
+        return
+    fi
+    if [[ ! -f "$APP_SUPPORT_DATA_DIR/default.store" ]]; then
+        fail "No installed-app store to seed from at $APP_SUPPORT_DATA_DIR"
+    fi
+    command -v sqlite3 >/dev/null 2>&1 || fail "--seed-store requires sqlite3"
+
+    local name
+    for name in default.store local-state.sqlite; do
+        [[ -f "$APP_SUPPORT_DATA_DIR/$name" ]] || continue
+        sqlite3 "$APP_SUPPORT_DATA_DIR/$name" ".backup '$DATA_DIR/$name'"
+        log "Seeded $name from a snapshot of the installed app's store"
+    done
+    if [[ -d "$APP_SUPPORT_DATA_DIR/ghostty" && ! -e "$DATA_DIR/ghostty" ]]; then
+        cp -R "$APP_SUPPORT_DATA_DIR/ghostty" "$DATA_DIR/ghostty"
+        log "Copied ghostty config"
     fi
 }
 
@@ -682,6 +746,7 @@ main() {
     verify_debug_binary
     stop_existing_if_requested
     configure_data_root
+    seed_store_if_requested
     configure_fixture_mode
     configure_launch_behavior
     configure_ghostty_resources

--- a/scripts/launch-dev.sh
+++ b/scripts/launch-dev.sh
@@ -364,6 +364,10 @@ configure_data_root() {
     fi
 
     DATA_DIR="$(expand_home_prefix "$DATA_DIR")"
+    # Relative --data-dir values resolve against the repo root: the synthetic
+    # fixture root derived from it must be absolute, and the app's own cwd is
+    # not a contract.
+    [[ "$DATA_DIR" == /* ]] || DATA_DIR="$REPO_ROOT/${DATA_DIR#./}"
     ENV_VARS+=("WORKSPACES_DATA_DIR=$DATA_DIR")
     ENV_VARS+=("WORKSPACES_APP_VARIANT=dev")
 

--- a/scripts/lib/app-capture.sh
+++ b/scripts/lib/app-capture.sh
@@ -139,8 +139,11 @@ app_capture_window() {
     synthetic_root_ensure "$data_dir/workspaces-root" || return 1
     synthetic_root_require || return 1
 
+    # --coexist: an evidence capture must never kill the operator's installed
+    # WorkSpaces.app (or the terminal session driving the capture); only a stale
+    # debug instance is replaced. Harmless on CI, where no installed app exists.
     local -a launch_args=(
-        --no-build --no-activate --fixture --clean-data
+        --no-build --no-activate --fixture --clean-data --coexist
         --data-dir "$data_dir"
         --env "WORKSPACES_SYNTHETIC_ROOT=$WORKSPACES_SYNTHETIC_ROOT"
         --env WORKSPACES_AUTOMATION_API=1


### PR DESCRIPTION
## Summary

`scripts/launch-dev.sh` was built for a clean desk: it `pkill`s the installed WorkSpaces.app and refuses to run while one is alive, and the evidence capture lane (`scripts/lib/app-capture.sh`) inherits both. That makes dogfooding a branch mean quitting the daily driver — and, when the capture is driven from a terminal inside that app, killing the session doing the capturing.

- `--coexist`: leave the installed app running; only a previous debug instance from this checkout is replaced (selected by exact executable path). The installed-instance gate is skipped; the debug pid/window verification still runs, and the window check now requires the window to belong to the launched pid.
- `--seed-store`: seed an empty isolated data dir from a snapshot of the installed app's `default.store` + `local-state.sqlite` (`VACUUM INTO` — consistent with the live app running and WAL in play; the live files are only read) plus the ghostty config. Staged and published in one step, so a part-way failure never leaves a dir that counts as seeded. Any schema migration a branch carries runs on the copy. Kept across relaunches; `--clean-data` reseeds.
- `app-capture.sh` launches with `--coexist`, so an evidence capture never kills the operator's app. Harmless on CI (no installed app).
- A relative `--data-dir` resolves against the repo root (the derived `WORKSPACES_SYNTHETIC_ROOT` must be absolute); the physical path is then refused if it is the checkout, an ancestor of it, `/`, or `$HOME`, so `--clean-data` can never delete those.

Trial copy: `./scripts/launch-dev.sh --coexist --seed-store --data-dir .dev-data/trial --no-activate`.

Replaces: quitting the daily driver, or hand-copying sqlite files, to try a branch.

## Evidence

Fixture launch with `--coexist` while the installed app (pid 71279, up 4h) kept running — captured from the debug instance's window (pid 9566):

![coexist-fixture-launch](https://evidence.cloudcompute.com/workspaces/pr-1333/20260823-025851-coexist-fixture-launch.png)

```
[19:13:07] Coexist mode: leaving the installed app running; stopping any previous debug instance...
[19:13:14] WorkspaceManager running (pid=9566)
 9566       00:24 /Users/fairchild/workspaces/workspaces/leftsort/.build/arm64-apple-macosx/debug/WorkspaceManager
71279    04:21:31 /Applications/WorkSpaces.app/Contents/MacOS/WorkspaceManager
```

Post-review run from a second checkout, with the installed app and a trial copy from the first checkout both alive:

```
T1a --data-dir ./ --clean-data   → ERROR: --data-dir must not be the checkout or an ancestor of it (exit 1)
T1b --data-dir ''                → ERROR: --data-dir requires a non-empty path (exit 1)
T1c --data-dir ..                → ERROR: --data-dir must not be the checkout or an ancestor of it (exit 1)
T2  --seed-store --data-dir ".dev-data/it's a trial"
    Seeded default.store / local-state.sqlite, Copied ghostty config; seeded repos|51; WorkspaceManager running (pid=52787)
T3  relaunch (same flags)        → Data dir already holds a store; keeping it; pid 52787 replaced by 53041
instances after T3:
18123  /Applications/WorkSpaces.app/Contents/MacOS/WorkspaceManager            (installed, untouched)
25523  .../workspaces/leftsort/.build/arm64-apple-macosx/debug/WorkspaceManager  (other checkout's trial copy, untouched)
53041  .../leftsort-launch-dev-coexist/.build/arm64-apple-macosx/debug/WorkspaceManager
```

## Review loop

Directed codex (gpt-5.6-sol, xhigh) review; reaction commit `In response to codex …`:

- **Blocker — relative `--data-dir` of `./` or `''` resolved to the checkout; `--clean-data` would `rm -rf` it.** *Fixed:* non-empty required; physical path refused if it is the checkout, an ancestor, `/`, or `$HOME`.
- **Blocker — coexist accepted the installed app's window as launch proof** (owner-name-only window match). *Fixed:* `read_window_id` filters `kCGWindowOwnerPID == APP_PID`; the shared-desktop capture hint names `--pid`.
- **Important — a part-way seed failure left a dir later treated as seeded.** *Fixed:* staged under `.seed-staging`, published in one `mv`.
- **Important — a `'` in the path broke sqlite3's `.backup` dot-command.** *Fixed:* `VACUUM INTO '<path>'` with `''` escaping (SQL, not the dot-command parser); verified against the live WAL store.
- **Important — `pkill -f <unescaped path>` could match `lldb <binary>` or a sibling path.** *Fixed:* instances selected by exact executable field (`list_instances_for_binary`).
- Minor, pre-existing: `expand_home_prefix` turns a quoted literal `~/x` into `$HOME/~/x` (SC2088) — untouched.
- Verified sound by the reviewer: main() ordering (parse → normalize → clean → seed); `--use-app-support --seed-store` fails before touching live Application Support; CI behavior of `app-capture.sh --coexist` unchanged; default no-flag behavior unchanged; `--coexist` honored at every `KILL_EXISTING` / `ensure_no_installed_app_instance` site.

## Mergeability

- Surface: desktop dev tooling — `scripts/launch-dev.sh`, `scripts/lib/app-capture.sh`
- User-facing behavior changed: No (dev launcher and evidence lane only)
- Non-happy paths considered: empty / checkout / ancestor / `/` / `$HOME` data dirs refused before deletion; `--seed-store` with `--use-app-support` rejected; missing installed store or `sqlite3` fails the launch; part-way seed failure leaves nothing published; quote-bearing paths; a coexisting *operator-scope* capture still collides on the bundle-id-keyed automation socket/credential and now fails instead of killing the installed app (#1330)
- Residual risk or follow-up: #1330 (socket/credential scoping); in coexist mode an evidence capture from the same checkout still replaces that checkout's running trial copy (exact-path selection) — capture first, then relaunch the trial

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln6fhaqFNcDbv1ezas34ZK