### PR TITLE
chore(release): note pinning and pin order in the v0.25.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@
 The sidebar gains a **Recent** arrangement: a flat, date-bucketed list (Today /
 This Week / Earlier) of the workspaces you are actually working in, each row
 carrying its repo as a `repo / workspace` breadcrumb, in place of the repository
-tree. Alphabetical and Last Accessed are unchanged. The rest is release-lane and
-dev-tooling hardening, including a launcher that runs a trial build next to the
-installed app.
+tree. Workspaces can be **pinned** — hover star or right-click — into a Pinned
+section that sits above every arrangement, and reordered there with Move Up /
+Move Down. Alphabetical and Last Accessed are unchanged. The rest is release-lane
+and dev-tooling hardening, including a launcher that runs a trial build next to
+the installed app.
 
 ### Added
 - manage deployment environments as code (#1327)
 - Recent arrangement — flat, date-bucketed workspace list (#1335)
+- pin workspaces to a Pinned section above every arrangement (#1339)
+- manual pin order — Move Up / Move Down on pinned rows (#1340)
 
 ### Fixed
 - name the scope when release config resolves empty (#1323)


### PR DESCRIPTION
## Summary

#1339 (pinning) and #1340 (Move Up / Move Down) landed on `main` after #1336 generated the 0.25.0 changelog section, and the `v0.25.0` tag has not been pushed yet. This adds their two `Added` lines and extends the section intro so the notes match what the tag will contain. `Info.plist` is unchanged (still 0.25.0 / 33).

## Evidence

- [x] Not a testable change (docs-only, config) — changelog text only.

## Review loop

Docs-only diff — codex skipped per the scope gate.

## Mergeability

- Surface: release notes — `CHANGELOG.md`
- User-facing behavior changed: No (release notes text)
- Non-happy paths considered: if #1340 has not merged when this lands, its line is one PR ahead of the tag; the tag is pushed only after both are on `main`
- Residual risk or follow-up: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln6fhaqFNcDbv1ezas34ZK