### PR TITLE
feat(sidebar): manual pin order — Move Up / Move Down on pinned rows

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarPinController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarPinController.swift
@@ -74,7 +74,9 @@ struct SidebarPinController {
     @discardableResult
     func move(_ workspace: Workspace, by offset: Int, in workspaces: [Workspace]) -> [Workspace] {
         var pinned = pinnedWorkspaces(in: workspaces)
-        guard let index = pinned.firstIndex(where: { $0.id == workspace.id }) else { return pinned }
+        guard offset != 0, let index = pinned.firstIndex(where: { $0.id == workspace.id }) else {
+            return pinned
+        }
 
         let destination = index + offset
         guard pinned.indices.contains(destination) else { return pinned }

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarPinController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarPinController.swift
@@ -4,7 +4,7 @@
 //
 //  Pin bookkeeping for the sidebar's Pinned section: which workspaces belong to it, in
 //  what order, and the 0…n renumbering that keeps that order contiguous through every
-//  pin, unpin, archive, and delete. Pure — the caller owns the save.
+//  pin, unpin, reorder, archive, and delete. Pure — the caller owns the save.
 //
 
 import Foundation
@@ -65,7 +65,36 @@ struct SidebarPinController {
     /// what reaches the store is contiguous and the display order is what was persisted.
     @discardableResult
     func renumber(in workspaces: [Workspace]) -> [Workspace] {
+        numberInPlace(pinnedWorkspaces(in: workspaces))
+    }
+
+    /// Shifts a pinned workspace `offset` places within the Pinned section. A workspace the
+    /// section does not hold, and a destination outside it, leave the store untouched — the
+    /// affordance offers the verb and the invariant lives here.
+    @discardableResult
+    func move(_ workspace: Workspace, by offset: Int, in workspaces: [Workspace]) -> [Workspace] {
+        var pinned = pinnedWorkspaces(in: workspaces)
+        guard let index = pinned.firstIndex(where: { $0.id == workspace.id }) else { return pinned }
+
+        let destination = index + offset
+        guard pinned.indices.contains(destination) else { return pinned }
+
+        pinned.insert(pinned.remove(at: index), at: destination)
+        return numberInPlace(pinned)
+    }
+
+    /// Whether `move(_:by:in:)` would change anything — what disables Move Up on the first
+    /// pinned row and Move Down on the last.
+    func canMove(_ workspace: Workspace, by offset: Int, in workspaces: [Workspace]) -> Bool {
         let pinned = pinnedWorkspaces(in: workspaces)
+        guard offset != 0, let index = pinned.firstIndex(where: { $0.id == workspace.id }) else {
+            return false
+        }
+        return pinned.indices.contains(index + offset)
+    }
+
+    @discardableResult
+    private func numberInPlace(_ pinned: [Workspace]) -> [Workspace] {
         for (index, workspace) in pinned.enumerated() where workspace.pinOrder != index {
             workspace.pinOrder = index
         }

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -38,20 +38,30 @@ private struct NewWorkspaceSheetContext: Identifiable {
     var id: UUID { repo.id }
 }
 
-/// Where a workspace row sits: indented under its repo in the tree arrangements, or
-/// flat in a Recent bucket, where the repo name travels with the row as a breadcrumb.
+/// Where a workspace row sits: indented under its repo in the tree arrangements, flat in a
+/// Recent bucket, or flat in the Pinned section. The two flat placements differ only in the
+/// verbs they offer — reordering belongs to the section that has an order to change, so a
+/// pinned workspace's tree row does not repeat it.
 private enum WorkspaceRowPlacement {
     case nested
     case flat(repoContext: String?)
+    case pinned(repoContext: String?)
 
     var isNested: Bool {
         if case .nested = self { return true }
         return false
     }
 
+    var isPinnedSection: Bool {
+        if case .pinned = self { return true }
+        return false
+    }
+
     var repoContext: String? {
-        if case .flat(let repoContext) = self { return repoContext }
-        return nil
+        switch self {
+        case .nested: return nil
+        case .flat(let repoContext), .pinned(let repoContext): return repoContext
+        }
     }
 }
 
@@ -193,8 +203,12 @@ struct SidebarView: View {
         )
     }
 
+    private var allWorkspaces: [Workspace] {
+        repos.flatMap(\.workspaces)
+    }
+
     private var pinnedWorkspaces: [Workspace] {
-        pinController.pinnedWorkspaces(in: repos.flatMap(\.workspaces))
+        pinController.pinnedWorkspaces(in: allWorkspaces)
     }
 
     private var recentBuckets: [RecentBucket] {
@@ -467,7 +481,7 @@ struct SidebarView: View {
                 ForEach(pinned) { workspace in
                     workspaceRow(
                         workspace,
-                        placement: .flat(repoContext: workspace.sourceRepo?.name)
+                        placement: .pinned(repoContext: workspace.sourceRepo?.name)
                     )
                 }
             } header: {
@@ -808,6 +822,18 @@ struct SidebarView: View {
             }
 
             Divider()
+
+            if placement.isPinnedSection {
+                Button("Move Up") {
+                    movePin(workspace, by: -1)
+                }
+                .disabled(!pinController.canMove(workspace, by: -1, in: allWorkspaces))
+
+                Button("Move Down") {
+                    movePin(workspace, by: 1)
+                }
+                .disabled(!pinController.canMove(workspace, by: 1, in: allWorkspaces))
+            }
 
             if pinController.isPinnable(workspace) {
                 Button(workspace.isPinned ? "Unpin" : "Pin") {
@@ -1559,7 +1585,7 @@ struct SidebarView: View {
     @MainActor
     private func togglePin(_ workspace: Workspace) {
         let action = workspace.isPinned ? "unpin workspace" : "pin workspace"
-        let workspaces = repos.flatMap(\.workspaces)
+        let workspaces = allWorkspaces
         let snapshot = pinController.pinOrderSnapshot(of: workspaces)
 
         if workspace.isPinned {
@@ -1569,6 +1595,18 @@ struct SidebarView: View {
         }
 
         if !saveModelContext(action: action) {
+            pinController.restore(snapshot, in: workspaces)
+        }
+    }
+
+    @MainActor
+    private func movePin(_ workspace: Workspace, by offset: Int) {
+        let workspaces = allWorkspaces
+        let snapshot = pinController.pinOrderSnapshot(of: workspaces)
+
+        pinController.move(workspace, by: offset, in: workspaces)
+
+        if !saveModelContext(action: "reorder pinned workspaces") {
             pinController.restore(snapshot, in: workspaces)
         }
     }

--- a/Tests/WorkspaceManagerAppTests/SidebarPinControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarPinControllerTests.swift
@@ -334,4 +334,17 @@ struct SidebarPinControllerTests {
         #expect(beta.pinOrder == nil)
         #expect(alpha.pinOrder == 0)
     }
+
+    @Test("A zero-offset move leaves even a gapped section untouched, matching canMove")
+    func zeroOffsetMoveIsANoOp() {
+        let repo = makeRepo()
+        let first = makeWorkspace("first", in: repo, pinOrder: 4)
+        let second = makeWorkspace("second", in: repo, pinOrder: 9)
+        let workspaces = [first, second]
+
+        #expect(!controller.canMove(first, by: 0, in: workspaces))
+        controller.move(first, by: 0, in: workspaces)
+        #expect(first.pinOrder == 4)
+        #expect(second.pinOrder == 9)
+    }
 }

--- a/Tests/WorkspaceManagerAppTests/SidebarPinControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarPinControllerTests.swift
@@ -187,6 +187,138 @@ struct SidebarPinControllerTests {
         #expect(controller.pinnedWorkspaces(in: [archived, live]).map(\.name) == ["live"])
     }
 
+    @Test("Moving up swaps a row with the one above it and renumbers the section")
+    func movingUpReordersTheSection() {
+        let repo = makeRepo()
+        let first = makeWorkspace("first", in: repo, pinOrder: 0)
+        let second = makeWorkspace("second", in: repo, pinOrder: 1)
+        let third = makeWorkspace("third", in: repo, pinOrder: 2)
+        let all = [first, second, third]
+
+        controller.move(third, by: -1, in: all)
+
+        #expect(controller.pinnedWorkspaces(in: all).map(\.name) == ["first", "third", "second"])
+        #expect(first.pinOrder == 0)
+        #expect(third.pinOrder == 1)
+        #expect(second.pinOrder == 2)
+    }
+
+    @Test("Moving down swaps a row with the one below it")
+    func movingDownReordersTheSection() {
+        let repo = makeRepo()
+        let first = makeWorkspace("first", in: repo, pinOrder: 0)
+        let second = makeWorkspace("second", in: repo, pinOrder: 1)
+        let all = [first, second]
+
+        controller.move(first, by: 1, in: all)
+
+        #expect(controller.pinnedWorkspaces(in: all).map(\.name) == ["second", "first"])
+        #expect(second.pinOrder == 0)
+        #expect(first.pinOrder == 1)
+    }
+
+    @Test("Moving past either end of the section changes nothing")
+    func movingAtTheBoundariesIsANoOp() {
+        let repo = makeRepo()
+        let first = makeWorkspace("first", in: repo, pinOrder: 0)
+        let second = makeWorkspace("second", in: repo, pinOrder: 1)
+        let all = [first, second]
+
+        controller.move(first, by: -1, in: all)
+        controller.move(second, by: 1, in: all)
+
+        #expect(controller.pinnedWorkspaces(in: all).map(\.name) == ["first", "second"])
+        #expect(first.pinOrder == 0)
+        #expect(second.pinOrder == 1)
+        #expect(controller.canMove(first, by: -1, in: all) == false)
+        #expect(controller.canMove(second, by: 1, in: all) == false)
+        #expect(controller.canMove(first, by: 1, in: all))
+        #expect(controller.canMove(second, by: -1, in: all))
+    }
+
+    @Test("Moving an unpinned workspace leaves the section alone")
+    func movingAnUnpinnedWorkspaceIsANoOp() {
+        let repo = makeRepo()
+        let pinned = makeWorkspace("pinned", in: repo, pinOrder: 0)
+        let loose = makeWorkspace("loose", in: repo)
+        let all = [pinned, loose]
+
+        controller.move(loose, by: -1, in: all)
+        controller.move(loose, by: 1, in: all)
+
+        #expect(loose.pinOrder == nil)
+        #expect(controller.pinnedWorkspaces(in: all).map(\.name) == ["pinned"])
+        #expect(pinned.pinOrder == 0)
+        #expect(controller.canMove(loose, by: 1, in: all) == false)
+    }
+
+    @Test("An archived workspace carrying a stale pinOrder cannot be moved")
+    func movingAnArchivedWorkspaceIsANoOp() {
+        let repo = makeRepo()
+        let live = makeWorkspace("live", in: repo, pinOrder: 0)
+        let archived = makeWorkspace("archived", in: repo, pinOrder: 1, status: .archived)
+        let all = [live, archived]
+
+        controller.move(archived, by: -1, in: all)
+
+        #expect(archived.pinOrder == 1)
+        #expect(live.pinOrder == 0)
+        #expect(controller.canMove(archived, by: -1, in: all) == false)
+    }
+
+    @Test("A move renumbers a gapped section rather than preserving its gaps")
+    func movingRepairsGaps() {
+        let repo = makeRepo()
+        let gapped = makeWorkspace("gapped", in: repo, pinOrder: 7)
+        let low = makeWorkspace("low", in: repo, pinOrder: 2)
+        let all = [gapped, low]
+
+        controller.move(gapped, by: -1, in: all)
+
+        #expect(controller.pinnedWorkspaces(in: all).map(\.name) == ["gapped", "low"])
+        #expect(gapped.pinOrder == 0)
+        #expect(low.pinOrder == 1)
+    }
+
+    @Test("A move of more than one place lands the row where it was asked to go")
+    func movingSeveralPlacesLandsAtTheOffset() {
+        let repo = makeRepo()
+        let first = makeWorkspace("first", in: repo, pinOrder: 0)
+        let second = makeWorkspace("second", in: repo, pinOrder: 1)
+        let third = makeWorkspace("third", in: repo, pinOrder: 2)
+        let all = [first, second, third]
+
+        controller.move(third, by: -2, in: all)
+
+        #expect(controller.pinnedWorkspaces(in: all).map(\.name) == ["third", "first", "second"])
+        #expect(all.compactMap(\.pinOrder).sorted() == [0, 1, 2])
+    }
+
+    @Test("A reordered section survives a round trip through the model store")
+    @MainActor
+    func reorderedPinOrderPersists() throws {
+        let schema = Schema([Repo.self, Workspace.self, WebSource.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        let context = container.mainContext
+
+        let repo = makeRepo()
+        let first = makeWorkspace("first", in: repo, pinOrder: 0)
+        let second = makeWorkspace("second", in: repo, pinOrder: 1)
+        let third = makeWorkspace("third", in: repo, pinOrder: 2)
+        context.insert(repo)
+        for workspace in [first, second, third] {
+            context.insert(workspace)
+        }
+
+        controller.move(third, by: -2, in: [first, second, third])
+        try context.save()
+
+        let refetched = try context.fetch(FetchDescriptor<Workspace>())
+        #expect(controller.pinnedWorkspaces(in: refetched).map(\.name) == ["third", "first", "second"])
+        #expect(refetched.compactMap(\.pinOrder).sorted() == [0, 1, 2])
+    }
+
     @Test("A snapshot restores exactly the touched pin orders after a failed save")
     func snapshotRestoresTouchedPinOrders() {
         let repo = makeRepo()

--- a/Tests/WorkspaceManagerAppTests/SidebarPinnedReorderRenderTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarPinnedReorderRenderTests.swift
@@ -1,0 +1,116 @@
+//
+//  SidebarPinnedReorderRenderTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Renders the Pinned section either side of a Move Up, so PR evidence shows the reorder
+//  as the controller actually produces it rather than as a hand-arranged mock. Writes a PNG
+//  when `WORKSPACES_EVIDENCE_DIR` is set; asserts the order and a non-empty image otherwise.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("Pinned section reorder render")
+struct SidebarPinnedReorderRenderTests {
+    private let controller = SidebarPinController()
+
+    @Test("Move Up on the second pinned row swaps the rendered order")
+    func rendersReorderedPinnedSection() throws {
+        let bertramChat = repo("bertram-chat")
+        let skills = repo("skills")
+        let featureAuth = workspace("feature-auth", in: bertramChat, pinOrder: 0)
+        let skillsV13 = workspace("skills-v13", in: skills, pinOrder: 1)
+        let all = [featureAuth, skillsV13]
+
+        let before = controller.pinnedWorkspaces(in: all)
+        #expect(before.map(\.name) == ["feature-auth", "skills-v13"])
+
+        controller.move(skillsV13, by: -1, in: all)
+
+        let after = controller.pinnedWorkspaces(in: all)
+        #expect(after.map(\.name) == ["skills-v13", "feature-auth"])
+        #expect(after.map(\.pinOrder) == [0, 1])
+
+        let comparison = HStack(alignment: .top, spacing: 20) {
+            column(
+                "Before",
+                caption: "Move Up on skills-v13 — disabled on feature-auth, the first row",
+                rows: before
+            )
+            column("After", caption: "skills-v13 renumbered to pinOrder 0", rows: after)
+        }
+        .padding(16)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .environment(\.colorScheme, .light)
+
+        let renderer = ImageRenderer(content: comparison)
+        renderer.scale = 2
+        let image = try #require(renderer.nsImage)
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+
+        guard let dir = ProcessInfo.processInfo.environment["WORKSPACES_EVIDENCE_DIR"],
+            let tiff = image.tiffRepresentation,
+            let bitmap = NSBitmapImageRep(data: tiff),
+            let png = bitmap.representation(using: .png, properties: [:])
+        else {
+            return
+        }
+        let url = URL(fileURLWithPath: dir).appendingPathComponent("sidebar-pinned-reorder.png")
+        try png.write(to: url)
+    }
+
+    private func repo(_ name: String) -> Repo {
+        Repo(name: name, localPath: URL(fileURLWithPath: "/tmp/\(name)"))
+    }
+
+    private func workspace(_ name: String, in repo: Repo, pinOrder: Int?) -> Workspace {
+        Workspace(
+            name: name,
+            path: URL(fileURLWithPath: "/tmp/\(repo.name)/\(name)"),
+            sourceRepo: repo,
+            gitBranch: "workspace/\(name)",
+            pinOrder: pinOrder
+        )
+    }
+
+    private func column(_ title: String, caption: String, rows: [Workspace]) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.headline)
+                .padding(.bottom, 4)
+            Text("Pinned")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 2)
+            ForEach(rows) { workspace in
+                row(workspace)
+            }
+            Text(caption)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .padding(.top, 8)
+        }
+        .frame(width: 280, alignment: .leading)
+    }
+
+    /// `ImageRenderer` never delivers a hover event, so the star is forced visible the same
+    /// way `SidebarPinnedRowRenderTests` does.
+    private func row(_ workspace: Workspace) -> some View {
+        WorkspaceRow(
+            workspace: workspace,
+            sessionActivity: workspace.name == "feature-auth" ? .thinking : .live,
+            paneCount: workspace.name == "feature-auth" ? 0 : 3,
+            repoContext: workspace.sourceRepo?.name,
+            isNested: false,
+            isPinned: workspace.isPinned,
+            onTogglePin: {},
+            revealsHoverActions: true
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Slice 3 of the sidebar arrangement arc (`docs/plans/sidebar-arrangement.handoff.md`; slice 1 = #1335, slice 2 = #1339). Rows in the **Pinned** section gain **Move Up** / **Move Down** in their context menu, disabled at the ends. Only the Pinned section's rows offer the verbs — a pinned workspace's tree row in Alphabetical / Last Accessed does not repeat them (new `WorkspaceRowPlacement.pinned`, identical rendering to `.flat`).

- `SidebarPinController.move(_:by:in:)` shifts within the pinned set and renumbers 0…n; no-op for a workspace the section doesn't hold (unpinned, or archived with a stale `pinOrder`), for a destination past either end, and for offset 0. `canMove(_:by:in:)` is the same predicate without the mutation and drives the disabled state.
- Persisted through `saveModelContext`; a failed save restores the snapshot of touched `pinOrder`s (the slice-2 pattern).
- **Drag reorder (`.onMove`) is not shipped.** It was implemented, built, launched, and removed: the rendered Pinned section was fine with it wired, but the one question that matters — does a press-drag on the `.plain`-Button rows start the List's reorder session reliably — could only be answered with a synthetic desktop drag, and the desktop was live (secure input held by the installed app, frontmost app changing between checks), so it was never driven. The brief says keep it only if it works reliably; Move Up/Down ship regardless. Settling it needs a VM desktop lane (`tart-gui-automation`).

Stacked on #1339; retarget to `main` before that merges (stacked PRs get auto-closed when their base branch is deleted).

## Evidence

Fixture launch with the pin list reversed vs slice 2's scenario (`WORKSPACES_UI_FIXTURE_PINNED=skills-v13,feature-auth`) — the Pinned section renders in the new order, buckets unchanged:

![sidebar-pin-reorder](https://evidence.cloudcompute.com/workspaces/pr-1340/20260823-051841-sidebar-pin-reorder.png)

Render test (ImageRenderer lane): the "After" column is produced by calling `controller.move(skillsV13, by: -1, in:)` between the two renders, not arranged by hand:

![sidebar-pin-reorder-render](https://evidence.cloudcompute.com/workspaces/pr-1340/20260823-051841-sidebar-pin-reorder-render.png)

Gates: `swift test` — 1740 tests / 237 suites passed; `swift-format lint --strict` clean; `test_release_harness_absence.py` 10 passed / 12 subtests. Not visually evidenced: the context menu itself (`ImageRenderer` can't render one; opening it needs a click on the shared desktop) — its presence and disabled ends are covered by `canMove` tests and review.

## Review loop

Directed codex (gpt-5.6-sol, xhigh): **nothing blocks merge**; reaction commit `In response to codex …`:

- **Minor — `move(by: 0)` could renumber a malformed stored order while `canMove(by: 0)` returns false.** *Fixed:* zero-offset guard in `move`, regression test.
- Verified sound by the reviewer: move sorts by stored order, name, then UUID so input order, gaps, duplicates and ties are deterministic; boundary and archived-stale-pin moves are true no-ops; `canMove`/`move` agree for every shipped input (±1); no stale menu-state path (`canMove` reads live `@Model` state and the menu dismisses on action); snapshot/restore writes back exact prior values including `nil`; the render test cannot fail CI from an unset env var; slice-2 behavior and fixture plumbing unchanged; `main` has no commits since the branch point; the Pinned section is the only `.pinned` producer and the context menu the only `isPinnedSection` consumer.

## Mergeability

- Surface: desktop — sidebar (`SidebarPinController`, `SidebarView` context menu, `WorkspaceRowPlacement`), tests
- User-facing behavior changed: Yes — Move Up / Move Down on Pinned rows' context menu
- Non-happy paths considered: boundary moves and offset 0 are no-ops; unpinned or archived-with-stale-`pinOrder` workspaces can't be moved; a gapped section renumbers on move; failed save restores touched orders
- Residual risk or follow-up: drag reorder deferred pending a VM-desktop verification lane; fixture mode uses an in-memory store so on-disk persistence is covered by the `ModelContainer` round-trip test rather than the fixture; no named `sidebar-pinned-reordered` scenario (the raw env override reproduces it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln6fhaqFNcDbv1ezas34ZK
