### PR TITLE
chore(release): prepare v0.25.0 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.25.0] - 2026-08-22
+
+The sidebar gains a **Recent** arrangement: a flat, date-bucketed list (Today /
+This Week / Earlier) of the workspaces you are actually working in, each row
+carrying its repo as a `repo / workspace` breadcrumb, in place of the repository
+tree. Alphabetical and Last Accessed are unchanged. The rest is release-lane and
+dev-tooling hardening, including a launcher that runs a trial build next to the
+installed app.
+
+### Added
+- manage deployment environments as code (#1327)
+- Recent arrangement — flat, date-bucketed workspace list (#1335)
+
+### Fixed
+- name the scope when release config resolves empty (#1323)
+- grade the perf gate by the version being built, not the ref (#1324)
+- scope the App Store Connect key to an environment (#1326)
+
+### Other
+- record the v0.24.0 release-arc lessons and correct the runner rule (#1310)
+- audit the release environment, not just repository scope (#1325)
+- bump sandbox mise pin to v2026.8.6 (weekly refresh) (#1328)
+- Explain file tree failures and offer recovery (#1329)
+- launch-dev --coexist / --seed-store — a trial copy next to the installed app (#1333)
+
 ## [0.24.0] - 2026-08-09
 
 No new user-facing capability in this release. The work went into consolidation —

--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.24.0</string>
+	<string>0.25.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>32</string>
+	<string>33</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSArchitecturePriority</key>


### PR DESCRIPTION
## Summary

Stable release metadata for **v0.25.0** per `RELEASING.md` Method 1: `Info.plist` 0.24.0 → 0.25.0 (build 32 → 33) and a `CHANGELOG.md` section generated by `./scripts/prepare-release.sh --version 0.25.0 --metadata-only` from commits since `v0.24.0`, with a short intro. Minor bump: the sidebar Recent arrangement (#1335) is a new user-facing capability.

No code changes. After merge: rehearsal dispatch from `main` (already queued, run 32615026218) → `release-version.sh assert-tag-match v0.25.0` → tag `v0.25.0` → `release.yml`.

## Evidence

- [x] Not a testable change (docs-only, config) — release metadata only; the release lane itself is exercised by the rehearsal run before tagging.

Metadata-only diff (no app behavior); the helper output:

```
[prepare-release] Updated release metadata without committing, tagging, or pushing
[prepare-release] Next: open a PR for CHANGELOG.md and Info.plist, merge it, then tag origin/main with v0.25.0
 CHANGELOG.md                                  | 18 ++++++++++++++++++
 Sources/WorkspaceManager/Resources/Info.plist |  4 ++--
```

The release lane itself is exercised by the rehearsal run before tagging; its DMG is stapler-validated per the runbook.

## Review loop

Metadata-only diff — codex skipped per the scope gate; reflection: version/build monotonic (0.24.0/32 → 0.25.0/33), changelog entries map to merged PRs since the last stable tag.

## Mergeability

- Surface: release metadata — `Info.plist`, `CHANGELOG.md`
- User-facing behavior changed: No (version string and release notes only)
- Non-happy paths considered: `release.yml` fails fast if the tag does not match `Info.plist`; the tag is only pushed after this merges and after a green rehearsal
- Residual risk or follow-up: the rehearsal prerelease is named from the version on `main` at dispatch time (`0.24.0` if it starts before this merges) — cosmetic; the stable tag is `v0.25.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln6fhaqFNcDbv1ezas34ZK
